### PR TITLE
Bug/random UUID breaks chain determinism

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1114,7 +1114,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - create and persist a new `GovernanceFrameworkDocument` entry `gfd`:
 
-- `gfd.id`: "gfd<blockheight><did><gfv.version>" (need for determinism)
+- `gfd.id`: "gfd<blockheight><did><gfd.version>" (need for determinism)
 - `gfd.gfv_id`: `gfv.id`
 - `gfd.created`: current datetime, in yyyyMMddHHmm format
 - `gfd.language`: `language`
@@ -1169,7 +1169,7 @@ load `GovernanceFrameworkVersion` entry `gfv` for the requested version, or crea
 
 - create and persist a new `GovernanceFrameworkDocument` entry `gfd`:
 
-- `gfd.id`: "gfd<blockheight><did><gfv.version>" (need for determinism)
+- `gfd.id`: "gfd<blockheight><did><gfd.version>" (need for determinism)
 - `gfd.gfv_id`: `gfv.id`
 - `gfd.created`: current datetime, in yyyyMMddHHmm format
 - `gfd.language`: `doc_language`


### PR DESCRIPTION
### [MOD-TR-MSG-1-3] Update Trust Registry Execution for Deterministic ID Generation

**Description:**

We identified a bug in the specification related to the generation of random UUIDs for the creation of `GovernanceFrameworkVersion` (gfv) and `GovernanceFrameworkDocument` (gfd) entries. The use of random UUIDs introduces indeterminism, leading to transaction (TX) triggers causing `apphash` mismatches.

### Proposed Solution:

To eliminate this indeterminism, we propose modifying the specification to build a deterministic key for both `gfv.id` and `gfd.id`. This change will ensure consistency and prevent mismatches in the application hash.

### Changes:

- **GovernanceFrameworkVersion (gfv):**
  - Updated `gfv.id` from a random UUID to a deterministic key generation approach.

- **GovernanceFrameworkDocument (gfd):**
  - Updated `gfd.id` from a random UUID to a deterministic key generation approach.

### Next Steps:

- Review the attached diff for the proposed solution.
- Discuss and validate the approach to ensure compatibility and correctness across modules.

