### PR TITLE
feat(perm,de,authz): VSOA record lifecycle — break TR→DE→Perm cycle

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ customElements.define("slide-panels",class extends HTMLElement{static get observ
       
                     <article id="content">
                       <h1 id="verifiable-public-registry-v4-specification"><a class="toc-anchor" href="#verifiable-public-registry-v4-specification" >§</a> Verifiable Public Registry v4 Specification</h1>
-<p><strong>Latest draft:</strong> <a path-0="verana-labs.github.io"path-1="verifiable-trust-vpr-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-vpr-spec/" >spec v4-draft4</a></p>
+<p><strong>Latest draft:</strong> <a path-0="verana-labs.github.io"path-1="verifiable-trust-vpr-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-vpr-spec/" >spec v4-draft18</a></p>
 <p><strong>Latest stable:</strong> <a path-0="verana-labs.github.io"path-1="verifiable-trust-vpr-spec"path-2="index-v3.html"href="https://verana-labs.github.io/verifiable-trust-vpr-spec/index-v3.html" >spec v3</a></p>
 <dl>
 <dt><strong>Editors:</strong></dt>
@@ -78,18 +78,14 @@ customElements.define("slide-panels",class extends HTMLElement{static get observ
 </dl>
 <hr>
 <h2 id="abstract"><a class="toc-anchor" href="#abstract" >§</a> Abstract</h2>
-<p>The internet is broken. Existing communication channels are insecure and outdated. Because they rely on public identifiers - like email addresses, usernames, or phone numbers - anyone who knows your identifier can reach you, whether you invited them or not.</p>
-<p>Worse, there’s no reliable way to verify the identity of either service providers or users. This leaves the door wide open to spam, phishing, fraud, and identity theft.</p>
-<p>On the service side, each provider imposes its own fragmented registration process, often with complex password requirements or forced reliance on federated login systems, effectively handing control over to large third-party platforms.</p>
-<p>Although the World Wide Web was originally built for openness and interoperability, dominant players have reshaped it into a closed, centralized system that most people and organizations now depend on. Privacy has become an afterthought, and personal data is routinely harvested, exploited, or leaked.</p>
-<p>To rebuild a trustworthy internet, we need new communication channels - channels that are secure by design, based on mutual verification, and governed by decentralized trust.</p>
-<p>Connecting to a service, proving who you are, or creating an account should be as simple and safe as presenting a verifiable credential.</p>
-<p>A universal, open trust layer is essential for this vision to succeed.</p>
-<p>That’s the purpose of <strong>Verifiable Trust</strong>. The concept of <strong>Verifiable Trust</strong> is specified in the <a path-0="github.com"path-1="verana-labs"path-2="verifiable-trust-spec"href="https://github.com/verana-labs/verifiable-trust-spec" >Verifiable Trust spec</a>.</p>
-<p>This specification deals with the Verifiable Public Registry (VPR), a decentralized registry of registries, part of the Verifiable Trust concept.</p>
+<p>Decentralized trust ecosystems need shared infrastructure to answer a fundamental question: who is authorized to issue, verify, or govern credentials in a given context? Without a common registry layer, each ecosystem operates in isolation, trust decisions depend on ad hoc configurations, and there is no interoperable way for Verifiable Services and Verifiable User Agents to resolve the legitimacy of a credential or its issuer.</p>
+<p>The <strong>Verifiable Public Registry (VPR)</strong> is a decentralized “registry of registries” that provides this foundational infrastructure. It allows ecosystems to create and manage their own trust registries, define credential schemas with fine-grained permission policies, and assign roles — issuers, verifiers, grantors — through a transparent, on-chain governance model.</p>
+<p>The VPR exposes a standardized query API that Verifiable Services and Verifiable User Agents use during trust resolution to confirm, in real time, whether a given participant is authorized to perform a specific action under a specific credential schema. This is what makes the trust in <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust</a> actually verifiable.</p>
+<p>The VPR is DID-method-agnostic — it stores registrations, not validations — leaving trust decisions and cryptographic verification where they belong: with the relying parties. It supports flexible permission management modes (open, ecosystem-controlled, or grantor-delegated), enabling ecosystems to tailor governance to their specific requirements.</p>
+<p>This specification defines the data model, API, and normative requirements for implementing and interacting with a Verifiable Public Registry.</p>
 <h2 id="about-this-document"><a class="toc-anchor" href="#about-this-document" >§</a> About this Document</h2>
 <p>In order to fully understand the concepts developed in this document, you should have some basic knowledge of <a class="term-reference" href="#term:did">DID</a>, <a class="term-reference" href="#term:didcomm">DIDComm</a>, <a class="term-reference" href="#term:vs">VS</a>, <a class="term-reference" href="#term:trust-registry">trust registry</a>, ledger-based applications, and more generally, all terms present in the <a href="#terminology" >Terminology</a> section.</p>
-<div id="note-1" class="notice note"><a class="notice-link" href="#note-1">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
+<div id="note-76" class="notice note"><a class="notice-link" href="#note-76">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
 </div>
 <h2 id="introduction"><a class="toc-anchor" href="#introduction" >§</a> Introduction</h2>
 <h3 id="what-is-a-trust-registry"><a class="toc-anchor" href="#what-is-a-trust-registry" >§</a> What is a Trust Registry?</h3>
@@ -130,7 +126,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <dd>A <a class="term-reference" href="#term:verifiable-public-registry">verifiable public registry</a> account.</dd>
 <dt><span id="term:applicants"><span id="term:applicant">applicant</span></span>:</dt>
 <dd>A <a class="term-reference" href="#term:account">account</a> that starts a <a class="term-reference" href="#term:validation-process">validation process</a>.</dd>
-<dt><span id="term:authorities"><span id="term:authority">authority</span></span>:</dt>
+<dt><span id="term:corporations"><span id="term:corporation">corporation</span></span>:</dt>
 <dd>An <a class="term-reference" href="#term:group">group</a> which is the owner of a specific resource in an <a class="term-reference" href="#term:vpr">VPR</a>.</dd>
 <dt><span id="term:credential-schemas"><span id="term:credential-schema">credential schema</span></span>:</dt>
 <dd>An <a class="term-reference" href="#term:vpr">VPR</a> resource which represents a verifiable credential definition and the associated permissions and business rules for issuing, verifying or holding a credential linked to this credential schema.</dd>
@@ -186,7 +182,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <dt><span id="term:transaction-fees">transaction fees</span>:</dt>
 <dd>Fees required, in <a class="term-reference" href="#term:denom">denom</a>, to execute a <a class="term-reference" href="#term:transaction">transaction</a> in an <a class="term-reference" href="#term:vpr">VPR</a>.</dd>
 <dt><span id="term:trust-deposits"><span id="term:trust-deposit">trust deposit</span></span>:</dt>
-<dd>A financial deposit that is used as a trust guarantee. For a given <a class="term-reference" href="#term:authority">authority</a>, its trust deposit is increased when running validation process (either as an <a class="term-reference" href="#term:applicant">applicant</a> or as a <a class="term-reference" href="#term:validator">validator</a>).</dd>
+<dd>A financial deposit that is used as a trust guarantee. For a given <a class="term-reference" href="#term:corporation">corporation</a>, its trust deposit is increased when running validation process (either as an <a class="term-reference" href="#term:applicant">applicant</a> or as a <a class="term-reference" href="#term:validator">validator</a>).</dd>
 <dt><span id="term:trust-fees"><span id="term:trust-fee">trust fee</span></span>:</dt>
 <dd>Fees paid by a <a class="term-reference" href="#term:participant">participant</a> that are distributed to other <a class="term-reference" href="#term:participants">participants</a>.</dd>
 <dt><span id="term:network-fees"><span id="term:network-fee">network fee</span></span>:</dt>
@@ -234,7 +230,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <h2 id="features-of-a-verifiable-public-registry-vpr"><a class="toc-anchor" href="#features-of-a-verifiable-public-registry-vpr" >§</a> Features of a Verifiable Public Registry (VPR)</h2>
 <h3 id="trust-registry-management"><a class="toc-anchor" href="#trust-registry-management" >§</a> Trust Registry Management</h3>
 <p><em>This section is non-normative.</em></p>
-<p>In an <a class="term-reference" href="#term:vpr">VPR</a>, any <a class="term-reference" href="#term:authority">authority</a> can create a <code>TrustRegistry</code> entry that represents a <a class="term-reference" href="#term:trust-registry">trust registry</a> of an ecosystem. Each <code>TrustRegistry</code> entry must provide, at a minimum:</p>
+<p>In an <a class="term-reference" href="#term:vpr">VPR</a>, any <a class="term-reference" href="#term:corporation">corporation</a> can create a <code>TrustRegistry</code> entry that represents a <a class="term-reference" href="#term:trust-registry">trust registry</a> of an ecosystem. Each <code>TrustRegistry</code> entry must provide, at a minimum:</p>
 <ul>
 <li>an ecosystem controlled resolvable <a class="term-reference" href="#term:did">DID</a>;</li>
 <li>one or more <a class="term-reference" href="#term:ecosystem-governance-framework">ecosystem governance framework</a> document(s);</li>
@@ -244,21 +240,27 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <img src="https://www.plantuml.com/plantuml/svg/NOv12i9040Jlyuf6Fn0Gn6FU87vWiZj9LhExC3Cn1l7lYeA7zAMBfWxTchFwd2Tg_sI19q7c1qvDWoL57mbKkwi4n-wYipdECYHpNNTWWojZV-Yxs1tn97mYeTfgBXannSqILA8KJpp1mYYPRICCzIvQk0H1hvnbgNf3hC7eHTHAYT-xltu3" alt="uml diagram">
 <h3 id="credential-schemas-and-permissions"><a class="toc-anchor" href="#credential-schemas-and-permissions" >§</a> Credential Schemas and Permissions</h3>
 <p><em>This section is non-normative.</em></p>
-<p><a class="term-reference" href="#term:credential-schemas">Credential schemas</a> are created and managed by trust registry authority (<a class="term-reference" href="#term:ecosystems">ecosystems</a>). Each <a class="term-reference" href="#term:credential-schema">Credential schema</a> includes, at a minimum:</p>
+<p><a class="term-reference" href="#term:credential-schemas">Credential schemas</a> are created and managed by trust registry corporation (<a class="term-reference" href="#term:ecosystems">ecosystems</a>). Each <a class="term-reference" href="#term:credential-schema">Credential schema</a> includes, at a minimum:</p>
 <ul>
 <li>A <strong>Json Schema</strong> that defines the structure of the corresponding <a class="term-reference" href="#term:verifiable-credential">verifiable credential</a></li>
-<li>A <strong>PermissionManagementMode</strong> for <strong>issuance policy</strong>, which determines how <code>ISSUER</code> permissions are granted. Modes include:
+<li>A <strong>IssuerOnboardingMode</strong> for <strong>issuance policy</strong>, which determines how <code>ISSUER</code> permissions are granted. Modes include:
 <ul>
-<li><code>OPEN</code>: <code>ISSUER</code> permissions can be created by anyone.</li>
-<li><code>ECOSYSTEM</code>: <code>ISSUER</code> permissions are granted directly by the <a class="term-reference" href="#term:ecosystem">ecosystem</a>, the trust registry authority</li>
-<li><code>GRANTOR</code>: <code>ISSUER</code> permissions are granted by one or several <a class="term-reference" href="#term:issuer-grantor">issuer grantor</a>(s) (trust registry operator(s) responsible for selecting issuers for the credential schema of this <a class="term-reference" href="#term:ecosystem">ecosystem</a>), selected by the <a class="term-reference" href="#term:ecosystem">ecosystem</a>.</li>
+<li><code>OPEN</code>: <code>ISSUER</code> permissions can be self-created by anyone.</li>
+<li><code>ECOSYSTEM_VALIDATION_PROCESS</code>: <code>ISSUER</code> permissions are granted directly by the <a class="term-reference" href="#term:ecosystem">ecosystem</a>, the trust registry corporation through the execution of a Validation Process.</li>
+<li><code>GRANTOR_VALIDATION_PROCESS</code>: <code>ISSUER</code> permissions are granted by one or several <a class="term-reference" href="#term:issuer-grantor">issuer grantor</a>(s) (trust registry operator(s) responsible for selecting issuers for the credential schema of this <a class="term-reference" href="#term:ecosystem">ecosystem</a>), selected by the <a class="term-reference" href="#term:ecosystem">ecosystem</a> through the execution of a Validation Process.</li>
 </ul>
 </li>
-<li>A <strong>PermissionManagementMode</strong> for <strong>verification policy</strong>, which determines how <code>VERIFIER</code> permissions are granted. Modes include:
+<li>A <strong>VerifierOnboardingMode</strong> for <strong>verification policy</strong>, which determines how <code>VERIFIER</code> permissions are granted. Modes include:
 <ul>
 <li><code>OPEN</code>: <code>VERIFIER</code> permissions can be created by anyone.</li>
-<li><code>ECOSYSTEM</code>: <code>VERIFIER</code> permissions are granted directly by the <a class="term-reference" href="#term:ecosystem">ecosystem</a>, the Trust Registry authority</li>
-<li><code>GRANTOR</code>: <code>VERIFIER</code> permissions are granted by one or several <a class="term-reference" href="#term:verifier-grantor">verifier grantor</a>(s) (trust registry operator(s) responsible for selecting verifiers for the credential schema of this <a class="term-reference" href="#term:ecosystem">ecosystem</a>), selected by the <a class="term-reference" href="#term:ecosystem">ecosystem</a>.</li>
+<li><code>ECOSYSTEM_VALIDATION_PROCESS</code>: <code>VERIFIER</code> permissions are granted directly by the <a class="term-reference" href="#term:ecosystem">ecosystem</a>, the Trust Registry corporation through the execution of a Validation Process.</li>
+<li><code>GRANTOR_VALIDATION_PROCESS</code>: <code>VERIFIER</code> permissions are granted by one or several <a class="term-reference" href="#term:verifier-grantor">verifier grantor</a>(s) (trust registry operator(s) responsible for selecting verifiers for the credential schema of this <a class="term-reference" href="#term:ecosystem">ecosystem</a>), selected by the <a class="term-reference" href="#term:ecosystem">ecosystem</a>, through the execution of a Validation Process.</li>
+</ul>
+</li>
+<li>An <strong>HolderOnboardingMode</strong> for <strong>holder policy</strong>, which determines how <code>HOLDER</code> permissions are granted. Modes include:
+<ul>
+<li><code>ISSUER_VALIDATION_PROCESS</code>: <code>HOLDER</code> permissions are granted directly by issuers to holder through the execution of a Validation Process.</li>
+<li><code>PERMISSIONLESS</code>: holder that want to obtain credentials from an issuer do not require a permission in the VPR.</li>
 </ul>
 </li>
 <li>A <strong>Permission tree</strong> that defines the roles and relationships involved in managing the schema’s lifecycle. Each created permission in the tree can define business rules, see below <a href="#business-models" >Business Models</a>.</li>
@@ -295,7 +297,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 </tr>
 <tr>
 <td><strong>Holder</strong></td>
-<td>Holds a credential.</td>
+<td>Holds a credential. Holder permission provide credential status (active, revoked…)</td>
 </tr>
 </tbody>
 </table>
@@ -360,7 +362,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <li>The <a class="term-reference" href="#term:validator">validator</a> — an entity that already holds permission for the same credential schema and has been delegated authority to validate applicants and issue permissions.</li>
 </ul>
 <p>Running a validation process <strong>typically involves the payment of <a class="term-reference" href="#term:trust-fees">trust fees</a></strong>. <a class="term-reference" href="#term:trust-fee">Trust fee</a> amount to be paid by the <a class="term-reference" href="#term:applicant">applicant</a> is defined in the permission of the <a class="term-reference" href="#term:validator">validator</a> involved in the <a class="term-reference" href="#term:validation-process">validation process</a>:</p>
-<img src="https://www.plantuml.com/plantuml/svg/fPDRJyCW583V-HKds_CIr6GpVJ2xUdbRdFfEuQn3QMc0rYrc_rtMhcGQsosHbvB3uUjt3Z2sZXbNf8gCmynofX1IjeLRIk5J2hSXG7B6FrY2q5ko7UHee6HA2kQapk0U4LRE5DmL1dl0B70BNuI07pf-H-wWj-3Qxgp352OmW9b1WPcJJC6ARp1byAorWoMQL5hhcHN56UZVh6CH3pqDZaD84U6MfRd221le92m_69OvRO3bkPBSpqz5VRgBu8hwkbvURRLd_yFooTh2rzP0fd-g_hAKIOkTJAOXVWJ_osfsaKsTsnyDHoCKqAOs2-57hSGvinQlDpHoBK_wDVU6vnNBjeQLoJp40xj3xBgrOs7tufAUbKrsdzAOhccRtkBufpqX_ceE1dU7iuyWELJlUsrhU1xWn2zNMVMPT6KsmB8RMDR08Do976CcggTTVxy1" alt="uml diagram">
+<img src="https://www.plantuml.com/plantuml/svg/fPHTJy8m58RlzojEs3L9bOIPNHY-XfYOI42zyAvR3wEwhxHbGep_tRAE2iOD4dkpvlJj-puzwpQGYWgrIHDdO6SoeWb2IhTmGmXySARM3ZW5ZTvfZD2PqnqKAA2a2MTKyJo3AI8ibTX4QYEm0rH29E7JSK2FF7p3I44dY7AvamfJ648NnW8PPehJ19RH6bCAYpnNC4UHSYcrP-MY1BYzLSZ2ldQ3UZ3EVDpIj4ZGnuFfq2xV2PgfN00jYeH7UduCgkNAXokYp_NqBAizNoUKzr9kzDaE9gC_KNzHyhY1ZiSZMw-D_qKrleZ6Q5slxtd8e0bjRCkpF67do1guNb3m5J_grqGJdaSicnfMnXDRjzujODUD7RExWqjwLXxKBY4XMP4clA1EEecg-_TwIT3QQDtfT4Iytb5CONLFkm9zc3q-J8957QS3zPVGxTxkhveFyRxP-jLA4_6prT7BbSfSWLQbaUpLXgbDN8UNxU6b2RUzRDCw0ynOzTSnpsy0" alt="uml diagram">
 <h3 id="did-indexing"><a class="toc-anchor" href="#did-indexing" >§</a> DID Indexing</h3>
 <p><em>This section is non-normative.</em></p>
 <p>The Permission registry is a can be used by crawlers to index the metadata associated with <a class="term-reference" href="#term:verifiable-services">verifiable services</a>.</p>
@@ -468,17 +470,18 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <td></td>
 <td></td>
 <td></td>
-<td>renewable subscription</td>
+<td>renewable subscription  (5)</td>
 <td></td>
 <td></td>
 </tr>
 </tbody>
 </table>
 <ul>
-<li>(1): if <em>issuer mode</em> is set to GRANTOR.</li>
-<li>(2): if <em>verifier mode</em> is set to GRANTOR.</li>
-<li>(3): if <em>issuer mode</em> is set to ECOSYSTEM.</li>
-<li>(4): if <em>verifier mode</em> is set to ECOSYSTEM.</li>
+<li>(1): if <em>issuer onboarding mode</em> is set to GRANTOR_VALIDATION_PROCESS.</li>
+<li>(2): if <em>verifier onboarding mode</em> is set to GRANTOR_VALIDATION_PROCESS.</li>
+<li>(3): if <em>issuer onboarding mode</em> is set to ECOSYSTEM_VALIDATION_PROCESS.</li>
+<li>(4): if <em>verifier onboarding mode</em> is set to ECOSYSTEM_VALIDATION_PROCESS.</li>
+<li>(5): if <em>holder onboarding mode</em> is set to ISSUEr_VALIDATION_PROCESS.</li>
 </ul>
 <p>Validation process is started by the applicant.</p>
 <p><em>Example of a candidate <a class="term-reference" href="#term:issuer">issuer</a> (<a class="term-reference" href="#term:applicant">applicant</a>) that would like to be granted an ISSUER permission for a credential schema of an ecosystem, by a <a class="term-reference" href="#term:validator">validator</a> that has a ISSUER_GRANTOR permission:</em></p>
@@ -524,7 +527,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <li>A portion defined by <code>trust_deposit_rate</code> is allocated to the <strong>participant’s trust deposit</strong>.</li>
 <li>The remaining portion is <strong>transferred directly to the participant’s wallet</strong>.</li>
 </ul>
-<div id="note-2" class="notice note"><a class="notice-link" href="#note-2">NOTE</a><p><strong>Wallet User Agents</strong> and <strong>User Agents</strong> that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
+<div id="note-77" class="notice note"><a class="notice-link" href="#note-77">NOTE</a><p><strong>Wallet User Agents</strong> and <strong>User Agents</strong> that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
 If not, they <strong>must reject</strong> the issuance or verification request.</p>
 <p>Note: The <strong>User Agent</strong> and <strong>Wallet User Agent</strong> may refer to the same implementation.</p>
 </div>
@@ -536,7 +539,7 @@ If not, they <strong>must reject</strong> the issuance or verification request.<
 <p><em>This section is non-normative.</em></p>
 <p>A <a class="term-reference" href="#term:governance-framework">governance framework</a> must define the governance rules that apply to a <a class="term-reference" href="#term:vpr">VPR</a>.</p>
 <p>A designated <a class="term-reference" href="#term:governance-authority">governance authority</a> is responsible for <strong>enforcing these rules</strong> and, when necessary, <strong>applying financial sanctions</strong> to participants who violate the rules.</p>
-<div id="note-3" class="notice note"><a class="notice-link" href="#note-3">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
+<div id="note-78" class="notice note"><a class="notice-link" href="#note-78">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
 <p>While the <strong>VPR governance framework</strong> defines the global rules for operating the Verifiable Public Registry (e.g., trust deposits, fee distribution, slashing conditions), each <strong>ecosystem</strong> must define its own <strong>EGF</strong> to govern roles, permissions, credential policies, and compliance within its specific domain.</p>
 <p>This separation ensures that ecosystems remain autonomous and can tailor governance to their unique needs, without being constrained by the global rules of the VPR.</p>
 </div>
@@ -544,18 +547,18 @@ If not, they <strong>must reject</strong> the issuance or verification request.<
 <p>For simplicity, the data model is presented using an <strong>object-relational structure</strong>. However, this representation may not be optimal for all implementation scenarios.</p>
 <p>Implementors are responsible for <strong>adapting the data model</strong> to suit their chosen architecture.<br>
 For example, a <strong>key-value store</strong> may be more appropriate for a <strong>ledger-based implementation</strong> than a relational model.</p>
-<img src="https://www.plantuml.com/plantuml/svg/jLXBR-Cs4BxhLmW-xRPDa6sBel0fHknDZMxYr7O254L1C29jSoE9AadPSOhzxnq-954MbTW8Uh6bcO_pud1cg4kfi51bbaQNzPDCS4hZ33_7lrvSn3j6r2QAQAwOsiU3fIYbcjCraqhi1p6MiHBnlr4SVyV8C2vPhdxv6Tw-9_eLC2nVwzT4KAmea1JBA6ZA2atDE64hrY5ZaMpOjaj-mhv8d2W0eIqLal5y68DgJKvnlYxnclhGGh047X6MaggMZ3JbEzHY8vbiQ8OH1y624P3po7bASHvzQw9mhRavpXFwMU2CxhXuUh1sc92iLzjGJC91y1sWQohUq3FcIPa1toaYnoiAHQOKgVzAs1hmI0fMKy6QsfmhGOb-nkd21CdOaCZZJJXjmxzAdhljy8raKfPKeBN0kU82RN7A25OGGli8bgA22iP1N5vcZn1H6sMj-THbJjU9Eew3RtXAZWOxGu2HeGpdi8qw2H045FRp3gW0014tDUi6E2sZJb_QUsnSck1qpGLJcynF5WesnmER7wDIRG3nOhoxuobBzdCuIoPj92viuPWk5lUJEJmyJERJprDuz5EkLr0bv1q73MW2p1aQMuux3Ne9tV8dBRog2q2ZgnMrvMWbUDRMs_1Ay2drcTPH7Q--RN0dhCYCcxExoItyNSz7jykP3jdaQhRuSx6StFX5uyDY_Fl7U9Gal7Hb0jjdaE7N5i7BmbOH_THcpY1RC1oJLk0Dc6CWlHXpu3pBDLBxWifXN3t-zRVXqEU22REg7Gt8AfVRfBHyN-t3eb_nLjQglHLZclDibDMk4cnC8vhixHesYFf0rNbwPrDyf3Dy2TOR6IxlJTfhbup4vJtyNCscUWC-JqTBtuXcznPKrbq0jiqlZIKZfnP6u-ym_c0p-uUu_VyHGkqPCNbEDb3XwHp46_tFmSRyY2NjdkX_Igu2PDWAUlYEp7nWHVxqepas1GcuP390PqRx45Obhjf-Bn603JWLRhc-UztaU1PURWJsfTgGG4JUDQcGhp0ETSWonNBJeGfQO4RwYiD9XQCAf6qRAwh3tEuLUcReC6mlICAh22suPCedEJzGW6MT2N3gyjYsja2G3rqYA802gpSTsUtjGfoZqB83PW0_AONG_QpZRCCABvHbbc41cHWiytuG0IAJLW4913CCaeYxYePCXYAQuyVqe7rqKRAWEK6TKXd4xg05QmFCPDCwEwx8FTIfib1LSO2ech2R0m5jPJozlTOzUFHbEXuj9sDTyIRpc-djQ3cTtQBvv8_xoQ9DXvV_lGQ-fc1E4ov8hIPOxGAQ_EPXTjxs3VDeHOGJeazKkttNJGHCKZtpJKL3JIElU2ZKs-FujzcNyS5WT9toHvm-OC5qFadRoEsrGvlgvlJgDkF-u5A797kXVefsmKSFs4OUmNlvkhmJPkyZ9RuvbfzgsRiblJdC7ob7wVjrg62r64XkiA1QHKdxGQPxzp6rENj6K_8wx37boHCIT8S5iLezQ2d1PPXMeSGwn86i7LomuKhzEkxRmTU5iLLjFoxO-wrLt3ZQZK-IOfRfa-3H-jjNR_Uo_IZKlWqdrC8D6YM7ysKraV2pCvXEMgzk71_6LI7NQCCvd3oXcjVZcfck-u7U16UH6de6qC6dytDTZ2kbTbf3kmrJD6LIHH7SuCCosnz6p2WSHVQsS7R6tLLWQCPKVH7SHzL5m-SsJZOhgrc-Rst3zzgTDhGmbkhQ2fkWlMn8KAjTSI0rTN1nVlvfeF73k9aZp4tOe0n82P0bDA6Yw6KGChWMGWpqRPDHQRHBFwAswO1QsuuWENG_Sa0HTmpmh_3MnX2gVL_lnxcZPKzLXOtS5Ma0gBF64OA7iPvGx5IHieofLv0-oaGoWF6d41z_1FpGaAY-s7cBZ8j5tLKbv5saH2FQxi1wjJK1Sn3zsQs3qEEJ-sGcMzchjxt9lePkLFSmfCzfPQpTkuDabUtZxhDhhbNNtiLwE6ia5tPATkPO1qZBcai8gVcGQ___0m00" alt="uml diagram">
+<img src="https://www.plantuml.com/plantuml/svg/hHZPZjisy5rV8UnJco91qXP5uASOQ-_6QB9Us8w1eYW8MgHjPYLH9IdlKUJVEpn4KHQrQpTziQMPuToSGn-amaBLHPvyy4yompbD2_oGld_xDhrdHEsJX9QAgSVqOYLggHPqnwGIZnSfbgaIwJz9chvYP9JMh5I__GflFn7z2ZIitEdNJ52iA80KAoX8AYeDBJXXMzO3Ov7jsQ4FliCXIvmf8487AYJZvIW5qHgSut9NuntrfDzQvQyvK9UupEYLm0Mzv-9kROyRItRRGyoKkEwXNBgZuWKv4vxL1U2T87Awe9v10Aj57huIjWDw90KBhVRgN0fAz3FEbzcU5jZeaCdJLJWlJbybBv4qaa8bcPGr5MWdSAcuG0USCu8LkD0-WgQeee9nO5VMnGOyQhsi9PzxpCawKyPfv7kUavE9dIAyt70i27W2WIyXb3C3dtlmPu1sTEcTM3jC_unJg7VYeu7twIl1Cas5fQGgaaOutt71rBxeNg6wI2zi_enhjGUA9sFzBSzPzhZWEJLf9N5bwy5ikVmoNS33UhgONStWCKp9GKODa--uY00JeCx8w7BQRT57w87VQUOR3eTngM5qkwMsocm5BxfoMrmDDkKXqXgg_HKBix6GyS9OEB-Tti3VzM9yivelq7hyQJOPhsRp6tIxc5zEbqj0JY_dop-Mg-dd6Dg79fuVHjZXVnSMIoqZQkz4sUZ7HTnE5vy13y1FZgbFYn-Mazz_JCTPncjNAh5z1gPXVHMyhcmbrKzTv1nk8OPIqKakGymnW9wCVb3Jv0wfnuhAKTey_lcNmT27YWbpgXjnk3dkVfFQuaEnw-Mmu8FqeeCJjrGKK1-0g7DYGJCkY3bNONkNqbV0ka2Ts_2S1VTmUz6MKbCqmup-hyPDQCcBSU6ZGh3HYsXmS8cmeV3rpwVBhQquOrrmLg2cDSu2JHNIkXkEgo_mSpcVwJozcerNeHBJXsmFlP0ke0WO3W_HoME39UtNjhzhhY9WC9KUloCp05cMl_ni2aX58eN7k59xlrkEccRG-37mAA21JajiGXAOTqNfjOwNCMsxCwODndWmZi-6CVHWFqiVH92aaInrOqEiD7_Nj4U-maZP0yiSotqFAcY56Hcgn6TLwIPMjeV3RP77ZLiFS3s4xT1P_1IX5PTCXI1d1ugWh34HZEz5NMqh157l0q40T3ETLyY6jq_Y38NvAQ86uBDQ20XutzWM5JyewwB00fBTzDJZSQzn8A1brYaD4KVsYTe-klQ1MghczeDDncYJZj3P9hERQprks9OpdUXgeZlDZNc9rjqbxIHsE17NZ9oNoSy924gw5XCjMn59OG4s_hMrrpnQ5dst3x4nPTZhvOimgAC6nZNVnDsy4E02a9yNuFdZ_DFaQCwxpla6vsii6DxaLDgURRSihQfRIzosqFp1weaaUw9XjlI9Jzud33-27-Np_CvODKxa-E8MSgvctytfnTtbH3vAVmM8bOGE0iaz5bIBgEamaMd1GqYjpYEZENcUR9Fpx0u9UW_Zg9KQaDOIJ8O56egOepZYTO_pd2hqFDstesyW4olQVWAnwxmLt1hQzq-MOrRecn30XXl4O7-m5J_M80qcrYGDDUhLLpi_ltxDOU8OfIxpasRexi0fJM0gkNXt0U3NwSNRDs-WS1AzubUq92Xd1LD9qWmH76WUHEVLSHsbt0tAcjfWZaT1c8_y46Tcdc72OAwpb9hKAFZEAEY5sXaEtU-PeZcJe6ec1tXs5cJ3DGqzPMVvKGerlU9ko0ezrk1RCzkppIOmVBgbE4ZaMVWDmllVcWSRmWZoHBSNcUXrGLi4HHsCi1k3DhDgeE06uwCM1D5pjOfug0ujI35Ssi6XuUUyfa2k4aw0FmOQmT8DmlKkpwWqqcMeiEr_8DPsHjJedbX4Jm5NGrlfKIfV8L-WSpVTNl8NQBj4oR7_s_pNiqju1uOfEpT5kpj24qIzm_K4ycD5aaI9uuJPRG_6NThvCatq9yyUXTuUtETAsSby7VGmRrkCyTWWIdPndNotyGjItQPCfs1qq7xkQqzNTlnrGgsgv4Zc1_2B-Svj__y5" alt="uml diagram">
 <h3 id="trustregistry"><a class="toc-anchor" href="#trustregistry" >§</a> TrustRegistry</h3>
 <p><code>TrustRegistry</code>:</p>
 <ul>
 <li><code>id</code> (uint64) (<em>mandatory</em>): the id of the trust registry.</li>
 <li><code>did</code> (string) (<em>mandatory</em>): the did of the ecosystem.</li>
-<li><code>authority</code> (group) (<em>mandatory</em>): <a class="term-reference" href="#term:group">group</a> that controls this entry.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): <a class="term-reference" href="#term:group">group</a> that controls this entry.</li>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this TrustRegistry has been created.</li>
 <li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this TrustRegistry has been modified.</li>
 <li><code>archived</code> (timestamp) (<em>mandatory</em>): timestamp this TrustRegistry has been archived.</li>
 <li><code>aka</code> (string) (<em>optional</em>): optional additional URI of this trust registry.</li>
-<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.ietf.org"path-1="rfc"path-2="rfc1766.txt"href="https://www.ietf.org/rfc/rfc1766.txt" >rfc1766</a>) of this trust registry.</li>
+<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of this trust registry.</li>
 <li><code>active_version</code> (int): (<em>mandatory</em>) active governance framework version.</li>
 </ul>
 <h3 id="governanceframeworkversion"><a class="toc-anchor" href="#governanceframeworkversion" >§</a> GovernanceFrameworkVersion</h3>
@@ -572,7 +575,7 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 <li><code>id</code> (uint64) (<em>mandatory</em>): the id of the schema.</li>
 <li><code>gfv_id</code> (uint64) (<em>mandatory</em>): the id of the <code>GovernanceFrameworkVersion</code> entry.</li>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this GovernanceFrameworkDocument has been created.</li>
-<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.ietf.org"path-1="rfc"path-2="rfc1766.txt"href="https://www.ietf.org/rfc/rfc1766.txt" >rfc1766</a>) of this trust registry.</li>
+<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of this trust registry.</li>
 <li><code>url</code> (string) (<em>mandatory</em>): URL where the document is published.</li>
 <li><code>digest_sri</code> (string) (<em>mandatory</em>): digest_sri of the document.</li>
 </ul>
@@ -591,8 +594,9 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 <li><code>issuer_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which an issuer validation process expires and must be renewed.</li>
 <li><code>verifier_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which a verifier validation process expires and must be renewed.</li>
 <li><code>holder_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which an holder validation process expires and must be renewed.</li>
-<li><code>issuer_perm_management_mode</code> (PermissionManagementMode) (<em>mandatory</em>): defines how permissions are managed for issuers of this <code>CredentialSchema</code>. OPEN means anyone can issue credential of this schema; GRANTOR means a validation process MUST be run between a candidate ISSUER and an ISSUER_GRANTOR in order to create an ISSUER permission; ECOSYSTEM means a validation process MUST be run between a candidate ISSUER and the trust registry owner (ecosystem) of the <code>CredentialSchema</code> entry in order to create an ISSUER permission;</li>
-<li><code>verifier_perm_management_mode</code> (PermissionManagementMode) (<em>mandatory</em>): defines how permissions are managed for verifiers of this <code>CredentialSchema</code>. OPEN means anyone can verify credentials of this schema (does not implies that a payment is not necessary); GRANTOR means a validation process MUST be run between a candidate VERIFIER and a VERIFIER_GRANTOR in order to create a VERIFIER permission; ECOSYSTEM means a validation process MUST be run between a candidate VERIFIER and the trust registry owner (ecosystem) of the <code>CredentialSchema</code> entry in order to create a VERIFIER permission;</li>
+<li><code>issuer_onboarding_mode</code> (IssuerOnboardingMode) (<em>mandatory</em>): defines how permissions are managed for issuers of this <code>CredentialSchema</code>. OPEN means anyone can issue credential of this schema; GRANTOR_VALIDATION_PROCESS means a validation process MUST be run between a candidate ISSUER and an ISSUER_GRANTOR in order to create an ISSUER permission; ECOSYSTEM_VALIDATION_PROCESS means a validation process MUST be run between a candidate ISSUER and the trust registry owner (ecosystem) of the <code>CredentialSchema</code> entry in order to create an ISSUER permission;</li>
+<li><code>verifier_onboarding_mode</code> (VerifierOnboardingMode) (<em>mandatory</em>): defines how permissions are managed for verifiers of this <code>CredentialSchema</code>. OPEN means anyone can verify credentials of this schema (does not implies that a payment is not necessary); GRANTOR_VALIDATION_PROCESS means a validation process MUST be run between a candidate VERIFIER and a VERIFIER_GRANTOR in order to create a VERIFIER permission; ECOSYSTEM_VALIDATION_PROCESS means a validation process MUST be run between a candidate VERIFIER and the trust registry owner (ecosystem) of the <code>CredentialSchema</code> entry in order to create a VERIFIER permission;</li>
+<li><code>holder_onboarding_mode</code> (HolderOnboardingMode) (<em>mandatory</em>): defines how permissions are managed for holders of this <code>CredentialSchema</code>. ISSUER_VALIDATION_PROCESS means a validation process MUST be run between a candidate HOLDER and an ISSUER in order to create a HOLDER permission. HOLDER permission is used to check credential revocation status; PERMISSIONLESS means no onboarding is required to take place on the VPR (and thus an ISSUER cannot use the VPR to charge validation fees to candidate holders);</li>
 <li><code>pricing_asset_type</code> (PricingAssetType) (<em>mandatory</em>): used asset for paying business fees. Can be TU (<a class="term-reference" href="#term:trust-unit">trust unit</a>),  COIN (a token available on the VPR chain), FIAT (means chain is used for settlement only and payment is done off-chain). Not that in all cases, trust deposits are always handled in <code>denom</code>.</li>
 <li><code>pricing_asset</code> (string) (<em>mandatory</em>): <code>&quot;tu&quot;</code> if <code>pricing_asset_type</code> is set to TU, else examples: COIN: <code>denom</code> <code>&quot;uvna&quot;</code>, <code>&quot;ufoo&quot;</code>, <code>&quot;ibc/3A0F9C2E4E2A9B7D6F...&quot;</code>, <code>&quot;factory/verana1.../ueurv&quot;</code>, FIAT: <code>&quot;USD&quot;</code>, <code>&quot;GBP&quot;</code>,…</li>
 <li><code>digest_algorithm</code> (string) (<em>mandatory</em>): algorithm used to compute the <code>digestSRI</code> for credentials issued under this schema. Valid values are defined in the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust spec</a>.</li>
@@ -618,7 +622,7 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 <li><code>schema_id</code> (uint64) (<em>mandatory</em>): the id of the related <code>CredentialSchema</code> entry.</li>
 <li><code>type</code> (PermissionType): ISSUER, VERIFIER, ISSUER_GRANTOR, VERIFIER_GRANTOR, ECOSYSTEM, HOLDER</li>
 <li><code>did</code> (string) (<em>optional</em>): <a class="term-reference" href="#term:did">DID</a> this permission refers to. MUST conform to [<a class="spec-reference" href="#ref:RFC3986">RFC3986</a>].</li>
-<li><code>authority</code> (group) (<em>mandatory</em>): <a class="term-reference" href="#term:group">group</a> that owns this permission.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): <a class="term-reference" href="#term:group">group</a> that owns this permission.</li>
 <li><code>vs_operator</code> (account) (<em>mandatory</em>): verifiable service agent account. This is the account that will have the right to create or update permission sessions.</li>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this <code>Permission</code> has been created.</li>
 <li><code>adjusted</code> (timestamp) (<em>mandatory</em>): timestamp this <code>Permission</code> has been adjusted.</li>
@@ -627,36 +631,33 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 <li><code>effective_from</code> (timestamp) (<em>optional</em>): timestamp from which (inclusive) this <code>Permission</code> is effective.</li>
 <li><code>effective_until</code> (timestamp) (<em>optional</em>): timestamp until when (exclusive) this <code>Permission</code> is effective, null if no time limit has been set for this permission.</li>
 <li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this Permission has been modified.</li>
-<li><code>validation_fees</code> (number) (<em>mandatory</em>): price to pay by an applicant to a validator (<code>authority</code> grantee of this perm) for running a validation process for a given validation period. Must be an integer. Default to 0. Considered unit depends on <code>pricing_asset_type</code> and <code>pricing_asset</code> configuration of related schema.</li>
-<li><code>issuance_fees</code> (number) (<em>mandatory</em>): fees requested by grantee <code>authority</code> of this perm when a credential is issued. Must be an integer. Default to 0. Considered unit depends on <code>pricing_asset_type</code> and <code>pricing_asset</code> configuration of related schema.</li>
-<li><code>verification_fees</code> (number) (<em>mandatory</em>): fees requested by grantee <code>authority</code> of this perm when a credential is verified. Must be an integer. Default to 0. Considered unit depends on <code>pricing_asset_type</code> and <code>pricing_asset</code> configuration of related schema.</li>
+<li><code>validation_fees</code> (number) (<em>mandatory</em>): price to pay by an applicant to a validator (<code>corporation</code> grantee of this perm) for running a validation process for a given validation period. Must be an integer. Default to 0. Considered unit depends on <code>pricing_asset_type</code> and <code>pricing_asset</code> configuration of related schema.</li>
+<li><code>issuance_fees</code> (number) (<em>mandatory</em>): fees requested by grantee <code>corporation</code> of this perm when a credential is issued. Must be an integer. Default to 0. Considered unit depends on <code>pricing_asset_type</code> and <code>pricing_asset</code> configuration of related schema.</li>
+<li><code>verification_fees</code> (number) (<em>mandatory</em>): fees requested by grantee <code>corporation</code> of this perm when a credential is verified. Must be an integer. Default to 0. Considered unit depends on <code>pricing_asset_type</code> and <code>pricing_asset</code> configuration of related schema.</li>
 <li><code>deposit</code> (number) (<em>mandatory</em>): accumulated <em>grantee</em> deposit in the context of the <em>use</em> of this permission (including the validation process), in <a class="term-reference" href="#term:native-denom">native denom</a>. Usually, it is incremented when for example, for a ISSUER type <code>Permission</code> <code>perm</code>, issuer issues credentials that require paying issuance fees: an additional % of the fees is charged to issuer and sent to its deposit, corresponding deposit amount increases this <code>perm.deposit</code> value as well. If <code>perm</code> is, let’s say revoked, then corresponding <code>perm.deposit</code> value is freed from <code>perm.grantee</code> Trust Deposit.</li>
 <li><code>slashed_deposit</code> (number) (<em>mandatory</em>): part of the deposit in <a class="term-reference" href="#term:native-denom">native denom</a> that has been slashed.</li>
 <li><code>repaid_deposit</code> (number) (<em>mandatory</em>): part of the slashed deposit in <a class="term-reference" href="#term:native-denom">native denom</a> that has been repaid.</li>
 <li><code>revoked</code> (timestamp) (<em>optional</em>): manual revocation timestamp of this Perm.</li>
 <li><code>validator_perm_id</code> (uint64) (<em>optional</em>): permission of the validator assigned to the validation process of this permission, ie <em>parent node</em> in the <code>Permission</code> tree.</li>
-<li><code>vp_state</code> (enum) (<em>mandatory</em>): one of PENDING, VALIDATED, TERMINATED, TERMINATION_REQUESTED.</li>
+<li><code>vp_state</code> (enum) (<em>mandatory</em>): one of PENDING, VALIDATED, TERMINATED.</li>
 <li><code>vp_exp</code> (timestamp) (<em>optional</em>): validation expiration timestamp. This expiration timestamp is for the validation process itself, not for the issued credential or <code>Permission</code> expiration timestamp.</li>
 <li><code>vp_last_state_change</code> (timestamp) (<em>mandatory</em>)</li>
 <li><code>vp_validator_deposit</code>: number (<em>optional</em>): accumulated validator trust deposit, in <a class="term-reference" href="#term:denom">denom</a>.</li>
 <li><code>vp_current_fees</code> (number) (<em>mandatory</em>): current action escrowed fees that will be paid to <a class="term-reference" href="#term:validator">validator</a> upon validation process completion, in <a class="term-reference" href="#term:denom">denom</a>.</li>
 <li><code>vp_current_deposit</code> (number) (<em>mandatory</em>): current action trust deposit, in <a class="term-reference" href="#term:denom">denom</a>.</li>
-<li><code>vp_summary_digest_sri</code> (string) (<em>optional</em>): an optional digest SRI, set by <a class="term-reference" href="#term:validator">validator</a>, of a summary of the information, proofs… provided by the <a class="term-reference" href="#term:applicant">applicant</a>.</li>
-<li><code>issuance_fee_discount</code>: (number) (<em>mandatory</em>): default to 0 (no discount). Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR mode) or an ISSUER permission (ECOSYSTEM mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
-<li><code>verification_fee_discount</code>: (number) (<em>mandatory</em>): default to 0 (no discount). Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR mode) and/or a VERIFIER permission (ECOSYSTEM mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
-<li><code>vs_operator_authz_enabled</code>: boolean (<em>mandatory</em>): if set to true, authorize this vs_operator to execute CreateOrUpdatePermissionSession <em>on behalf</em> of <code>authority</code> account (trust fees will be paid by authority account)</li>
-<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds that the vs_operator is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.</li>
-<li><code>vs_operator_authz_with_feegrant</code>: boolean (<em>mandatory</em>): if set to true, enable feegrant for this permission so vs_operator can pay the fees for CreateOrUpdatePermissionSession with <code>authority</code> account.</li>
-<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of fees that can be spent by vs_operator in the context of this permission.</li>
-<li><code>vs_operator_authz_spend_period</code>: (period) (<em>optional</em>): reset period for vs_operator_authz_spend_limit and vs_operator_authz_fee_spend_limit in the context of this permission.</li>
+<li><code>vp_summary_digest</code> (string) (<em>optional</em>): an optional digest SRI, set by <a class="term-reference" href="#term:validator">validator</a>, of a summary of the information, proofs… provided by the <a class="term-reference" href="#term:applicant">applicant</a>.</li>
+<li><code>issuance_fee_discount</code>: (number) (<em>mandatory</em>): default to 0 (no discount). Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_VALIDATION_PROCESS mode) or an ISSUER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
+<li><code>verification_fee_discount</code>: (number) (<em>mandatory</em>): default to 0 (no discount). Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_VALIDATION_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
 </ul>
+<blockquote>
+<p>Note: VS operator authorization settings (spend limits, feegrant, expiration, authorized message types) are no longer stored on <code>Permission</code>. They live in <code>PermissionAuthorizationRecord</code> entries inside <a href="#vsoperatorauthorization" >VSOperatorAuthorization</a>, keyed by <code>Permission.id</code>. See <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a> and <a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a>.</p>
+</blockquote>
 <h3 id="permissionsession"><a class="toc-anchor" href="#permissionsession" >§</a> PermissionSession</h3>
 <p><code>PermissionSession</code>:</p>
 <ul>
 <li><code>id</code> (uuid) (<em>mandatory</em>): session uuid.</li>
-<li><code>authority</code> (group) (<em>mandatory</em>): authority that controls the entry.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): corporation that controls the entry.</li>
 <li><code>vs_operator</code> (account) (<em>mandatory</em>): verifiable service agent account that controls the entry (agent crypto account).</li>
-<li><code>agent_perm_id</code> (uint64) (<em>mandatory</em>): permission id of the agent.</li>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this PermissionSession has been created.</li>
 <li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this PermissionSession has been modified.</li>
 <li><code>session_records</code> (PermissionSessionRecord[]) (<em>mandatory</em>): session records, for this session.</li>
@@ -668,12 +669,13 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 <li><code>issuer_perm_id</code> (uint64) (<em>optional</em>): related issuer <code>Permission</code> id (if applicable).</li>
 <li><code>verifier_perm_id</code> (uint64) (<em>optional</em>): related verifier <code>Permission</code> id (if applicable).</li>
 <li><code>wallet_agent_perm_id</code> (uint64) (<em>optional</em>): related wallet agent <code>Permission</code> id (if applicable).</li>
+<li><code>agent_perm_id</code> (uint64) (<em>optional</em>): permission id of the agent <code>Permission</code> id (if applicable).</li>
 </ul>
 <h3 id="trustdeposit"><a class="toc-anchor" href="#trustdeposit" >§</a> TrustDeposit</h3>
 <p><code>TrustDeposit</code>:</p>
 <ul>
 <li><code>share</code> (number) (<em>mandatory</em>): share of the module total deposit.</li>
-<li><code>authority</code> (group) (<em>mandatory</em>) (key): the <a class="term-reference" href="#term:group">group</a></li>
+<li><code>corporation</code> (group) (<em>mandatory</em>) (key): the <a class="term-reference" href="#term:group">group</a></li>
 <li><code>deposit</code> (number) (<em>mandatory</em>): amount of deposit in <code>denom</code>.</li>
 <li><code>claimable</code> (number) (<em>mandatory</em>): amount of claimable deposit in <code>denom</code>.</li>
 <li><code>slashed_deposit</code> (number) (<em>optional</em>): amount of slashed deposit in <code>denom</code>.</li>
@@ -689,12 +691,12 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 </ul>
 <h3 id="digest"><a class="toc-anchor" href="#digest" >§</a> Digest</h3>
 <ul>
-<li><code>digest_sri</code> (string) (<em>mandatory</em>): digestSRI to store.</li>
+<li><code>digest</code> (string) (<em>mandatory</em>): digest to store.</li>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): block execution date of when it was persisted.</li>
 </ul>
 <h3 id="operatorauthorization"><a class="toc-anchor" href="#operatorauthorization" >§</a> OperatorAuthorization</h3>
 <ul>
-<li><code>authority</code> (group) (<em>mandatory</em>): the authority group granting the authorization.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): the corporation group granting the authorization.</li>
 <li><code>operator</code> (account) (<em>mandatory</em>): the operator account receiving the authorization.</li>
 <li><code>msg_types</code> (msg_type[]) (<em>mandatory</em>): list of module message types this authorization applies to.</li>
 <li><code>spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds that the grantee is allowed to spend
@@ -703,11 +705,33 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>expiration</code> (timestamp) (<em>optional</em>): timestamp after which the authorization is no longer valid.</li>
 <li><code>period</code> (duration) (<em>optional</em>): reset period for spend_limit and fee_spend_limit.</li>
 </ul>
-<h3 id="vsoperatorauthorization"><a class="toc-anchor" href="#vsoperatorauthorization" >§</a> VSOperatorAuthorization</h3>
+<h3 id="feegrant"><a class="toc-anchor" href="#feegrant" >§</a> FeeGrant</h3>
+<p><code>FeeGrant</code>:</p>
 <ul>
-<li><code>authority</code> (group) (<em>mandatory</em>): the authority group granting the authorization.</li>
+<li><code>grantor</code> (group) (<em>mandatory</em>): the corporation group granting the fee allowance.</li>
+<li><code>grantee</code> (account) (<em>mandatory</em>): the account that receives the fee grant from <code>grantor</code>.</li>
+<li><code>msg_types</code> (msg_type[]) (<em>mandatory</em>): list of VPR delegable message types for which the fee allowance applies.</li>
+<li><code>spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of fees that can be spent using this grant.</li>
+<li><code>expiration</code> (timestamp) (<em>optional</em>): timestamp after which the fee grant is no longer valid.</li>
+<li><code>period</code> (duration) (<em>optional</em>): reset period for spend_limit.</li>
+</ul>
+<h3 id="vsoperatorauthorization"><a class="toc-anchor" href="#vsoperatorauthorization" >§</a> VSOperatorAuthorization</h3>
+<p>A <code>VSOperatorAuthorization</code> groups all <code>PermissionAuthorizationRecord</code> entries delegated by one <code>corporation</code> to one <code>vs_operator</code>. It is keyed by the <code>(corporation, vs_operator)</code> pair. The entry exists if, and only if, it has at least one record.</p>
+<ul>
+<li><code>corporation</code> (group) (<em>mandatory</em>): the corporation group granting the authorization.</li>
 <li><code>vs_operator</code> (account) (<em>mandatory</em>): the operator account receiving the authorization.</li>
-<li><code>permissions[]</code> (uint64[]) (<em>mandatory</em>): permission ids for which we grant this authorization.</li>
+<li><code>records</code> (PermissionAuthorizationRecord[]) (<em>mandatory</em>): per-permission authorization records granted to <code>vs_operator</code> by <code>corporation</code>.</li>
+</ul>
+<h3 id="permissionauthorizationrecord"><a class="toc-anchor" href="#permissionauthorizationrecord" >§</a> PermissionAuthorizationRecord</h3>
+<p>A <code>PermissionAuthorizationRecord</code> carries the per-permission authorization configuration that was previously stored on <code>Permission.vs_operator_authz_*</code> fields. Each record is globally unique by <code>perm_id</code>: for any <code>Permission.id</code>, at most one record exists system-wide, so <code>(corporation, vs_operator)</code> can be derived from <code>perm_id</code> via a direct lookup.</p>
+<ul>
+<li><code>perm_id</code> (uint64) (<em>mandatory</em>): id of the <code>Permission</code> this authorization record applies to. Globally unique across all <code>PermissionAuthorizationRecord</code> entries.</li>
+<li><code>msg_types</code> (msg_type[]) (<em>mandatory</em>): list of delegable message types for which the <code>vs_operator</code> is authorized on behalf of <code>corporation</code> when acting in the context of <code>perm_id</code>. Declared by the applicant at record creation time (see <a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a> and <a href="#mod-perm-msg-14-self-create-permission" >[MOD-PERM-MSG-14]</a>). Frozen after creation.</li>
+<li><code>spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount the <code>vs_operator</code> is allowed to spend, in the context of this permission, as a direct consequence of executing authorized messages.</li>
+<li><code>fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of transaction fees that can be spent by <code>vs_operator</code> (paid by <code>corporation</code> via fee grant) in the context of this permission.</li>
+<li><code>with_feegrant</code> (bool) (<em>mandatory</em>): if true, <code>corporation</code> pays the transaction fees for <code>vs_operator</code> when executing authorized messages in the context of this permission, through an on-chain <code>FeeGrant</code>.</li>
+<li><code>expiration</code> (timestamp) (<em>mandatory</em>): timestamp after which this authorization is no longer valid. Written to <code>now</code> at <a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a> (disabled until validation) and to <code>Permission.effective_until</code> at <a href="#mod-perm-msg-3-set-permission-vp-to-validated" >[MOD-PERM-MSG-3]</a> / <a href="#mod-perm-msg-8-adjust-permission" >[MOD-PERM-MSG-8]</a> / <a href="#mod-perm-msg-14-self-create-permission" >[MOD-PERM-MSG-14]</a>.</li>
+<li><code>period</code> (duration) (<em>optional</em>): reset period for <code>spend_limit</code> and <code>fee_spend_limit</code> in the context of this permission.</li>
 </ul>
 <h3 id="exchangerate"><a class="toc-anchor" href="#exchangerate" >§</a> ExchangeRate</h3>
 <p>Represents an on-chain exchange rate between two assets.</p>
@@ -764,7 +788,7 @@ as a direct consequence of executing authorized messages.</li>
   <span class="token punctuation">{</span>
     <span class="token property">"active_version"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span>
     <span class="token property">"aka"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
-    <span class="token property">"authority"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
+    <span class="token property">"corporation"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
     <span class="token property">"created"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span><span class="token punctuation">,</span>
     <span class="token property">"deposit"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
     <span class="token property">"did"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
@@ -796,7 +820,7 @@ as a direct consequence of executing authorized messages.</li>
   <span class="token punctuation">{</span>
     <span class="token property">"active_version"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span>
     <span class="token property">"aka"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
-    <span class="token property">"authority"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
+    <span class="token property">"corporation"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
     <span class="token property">"created"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span><span class="token punctuation">,</span>
     <span class="token property">"deposit"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
     <span class="token property">"did"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
@@ -825,7 +849,7 @@ as a direct consequence of executing authorized messages.</li>
   <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
     <span class="token property">"active_version"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span>
     <span class="token property">"aka"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
-    <span class="token property">"authority"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
+    <span class="token property">"corporation"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
     <span class="token property">"created"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span><span class="token punctuation">,</span>
     <span class="token property">"deposit"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
     <span class="token property">"did"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
@@ -854,49 +878,48 @@ as a direct consequence of executing authorized messages.</li>
   <span class="token punctuation">}</span>
 <span class="token punctuation">]</span>
 </code></pre>
-<div id="warning-1" class="notice warning"><a class="notice-link" href="#warning-1">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
+<div id="warning-46" class="notice warning"><a class="notice-link" href="#warning-46">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
 </div>
 <p>A VPR implementation MUST implement all the following requirements.</p>
-<div id="note-4" class="notice note"><a class="notice-link" href="#note-4">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="tr"path-3="v1"path-4="get"href="https://example/verana/tr/v1/get" ><span>https://example/verana/tr/v1/get</span></a>.</p>
+<div id="note-79" class="notice note"><a class="notice-link" href="#note-79">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="tr"path-3="v1"path-4="get"href="https://example/verana/tr/v1/get" ><span>https://example/verana/tr/v1/get</span></a>.</p>
 </div>
 <h3 id="authorization-and-fee-grants"><a class="toc-anchor" href="#authorization-and-fee-grants" >§</a> Authorization and Fee Grants</h3>
 <h4 id="delegable-module-messages"><a class="toc-anchor" href="#delegable-module-messages" >§</a> Delegable Module Messages</h4>
 <p>Most VPR module messages (Msg) <strong>support delegation</strong> and follow the pattern described below.</p>
-<p>Delegable messages are defined as messages that can be executed by an <code>operator</code> account on behalf of an <code>authority</code> group, provided that the appropriate authorization has been granted.</p>
+<p>Delegable messages are defined as messages that can be executed by an <code>operator</code> account on behalf of a <code>corporation</code> group, provided that the appropriate authorization has been granted.</p>
 <p>Such messages conceptually involve <strong>two roles</strong>:</p>
 <ul>
 <li>
-<p><code>authority</code> (group):<br>
+<p><code>corporation</code> (group):<br>
 The <code>group</code> that owns the created or manipulated resource.<br>
-The authority is represented in the Msg through an authorization granted to an <code>operator</code> account.</p>
+The corporation is represented in the Msg through an authorization granted to an <code>operator</code> account.</p>
 </li>
 <li>
 <p><code>operator</code> (account):<br>
-The <code>account</code> that executes the Msg on behalf of the <code>authority</code>.<br>
+The <code>account</code> that executes the Msg on behalf of the <code>corporation</code>.<br>
 The operator MUST be explicitly authorized for the given message type.</p>
 </li>
 </ul>
 <p>When a delegable message is executed <strong>directly by an operator account</strong>, both roles are authenticated and enforced by the authorization system.</p>
-<p>Using this model makes it possible to:
-vs_operator_authz_spend_limit</p>
+<p>Using this model makes it possible to:</p>
 <ul>
-<li>identify, within the Msg, both the authenticated <code>authority</code> and the executing <code>operator</code>,</li>
-<li>allow network fees to be paid either by the <code>operator</code> account or by the <code>authority</code> account via a fee grant.</li>
+<li>identify, within the Msg, both the authenticated <code>corporation</code> and the executing <code>operator</code>,</li>
+<li>allow network fees to be paid either by the <code>operator</code> account or by the <code>corporation</code> account via a fee grant.</li>
 </ul>
 <p>For the execution of delegable messages:</p>
 <ul>
-<li>the <code>operator</code> account MUST have a valid authorization from the <code>authority</code> group for the specific message type being executed.</li>
+<li>the <code>operator</code> account MUST have a valid authorization from the <code>corporation</code> group for the specific message type being executed.</li>
 </ul>
-<p>An <code>authority</code> group is not required to delegate all message types to the same <code>operator</code>.<br>
-It is entirely up to the <code>authority</code> group to decide <strong>which accounts may execute which messages</strong>.</p>
+<p>A <code>corporation</code> group is not required to delegate all message types to the same <code>operator</code>.<br>
+It is entirely up to the <code>corporation</code> group to decide <strong>which accounts may execute which messages</strong>.</p>
 <ul>
 <li>Authorizations MUST be granted to individual <code>account</code>s through <strong>group proposals</strong>.</li>
 <li>Authorizations MAY include an optional <code>spend_limit</code> and an optional <code>expiration</code> date.</li>
 </ul>
 <h4 id="not-delegable-module-messages"><a class="toc-anchor" href="#not-delegable-module-messages" >§</a> Not Delegable Module Messages</h4>
-<p>Some module messages specify only an <code>authority</code>:</p>
+<p>Some module messages specify only a <code>corporation</code>:</p>
 <ul>
-<li><code>authority</code> (group):<br>
+<li><code>corporation</code> (group):<br>
 The <code>group</code> that owns the manipulated resource.</li>
 </ul>
 <p>Such messages <strong>cannot be delegated</strong> and MUST be executed exclusively through a <strong>group proposal</strong>.</p>
@@ -904,24 +927,66 @@ The <code>group</code> that owns the manipulated resource.</li>
 <p>Some module messages can be executed <strong>only through a governance proposal</strong>.</p>
 <p>These messages do not support delegation and are not executable by accounts, whether directly or via group authorization.</p>
 <h4 id="fee-grants"><a class="toc-anchor" href="#fee-grants" >§</a> Fee Grants</h4>
-<p>An <code>authority</code> group MAY allow its <code>operator</code>s to pay <strong>network transaction fees</strong> using the <code>authority</code>’s funds.</p>
+<p>A <code>corporation</code> group MAY allow its <code>operator</code>s to pay <strong>network transaction fees</strong> using the <code>corporation</code>’s funds.</p>
 <p>Fee grants are <strong>not created directly</strong>.<br>
 They are created, updated, and revoked <strong>exclusively by Authorization module messages</strong>.<br>
 When an authorization is created or updated, it MAY optionally include an associated fee grant.</p>
+<h4 id="authz-check-common-authorization-and-fee-grant-precondition-checks"><a class="toc-anchor" href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >§</a> [AUTHZ-CHECK] Common Authorization and Fee Grant Precondition Checks</h4>
+<p>For any <strong>delegable message</strong> executed by an <code>operator</code> on behalf of a <code>corporation</code>, the following precondition checks MUST be performed before any method-specific checks. If any check fails, the <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<h5 id="authz-check-1-operator-authorization-checks"><a class="toc-anchor" href="#authz-check-1-operator-authorization-checks" >§</a> [AUTHZ-CHECK-1] Operator Authorization checks</h5>
+<ol>
+<li>An <code>OperatorAuthorization</code> <code>oauthz</code> MUST exist where <code>oauthz.corporation</code> = <code>corporation</code>, <code>oauthz.operator</code> = <code>operator</code>, and <code>oauthz.msg_types</code> includes the current message type.</li>
+<li>If <code>oauthz.expiration</code> is set, it MUST be in the future.</li>
+<li>If <code>oauthz.spend_limit</code> is set, the remaining balance MUST be sufficient for the operation. After successful execution, the consumed amount MUST be deducted from the remaining balance.</li>
+<li>If <code>oauthz.period</code> is set and the current period has elapsed since the last reset, the remaining balance MUST be reset to <code>oauthz.spend_limit</code> before evaluating the check above.</li>
+</ol>
+<h5 id="authz-check-2-fee-grant-checks"><a class="toc-anchor" href="#authz-check-2-fee-grant-checks" >§</a> [AUTHZ-CHECK-2] Fee Grant checks</h5>
+<p>If the transaction fees are paid by the <code>corporation</code> account (via fee grant) instead of the <code>operator</code> account:</p>
+<ol>
+<li>A <code>FeeGrant</code> <code>fg</code> MUST exist where <code>fg.grantor</code> = <code>corporation</code>, <code>fg.grantee</code> = <code>operator</code>, and <code>fg.msg_types</code> includes the current message type.</li>
+<li>If <code>fg.expiration</code> is set, it MUST be in the future.</li>
+<li>If <code>fg.spend_limit</code> is set, the remaining balance MUST be sufficient for the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>. After successful execution, the consumed fee amount MUST be deducted from the remaining balance.</li>
+<li>If <code>fg.period</code> is set and the current period has elapsed since the last reset, the remaining balance MUST be reset to <code>fg.spend_limit</code> before evaluating the check above.</li>
+</ol>
+<h5 id="authz-check-3-vs-operator-authorization-checks"><a class="toc-anchor" href="#authz-check-3-vs-operator-authorization-checks" >§</a> [AUTHZ-CHECK-3] VS Operator Authorization checks</h5>
+<p>A second authorization grant mode exists for vs-agents. It is used when a corporation delegates a specific permission (and a specific set of message types, scoped to that permission) to a <code>vs_operator</code> account. The authorization model differs from other delegable messages: it relies on <a href="#vsoperatorauthorization" >VSOperatorAuthorization</a> / <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> instead of <code>OperatorAuthorization</code>.</p>
+<blockquote>
+<p>Note: the set of messages a <code>vs_operator</code> is authorized to execute in the context of a permission is declared by the applicant at permission creation time (see <a href="#mod-perm-msg-1-1-start-permission-vp-parameters" >[MOD-PERM-MSG-1-1]</a> and <a href="#mod-perm-msg-14-1-self-create-permission-parameters" >[MOD-PERM-MSG-14-1]</a>) and stored in <code>record.msg_types</code>. It is frozen for the lifetime of the record and can only be changed by revoking the permission and starting a new one.</p>
+</blockquote>
+<p>Given a <code>corporation</code>, an <code>operator</code> (the <code>vs_operator</code>), a <strong>primary permission id</strong> <code>perm_id</code> (determined by the calling method), and the current message type <code>msg_type</code>:</p>
+<ol>
+<li>A <code>PermissionAuthorizationRecord</code> <code>record</code> MUST exist for <code>perm_id</code>. Abort if not found.</li>
+<li><code>record</code> MUST belong to <code>VSOperatorAuthorization[corporation, operator]</code>, that is: the containing <code>VSOperatorAuthorization</code> MUST have <code>corporation</code> as its <code>corporation</code> and <code>operator</code> as its <code>vs_operator</code>. Abort otherwise.</li>
+<li><code>msg_type</code> MUST be in <code>record.msg_types</code>. Abort otherwise.</li>
+<li><code>record.expiration</code> MUST be strictly greater than now(). Abort otherwise.</li>
+<li>If <code>record.period</code> is set and the current period has elapsed since the last reset, the remaining balances for <code>record.spend_limit</code> and <code>record.fee_spend_limit</code> MUST be reset to their original values before evaluating the check below.</li>
+<li>If <code>record.spend_limit</code> is set, the remaining balance MUST be sufficient for the operation. After successful execution, the consumed amount MUST be deducted from the remaining balance.</li>
+</ol>
+<h5 id="authz-check-4-vs-operator-fee-grant-checks"><a class="toc-anchor" href="#authz-check-4-vs-operator-fee-grant-checks" >§</a> [AUTHZ-CHECK-4] VS Operator Fee Grant checks</h5>
+<p>If the <a class="term-reference" href="#term:transaction">transaction</a> fees are paid by the <code>corporation</code> account (via fee grant) instead of the <code>operator</code> account, using the same <code>PermissionAuthorizationRecord</code> <code>record</code> looked up in <a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a>:</p>
+<ol>
+<li><code>record.with_feegrant</code> MUST be true, else abort.</li>
+<li>If <code>record.period</code> is set and the current period has elapsed since the last reset, the remaining balance for <code>record.fee_spend_limit</code> MUST be reset to its original value before evaluating the check below.</li>
+<li>If <code>record.fee_spend_limit</code> is set, the remaining balance MUST be sufficient for the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>. After successful execution, the consumed fee amount MUST be deducted from the remaining balance.</li>
+</ol>
 <h4 id="example"><a class="toc-anchor" href="#example" >§</a> Example</h4>
-<p>An authority group <code>authorityABC</code> wants to authorize an operator account <code>accountABC</code> to execute the<br>
-<a href="#mod-perm-msg-10-create-or-update-permission-session" ><code>mod-perm-msg-10-create-or-update-permission-session</code></a> message.</p>
-<p>Additionally, the authority wants <code>accountABC</code> to pay the transaction fees for this message using the authority’s funds.</p>
-<p>To achieve this, <code>authorityABC</code> MUST:</p>
+<p>A corporation group <code>corporationABC</code> wants to authorize an operator account <code>accountABC</code> to execute the<br>
+<a href="#mod-perm-msg-10-create-or-update-permission-session" ><code>mod-perm-msg-10-create-or-update-permission-session</code></a>,
+<a href="#mod-perm-msg-3-set-permission-vp-to-validated" ><code>mod-perm-msg-3-set-permission-vp-to-validated</code></a>, and
+<a href="#mod-perm-msg-15-trigger-resolver" ><code>mod-perm-msg-15-trigger-resolver</code></a>
+messages.</p>
+<p>Additionally, the corporation wants <code>accountABC</code> to pay the transaction fees for this message using the corporation’s funds.</p>
+<p>To achieve this, <code>corporationABC</code> MUST:</p>
 <ul>
-<li>create an <strong>authorization</strong> from <code>authorityABC</code> to <code>accountABC</code> for the<br>
-<a href="#mod-perm-msg-10-create-or-update-permission-session" ><code>mod-perm-msg-10-create-or-update-permission-session</code></a> message type,<br>
-optionally enabling an associated fee grant.</li>
+<li>create an <strong>authorization</strong> from <code>corporationABC</code> to <code>accountABC</code> for the<br>
+<a href="#mod-perm-msg-10-create-or-update-permission-session" ><code>mod-perm-msg-10-create-or-update-permission-session</code></a>,
+<a href="#mod-perm-msg-3-set-permission-vp-to-validated" ><code>mod-perm-msg-3-set-permission-vp-to-validated</code></a>, and
+<a href="#mod-perm-msg-15-trigger-resolver" ><code>mod-perm-msg-15-trigger-resolver</code></a> message types, optionally enabling an associated fee grant.</li>
 </ul>
 <p>As a result, <code>accountABC</code> is authorized to:</p>
 <ul>
-<li>execute the specified message type on behalf of <code>authorityABC</code>, including any state changes and fund movements that are a direct consequence of that message, and</li>
-<li>pay the network transaction fees for that message using the funds of <code>authorityABC</code>, via the associated fee grant.</li>
+<li>execute the specified messages type on behalf of <code>corporationABC</code>, including any state changes and fund movements that are a direct consequence of that message, and</li>
+<li>pay the network transaction fees for that message using the funds of <code>corporationABC</code>, via the associated fee grant.</li>
 </ul>
 <h3 id="method-list"><a class="toc-anchor" href="#method-list" >§</a> Method List</h3>
 <table>
@@ -942,7 +1007,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-tr-msg-1-create-new-trust-registry" >[MOD-TR-MSG-1]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -950,7 +1015,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-tr-msg-2-add-governance-framework-document" >[MOD-TR-MSG-2]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -958,7 +1023,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-tr-msg-3-increase-active-governance-framework-version" >[MOD-TR-MSG-3]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -966,7 +1031,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-tr-msg-4-update-trust-registry" >[MOD-TR-MSG-4]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -974,7 +1039,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-tr-msg-5-archive-trust-registry" >[MOD-TR-MSG-5]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1014,7 +1079,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-cs-msg-1-create-new-credential-schema" >[MOD-CS-MSG-1]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1022,7 +1087,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-cs-msg-2-update-credential-schema" >[MOD-CS-MSG-2]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1030,7 +1095,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-cs-msg-3-archive-credential-schema" >[MOD-CS-MSG-3]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1046,7 +1111,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-cs-msg-5-create-schema-authorization-policy" >[MOD-CS-MSG-5]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1054,7 +1119,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-cs-msg-6-increase-active-schema-authorization-policy-version" >[MOD-CS-MSG-6]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1062,7 +1127,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-cs-msg-7-revoke-schema-authorization-policy" >[MOD-CS-MSG-7]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1118,7 +1183,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1126,7 +1191,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-perm-msg-2-renew-permission-vp" >[MOD-PERM-MSG-2]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1134,7 +1199,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-perm-msg-3-set-permission-vp-to-validated" >[MOD-PERM-MSG-3]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1142,7 +1207,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-perm-msg-6-cancel-permission-vp-last-request" >[MOD-PERM-MSG-6]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1150,7 +1215,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-perm-msg-7-create-root-permission" >[MOD-PERM-MSG-7]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1158,7 +1223,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-perm-msg-8-adjust-permission" >[MOD-PERM-MSG-8]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1166,7 +1231,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-perm-msg-9-revoke-permission" >[MOD-PERM-MSG-9]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1174,7 +1239,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-perm-msg-10-create-or-update-permission-session" >[MOD-PERM-MSG-10]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1190,7 +1255,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-perm-msg-12-slash-permission-trust-deposit" >[MOD-PERM-MSG-12]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1198,7 +1263,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-perm-msg-13-repay-permission-slashed-trust-deposit" >[MOD-PERM-MSG-13]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1206,7 +1271,15 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-perm-msg-14-self-create-permission" >[MOD-PERM-MSG-14]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
+</tr>
+<tr>
+<td></td>
+<td>Trigger Resolver</td>
+<td>N/A (Tx)</td>
+<td>Msg</td>
+<td><a href="#mod-perm-msg-15-trigger-resolver" >[MOD-PERM-MSG-15]</a></td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1262,7 +1335,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-td-msg-2-reclaim-trust-deposit-yield" >[MOD-TD-MSG-2]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1286,7 +1359,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-td-msg-6-repay-slashed-trust-deposit" >[MOD-TD-MSG-6]</a></td>
-<td>authority + operator</td>
+<td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
@@ -1334,7 +1407,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-de-msg-3-grant-operator-authorization" >[MOD-DE-MSG-3]</a></td>
-<td>authority (group proposal) OR authority + operator OR module call</td>
+<td>corporation (group proposal) OR corporation + operator OR module call</td>
 </tr>
 <tr>
 <td></td>
@@ -1342,7 +1415,7 @@ optionally enabling an associated fee grant.</li>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-de-msg-4-revoke-operator-authorization" >[MOD-DE-MSG-4]</a></td>
-<td>authority (group proposal) OR authority + operator OR module call</td>
+<td>corporation (group proposal) OR corporation + operator OR module call</td>
 </tr>
 <tr>
 <td></td>
@@ -1377,12 +1450,36 @@ optionally enabling an associated fee grant.</li>
 <td>governance proposal</td>
 </tr>
 <tr>
+<td></td>
+<td>Update VS Operator Authorization Expiration</td>
+<td>N/A (Tx)</td>
+<td>Msg</td>
+<td><a href="#mod-de-msg-9-update-vs-operator-authorization-expiration" >[MOD-DE-MSG-9]</a></td>
+<td>module call</td>
+</tr>
+<tr>
+<td></td>
+<td>List Operator Authorizations</td>
+<td>/de/v1/authz/list</td>
+<td>Query</td>
+<td><a href="#mod-de-qry-1-list-operator-authorizations" >[MOD-DE-QRY-1]</a></td>
+<td>N/A</td>
+</tr>
+<tr>
+<td></td>
+<td>List VS Operator Authorizations</td>
+<td>/de/v1/vs-authz/list</td>
+<td>Query</td>
+<td><a href="#mod-de-qry-2-list-vs-operator-authorizations" >[MOD-DE-QRY-2]</a></td>
+<td>N/A</td>
+</tr>
+<tr>
 <td>Digests</td>
 <td>Store Digest</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
 <td><a href="#mod-di-msg-1-store-digest" >[MOD-DI-MSG-1]</a></td>
-<td>authority + operator OR module call</td>
+<td>corporation + operator OR module call</td>
 </tr>
 <tr>
 <td></td>
@@ -1442,19 +1539,19 @@ optionally enabling an associated fee grant.</li>
 </tr>
 </tbody>
 </table>
-<div id="note-5" class="notice note"><a class="notice-link" href="#note-5">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
+<div id="note-80" class="notice note"><a class="notice-link" href="#note-80">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
 </div>
 <h3 id="trust-registry-module"><a class="toc-anchor" href="#trust-registry-module" >§</a> Trust Registry Module</h3>
 <h4 id="mod-tr-msg-1-create-new-trust-registry"><a class="toc-anchor" href="#mod-tr-msg-1-create-new-trust-registry" >§</a> [MOD-TR-MSG-1] Create New Trust Registry</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <h5 id="mod-tr-msg-1-1-create-new-trust-registry-parameters"><a class="toc-anchor" href="#mod-tr-msg-1-1-create-new-trust-registry-parameters" >§</a> [MOD-TR-MSG-1-1] Create New Trust Registry parameters</h5>
 <p>An authorized <code>operator</code> that would like to create a <a class="term-reference" href="#term:trust-registry">trust registry</a> MUST call this method by specifying:</p>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>did</code> (string) (<em>mandatory</em>): the did of the ecosystem that is creating the trust registry.</li>
 <li><code>aka</code> (string) (<em>optional</em>): optional additional URI of this trust registry.</li>
-<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.ietf.org"path-1="rfc"path-2="rfc1766.txt"href="https://www.ietf.org/rfc/rfc1766.txt" >rfc1766</a>) of this trust registry.</li>
+<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of this trust registry.</li>
 <li><code>doc_url</code> (string) (<em>mandatory</em>): URL where the document is published.</li>
 <li><code>doc_digest_sri</code> (string) (<em>mandatory</em>): digest_sri of the document.</li>
 </ul>
@@ -1467,10 +1564,13 @@ optionally enabling an associated fee grant.</li>
 <p>if a mandatory parameter is not present, method MUST abort.</p>
 </li>
 <li>
-<p><code>authority</code> (group): (Signer) signature must be verified.</p>
+<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
 </li>
 <li>
 <p><code>operator</code> (account): (Signer) signature must be verified.</p>
+</li>
+<li>
+<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
 </li>
 <li>
 <p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
@@ -1479,7 +1579,7 @@ optionally enabling an associated fee grant.</li>
 <p><code>aka</code> (string) (<em>optional</em>): optional additional URI of this trust registry. MUST be an <a class="term-reference" href="#term:uri">URI</a>.</p>
 </li>
 <li>
-<p><code>language</code> (string(17)) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.ietf.org"path-1="rfc"path-2="rfc1766.txt"href="https://www.ietf.org/rfc/rfc1766.txt" >rfc1766</a>).</p>
+<p><code>language</code> (string(17)) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>).</p>
 </li>
 <li>
 <p><code>doc_url</code> (string) (<em>mandatory</em>): MUST be a valid URL .</p>
@@ -1488,7 +1588,7 @@ optionally enabling an associated fee grant.</li>
 <p><code>doc_digest_sri</code> (string) (<em>mandatory</em>): MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</p>
 </li>
 </ul>
-<div id="note-6" class="notice note"><a class="notice-link" href="#note-6">NOTE</a><p>It is not a problem if several trust registries are created with the same ecosystem DID. Identifier of a <code>TrustRegistry</code> is its id, and the Verifiable Trust Spec includes the id of the <code>TrustRegistry</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
+<div id="note-81" class="notice note"><a class="notice-link" href="#note-81">NOTE</a><p>It is not a problem if several trust registries are created with the same ecosystem DID. Identifier of a <code>TrustRegistry</code> is its id, and the Verifiable Trust Spec includes the id of the <code>TrustRegistry</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
 </div>
 <h6 id="mod-tr-msg-1-2-2-create-new-trust-registry-fee-checks"><a class="toc-anchor" href="#mod-tr-msg-1-2-2-create-new-trust-registry-fee-checks" >§</a> [MOD-TR-MSG-1-2-2] Create New Trust Registry fee checks</h6>
 <p>Fee payer MUST have an available balance to cover the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</p>
@@ -1506,7 +1606,7 @@ optionally enabling an associated fee grant.</li>
 <p><code>tr.did</code>: <code>did</code></p>
 </li>
 <li>
-<p><code>tr.authority</code>: <code>authority</code></p>
+<p><code>tr.corporation</code>: <code>corporation</code></p>
 </li>
 <li>
 <p><code>tr.created</code>: current timestamp</p>
@@ -1564,13 +1664,13 @@ optionally enabling an associated fee grant.</li>
 </li>
 </ul>
 <h4 id="mod-tr-msg-2-add-governance-framework-document"><a class="toc-anchor" href="#mod-tr-msg-2-add-governance-framework-document" >§</a> [MOD-TR-MSG-2] Add Governance Framework Document</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <h5 id="mod-tr-msg-2-1-add-governance-framework-document-parameters"><a class="toc-anchor" href="#mod-tr-msg-2-1-add-governance-framework-document-parameters" >§</a> [MOD-TR-MSG-2-1] Add Governance Framework Document parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uint64) (<em>mandatory</em>): the id of the trust registry.</li>
-<li><code>doc_language</code> (string) (<em>mandatory</em>): language tag (<a path-0="www.ietf.org"path-1="rfc"path-2="rfc1766.txt"href="https://www.ietf.org/rfc/rfc1766.txt" >rfc1766</a>) of the <a class="term-reference" href="#term:egf">EGF</a> document, provided by the <a class="term-reference" href="#term:ega">EGA</a>.</li>
+<li><code>doc_language</code> (string) (<em>mandatory</em>): language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of the <a class="term-reference" href="#term:egf">EGF</a> document, provided by the <a class="term-reference" href="#term:ega">EGA</a>.</li>
 <li><code>doc_url</code> (string) (<em>mandatory</em>): URL where the document is published.</li>
 <li><code>doc_digest_sri</code> (string) (<em>mandatory</em>): digest_sri of the document.</li>
 <li><code>version</code> (int) (<em>mandatory</em>): targeted version.</li>
@@ -1581,11 +1681,12 @@ optionally enabling an associated fee grant.</li>
 <h6 id="mod-tr-msg-2-2-1-add-governance-framework-document-basic-checks"><a class="toc-anchor" href="#mod-tr-msg-2-2-1-add-governance-framework-document-basic-checks" >§</a> [MOD-TR-MSG-2-2-1] Add Governance Framework Document basic checks</h6>
 <p>if a mandatory parameter is not present, method MUST abort.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): a <code>TrustRegistry</code> entry with this id MUST exist and <code>authority</code> executing the method MUST be the <code>authority</code> of the <code>TrustRegistry</code> entry.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): a <code>TrustRegistry</code> entry with this id MUST exist and <code>corporation</code> executing the method MUST be the <code>corporation</code> of the <code>TrustRegistry</code> entry.</li>
 <li><code>version</code>: there MUST exist a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> where <code>gfv.tr_id</code> is equal to <code>id</code> and <code>gfv.version</code> = <code>version</code>, or <code>version</code> MUST be exactly equal to the biggest found <code>gfv.version</code> + 1 of all <code>GovernanceFrameworkVersion</code> entries found for this <code>gfv.tr_id</code> equal to <code>id</code>. <code>version</code> MUST be greater than the <code>tr.active_version</code>.</li>
-<li><code>doc_language</code> (string) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.ietf.org"path-1="rfc"path-2="rfc1766.txt"href="https://www.ietf.org/rfc/rfc1766.txt" >rfc1766</a>).</li>
+<li><code>doc_language</code> (string) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>).</li>
 <li><code>doc_url</code> (string) (<em>mandatory</em>): MUST be a valid URL.</li>
 <li><code>doc_digest_sri</code> (string) (<em>mandatory</em>): MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</li>
 </ul>
@@ -1634,11 +1735,11 @@ optionally enabling an associated fee grant.</li>
 </li>
 </ul>
 <h4 id="mod-tr-msg-3-increase-active-governance-framework-version"><a class="toc-anchor" href="#mod-tr-msg-3-increase-active-governance-framework-version" >§</a> [MOD-TR-MSG-3] Increase Active Governance Framework Version</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <h5 id="mod-tr-msg-3-1-increase-active-governance-framework-version-parameters"><a class="toc-anchor" href="#mod-tr-msg-3-1-increase-active-governance-framework-version-parameters" >§</a> [MOD-TR-MSG-3-1] Increase Active Governance Framework Version parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uint64) (<em>mandatory</em>): the id of the trust registry.</li>
 </ul>
 <h5 id="mod-tr-msg-3-2-increase-active-governance-framework-version-precondition-checks"><a class="toc-anchor" href="#mod-tr-msg-3-2-increase-active-governance-framework-version-precondition-checks" >§</a> [MOD-TR-MSG-3-2] Increase Active Governance Framework Version precondition checks</h5>
@@ -1649,13 +1750,16 @@ optionally enabling an associated fee grant.</li>
 <p>if a mandatory parameter is not present, method MUST abort.</p>
 </li>
 <li>
-<p><code>authority</code> (group): (Signer) signature must be verified.</p>
+<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
 </li>
 <li>
 <p><code>operator</code> (account): (Signer) signature must be verified.</p>
 </li>
 <li>
-<p><code>id</code> (uint64) (<em>mandatory</em>): a <code>TrustRegistry</code> entry with this id MUST exist and <code>authority</code> executing the method MUST be the <code>authority</code> of the <code>TrustRegistry</code> entry.</p>
+<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
+</li>
+<li>
+<p><code>id</code> (uint64) (<em>mandatory</em>): a <code>TrustRegistry</code> entry with this id MUST exist and <code>corporation</code> executing the method MUST be the <code>corporation</code> of the <code>TrustRegistry</code> entry.</p>
 </li>
 <li>
 <p>load <code>TrustRegistry</code> entry <code>tr</code> from its <code>id</code>. Find a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> where version is equal to <code>tr.active_version</code> + 1. If none is found, transaction MUST abort.</p>
@@ -1673,11 +1777,11 @@ optionally enabling an associated fee grant.</li>
 <li>load <code>TrustRegistry</code> entry <code>tr</code> from its <code>id</code>. Find a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> where version is equal to <code>tr.active_version</code> + 1. If none is found, transaction MUST abort. Else, update <code>tr.active_version</code> to <code>tr.active_version</code> + 1. Set <code>tr.modified</code> to current timestamp, and set <code>gfv.active_since</code> to current timestamp and persist changes.</li>
 </ul>
 <h4 id="mod-tr-msg-4-update-trust-registry"><a class="toc-anchor" href="#mod-tr-msg-4-update-trust-registry" >§</a> [MOD-TR-MSG-4] Update Trust Registry</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <h5 id="mod-tr-msg-4-1-update-trust-registry-parameters"><a class="toc-anchor" href="#mod-tr-msg-4-1-update-trust-registry-parameters" >§</a> [MOD-TR-MSG-4-1] Update Trust Registry parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uint64) (<em>mandatory</em>): the id of the trust registry.</li>
 <li><code>did</code> (string) (<em>mandatory</em>): the did of the trust registry.</li>
 <li><code>aka</code> (string) (<em>optional</em>): optional additional URI of this trust registry. If null, it means replace existing value with null.</li>
@@ -1690,13 +1794,16 @@ optionally enabling an associated fee grant.</li>
 <p>if a mandatory parameter is not present, method MUST abort.</p>
 </li>
 <li>
-<p><code>authority</code> (group): (Signer) signature must be verified.</p>
+<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
 </li>
 <li>
 <p><code>operator</code> (account): (Signer) signature must be verified.</p>
 </li>
 <li>
-<p><code>id</code> (uint64) (<em>mandatory</em>): a <code>TrustRegistry</code> entry <code>tr</code> with id <code>id</code> MUST exist and <code>authority</code> executing the method MUST be the <code>authority</code> of the <code>TrustRegistry</code> entry <code>tr</code>.</p>
+<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
+</li>
+<li>
+<p><code>id</code> (uint64) (<em>mandatory</em>): a <code>TrustRegistry</code> entry <code>tr</code> with id <code>id</code> MUST exist and <code>corporation</code> executing the method MUST be the <code>corporation</code> of the <code>TrustRegistry</code> entry <code>tr</code>.</p>
 </li>
 <li>
 <p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
@@ -1725,11 +1832,11 @@ optionally enabling an associated fee grant.</li>
 </li>
 </ul>
 <h4 id="mod-tr-msg-5-archive-trust-registry"><a class="toc-anchor" href="#mod-tr-msg-5-archive-trust-registry" >§</a> [MOD-TR-MSG-5] Archive Trust Registry</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <h5 id="mod-tr-msg-5-1-archive-trust-registry-parameters"><a class="toc-anchor" href="#mod-tr-msg-5-1-archive-trust-registry-parameters" >§</a> [MOD-TR-MSG-5-1] Archive Trust Registry parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uint64) (<em>mandatory</em>) id of the trust registry (<em>mandatory</em>);</li>
 <li><code>archive</code> (boolean) (<em>mandatory</em>), true means archive, false means unarchive.</li>
 </ul>
@@ -1741,13 +1848,16 @@ optionally enabling an associated fee grant.</li>
 <p>if a mandatory parameter is not present, method MUST abort.</p>
 </li>
 <li>
-<p><code>authority</code> (group): (Signer) signature must be verified.</p>
+<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
 </li>
 <li>
 <p><code>operator</code> (account): (Signer) signature must be verified.</p>
 </li>
 <li>
-<p>load <code>TrustRegistry</code> <code>tr</code> from <code>id</code>. <code>tr.authority</code> MUST be the authority executing the method, else MUST abort.</p>
+<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
+</li>
+<li>
+<p>load <code>TrustRegistry</code> <code>tr</code> from <code>id</code>. <code>tr.corporation</code> MUST be the corporation executing the method, else MUST abort.</p>
 </li>
 <li>
 <p><code>archive</code> (boolean) (<em>mandatory</em>) MUST be a boolean.</p>
@@ -1805,7 +1915,7 @@ optionally enabling an associated fee grant.</li>
 <h5 id="mod-tr-qry-2-1-list-trust-registries-query-parameters"><a class="toc-anchor" href="#mod-tr-qry-2-1-list-trust-registries-query-parameters" >§</a> [MOD-TR-QRY-2-1] List Trust Registries query parameters</h5>
 <p>The following parameters are optional:</p>
 <ul>
-<li><code>authority</code> (group) (<em>optional</em>): if specified, filter by authority.</li>
+<li><code>corporation</code> (group) (<em>optional</em>): if specified, filter by corporation.</li>
 <li><code>modified_after</code> (timestamp) (<em>optional</em>): if specified, returns only <code>TrustRegistry</code> entries with <code>TrustRegistry.modified</code> greater than <code>modified</code>.</li>
 <li><code>active_gf_only</code> (boolean) (<em>optional</em>): if true, include only current governance framework data. If false or null, returns everything.</li>
 <li><code>preferred_language</code> (string) (<em>optional</em>): if set, return only one document per version, with language=<code>preferred_language</code> when possible, else if no document exist with this language, return language. If not set, return all documents of all languages.</li>
@@ -1836,12 +1946,12 @@ optionally enabling an associated fee grant.</li>
 </code></pre>
 <h3 id="credential-schema-module"><a class="toc-anchor" href="#credential-schema-module" >§</a> Credential Schema Module</h3>
 <h4 id="mod-cs-msg-1-create-new-credential-schema"><a class="toc-anchor" href="#mod-cs-msg-1-create-new-credential-schema" >§</a> [MOD-CS-MSG-1] Create New Credential Schema</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <h5 id="mod-cs-msg-1-1-create-new-credential-schema-parameters"><a class="toc-anchor" href="#mod-cs-msg-1-1-create-new-credential-schema-parameters" >§</a> [MOD-CS-MSG-1-1] Create New Credential Schema parameters</h5>
 <p>An <a class="term-reference" href="#term:account">account</a> that would like to create a <a class="term-reference" href="#term:credential-schema">credential schema</a> MUST call this method by specifying:</p>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>tr_id</code> id of the trust registry (<em>mandatory</em>);</li>
 <li><code>json_schema</code> the <a class="term-reference" href="#term:json-schema">Json Schema</a> of the credential (<em>mandatory</em>).</li>
 <li><code>issuer_grantor_validation_validity_period</code> (<em>mandatory</em>), default to 0 (days).</li>
@@ -1849,8 +1959,9 @@ optionally enabling an associated fee grant.</li>
 <li><code>issuer_validation_validity_period</code> (<em>mandatory</em>), default to 0 (days).</li>
 <li><code>verifier_validation_validity_period</code> (<em>mandatory</em>), default to 0 (days).</li>
 <li><code>holder_validation_validity_period</code> (<em>mandatory</em>), default to 0 (days).</li>
-<li><code>issuer_perm_management_mode</code> (PermissionManagementMode) (<em>mandatory</em>).</li>
-<li><code>verifier_perm_management_mode</code> (PermissionManagementMode) (<em>mandatory</em>).</li>
+<li><code>issuer_onboarding_mode</code> (IssuerOnbpardingMode) (<em>mandatory</em>).</li>
+<li><code>verifier_onboarding_mode</code> (VerifierOnboardingMode) (<em>mandatory</em>).</li>
+<li><code>holder_onboarding_mode</code> (HolderOnboardingMode) (<em>mandatory</em>).</li>
 <li><code>pricing_asset_type</code> (PricingAssetType) (<em>mandatory</em>).</li>
 <li><code>pricing_asset</code> (string) (<em>mandatory</em>).</li>
 <li><code>digest_algorithm</code> (string) (<em>mandatory</em>): valid values are defined in the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust spec</a>.</li>
@@ -1863,13 +1974,16 @@ optionally enabling an associated fee grant.</li>
 <p>if a mandatory parameter is not present, method MUST abort.</p>
 </li>
 <li>
-<p><code>authority</code> (group): (Signer) signature must be verified.</p>
+<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
 </li>
 <li>
 <p><code>operator</code> (account): (Signer) signature must be verified.</p>
 </li>
 <li>
-<p><code>tr_id</code> MUST represent an existing <code>TrustRegistry</code> entry <code>tr</code> and <code>tr.authority</code> MUST be the <code>authority</code> executing the method.</p>
+<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
+</li>
+<li>
+<p><code>tr_id</code> MUST represent an existing <code>TrustRegistry</code> entry <code>tr</code> and <code>tr.corporation</code> MUST be the <code>corporation</code> executing the method.</p>
 </li>
 <li>
 <p><code>json_schema</code> MUST be a valid <a class="term-reference" href="#term:json-schema">Json Schema</a>, and size must not be greater than <code>GlobalVariables.credential_schema_schema_max_size</code>. <code>$id</code> of the <a class="term-reference" href="#term:json-schema">Json Schema</a> is ignored and will be replaced during execution by the auto-generated id of this <code>CredentialSchema</code>.</p>
@@ -1890,10 +2004,13 @@ optionally enabling an associated fee grant.</li>
 <p><code>holder_validation_validity_period</code> must be between 0 (never expire) and <code>GlobalVariables.credential_schema_holder_validation_validity_period_max_days</code> days.</p>
 </li>
 <li>
-<p><code>issuer_perm_management_mode</code> (PermissionManagementMode) (<em>mandatory</em>) MUST be a valid PermissionManagementMode.</p>
+<p><code>issuer_onboarding_mode</code> (IssuerOnbpardingMode) (<em>mandatory</em>). MUST be a valid IssuerOnboardingMode.</p>
 </li>
 <li>
-<p><code>verifier_perm_management_mode</code> (PermissionManagementMode) (<em>mandatory</em>) MUST be a valid PermissionManagementMode.</p>
+<p><code>verifier_onboarding_mode</code> (VerifierOnboardingMode) (<em>mandatory</em>). MUST be a valid VerifierOnboardingMode.</p>
+</li>
+<li>
+<p><code>holder_onboarding_mode</code> (HolderOnboardingMode) (<em>mandatory</em>). MUST be a valid HolderOnboardingMode.</p>
 </li>
 <li>
 <p><code>digest_algorithm</code> (string) (<em>mandatory</em>) MUST be a valid digest algorithm as defined in the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust spec</a>.</p>
@@ -1905,7 +2022,7 @@ optionally enabling an associated fee grant.</li>
 <p><code>pricing_asset</code> (string) (<em>mandatory</em>): <code>&quot;tu&quot;</code> if <code>pricing_asset_type</code> is set to TU, else examples: COIN: <code>denom</code> <code>&quot;uvna&quot;</code>, <code>&quot;ufoo&quot;</code>, <code>&quot;ibc/3A0F9C2E4E2A9B7D6F...&quot;</code>, <code>&quot;factory/verana1.../ueurv&quot;</code>, FIAT: <code>&quot;EUR&quot;</code>, <code>&quot;GBP&quot;</code>,…</p>
 </li>
 </ul>
-<div id="note-7" class="notice note"><a class="notice-link" href="#note-7">NOTE</a><p>When pricing_currency is set to FIAT, pricing_asset MUST be an ISO-4217 currency code.
+<div id="note-82" class="notice note"><a class="notice-link" href="#note-82">NOTE</a><p>When pricing_currency is set to FIAT, pricing_asset MUST be an ISO-4217 currency code.
 The number of decimals and minor unit semantics MUST follow the ISO-4217 standard for that currency.
 FIAT amounts MUST be expressed in minor units and MUST NOT be represented as on-chain coins.
 FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on chain.</p>
@@ -1921,14 +2038,15 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 <ul>
 <li><code>cs.id</code>: auto-incremented uint64.</li>
 <li><code>cs.tr_id</code>: id of the <code>TrustRegistry</code> entry that will be the owner of <code>cs</code>.</li>
-<li><code>cs.json_schema</code>: <code>json_schema</code>, with VPR_CREDENTIAL_SCHEMA_ID string replaced by generated <code>cs.id</code>.</li>
+<li><code>cs.json_schema</code>: <code>json_schema</code>, with VPR_CREDENTIAL_SCHEMA_ID string replaced by generated <code>cs.id</code>, and then canonicalize it using the <a path-0="www.rfc-editor.org"path-1="rfc"path-2="rfc8785"href="https://www.rfc-editor.org/rfc/rfc8785" >JSON Canonicalization Scheme (JCS)</a> as defined in RFC 8785. Schema MUST be saved canonized.</li>
 <li><code>cs.issuer_grantor_validation_validity_period</code>: <code>issuer_grantor_validation_validity_period</code></li>
 <li><code>cs.verifier_grantor_validation_validity_period</code>: <code>verifier_grantor_validation_validity_period</code></li>
 <li><code>cs.issuer_validation_validity_period</code>: <code>issuer_validation_validity_period</code></li>
 <li><code>cs.verifier_validation_validity_period</code>: <code>verifier_validation_validity_period</code></li>
 <li><code>cs.holder_validation_validity_period</code>: <code>holder_validation_validity_period</code></li>
-<li><code>cs.issuer_perm_management_mode</code>: <code>issuer_perm_management_mode</code></li>
-<li><code>cs.verifier_perm_management_mode</code>: <code>verifier_perm_management_mode</code></li>
+<li><code>cs.issuer_onboarding_mode</code>: <code>issuer_onboarding_mode</code></li>
+<li><code>cs.verifier_onboarding_mode</code>: <code>verifier_onboarding_mode</code></li>
+<li><code>cs.holder_onboarding_mode</code>: <code>holder_onboarding_mode</code></li>
 <li><code>cs.created</code>: current timestamp</li>
 <li><code>cs.modified</code>: <code>cs.created</code>.</li>
 <li><code>cs.pricing_asset_type</code>: <code>pricing_asset_type</code></li>
@@ -1937,15 +2055,15 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 </ul>
 </li>
 </ul>
-<div id="note-8" class="notice note"><a class="notice-link" href="#note-8">NOTE</a><p>If needed, depending on configuration mode, Trust Registry controller MAY need to create a ECOSYSTEM <code>Permission</code> so that validation processes can be run.</p>
+<div id="note-83" class="notice note"><a class="notice-link" href="#note-83">NOTE</a><p>If needed, depending on configuration mode, Trust Registry controller MAY need to create a ECOSYSTEM <code>Permission</code> so that validation processes can be run.</p>
 </div>
 <h4 id="mod-cs-msg-2-update-credential-schema"><a class="toc-anchor" href="#mod-cs-msg-2-update-credential-schema" >§</a> [MOD-CS-MSG-2] Update Credential Schema</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <h5 id="mod-cs-msg-2-1-update-credential-schema-parameters"><a class="toc-anchor" href="#mod-cs-msg-2-1-update-credential-schema-parameters" >§</a> [MOD-CS-MSG-2-1] Update Credential Schema parameters</h5>
 <p>An <a class="term-reference" href="#term:account">account</a> that would like to update a <a class="term-reference" href="#term:credential-schema">credential schema</a> MUST call this method by specifying:</p>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> id of the credential schema (<em>mandatory</em>);</li>
 <li><code>issuer_grantor_validation_validity_period</code> (<em>mandatory</em>), default to 0 (days).</li>
 <li><code>verifier_grantor_validation_validity_period</code> (<em>mandatory</em>), default to 0 (days).</li>
@@ -1962,16 +2080,19 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 <p>if a mandatory parameter is not present, method MUST abort.</p>
 </li>
 <li>
-<p><code>authority</code> (group): (Signer) signature must be verified.</p>
+<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
 </li>
 <li>
 <p><code>operator</code> (account): (Signer) signature must be verified.</p>
 </li>
 <li>
+<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
+</li>
+<li>
 <p><code>id</code> MUST represent an existing <code>CredentialSchema</code> entry <code>cs</code>.</p>
 </li>
 <li>
-<p>load <code>TrustRegistry</code> <code>tr</code> from <code>cs.tr_id</code>. <code>tr.authority</code> MUST be the <code>authority</code> executing the method, else MUST abort.</p>
+<p>load <code>TrustRegistry</code> <code>tr</code> from <code>cs.tr_id</code>. <code>tr.corporation</code> MUST be the <code>corporation</code> executing the method, else MUST abort.</p>
 </li>
 <li>
 <p><code>issuer_grantor_validation_validity_period</code> MUST be between 0 (never expire) and <code>GlobalVariables.credential_schema_issuer_grantor_validation_validity_period_max_days</code> days.</p>
@@ -2008,12 +2129,12 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 </li>
 </ul>
 <h4 id="mod-cs-msg-3-archive-credential-schema"><a class="toc-anchor" href="#mod-cs-msg-3-archive-credential-schema" >§</a> [MOD-CS-MSG-3] Archive Credential Schema</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <h5 id="mod-cs-msg-3-1-archive-credential-schema-parameters"><a class="toc-anchor" href="#mod-cs-msg-3-1-archive-credential-schema-parameters" >§</a> [MOD-CS-MSG-3-1] Archive Credential Schema parameters</h5>
 <p>An <a class="term-reference" href="#term:account">account</a> that would like to archive or unarchive a <a class="term-reference" href="#term:credential-schema">credential schema</a> MUST call this method by specifying:</p>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uint64) (<em>mandatory</em>) id of the credential schema (<em>mandatory</em>);</li>
 <li><code>archive</code> (boolean) (<em>mandatory</em>), true means archive, false means unarchive.</li>
 </ul>
@@ -2025,16 +2146,19 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 <p>if a mandatory parameter is not present, method MUST abort.</p>
 </li>
 <li>
-<p><code>authority</code> (group): (Signer) signature must be verified.</p>
+<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
 </li>
 <li>
 <p><code>operator</code> (account): (Signer) signature must be verified.</p>
 </li>
 <li>
+<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
+</li>
+<li>
 <p><code>id</code> MUST represent an existing <code>CredentialSchema</code> entry <code>cs</code>.</p>
 </li>
 <li>
-<p>load <code>TrustRegistry</code> <code>tr</code> from <code>cs.tr_id</code>. <code>tr.authority</code> MUST be the <code>authority</code> executing the method, else MUST abort.</p>
+<p>load <code>TrustRegistry</code> <code>tr</code> from <code>cs.tr_id</code>. <code>tr.corporation</code> MUST be the <code>corporation</code> executing the method, else MUST abort.</p>
 </li>
 <li>
 <p><code>archive</code> (boolean) (<em>mandatory</em>) MUST be a boolean.</p>
@@ -2086,14 +2210,14 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 <li>update parameter set value = <code>value</code> where key = <code>key</code>.</li>
 </ul>
 <h4 id="mod-cs-msg-5-create-schema-authorization-policy"><a class="toc-anchor" href="#mod-cs-msg-5-create-schema-authorization-policy" >§</a> [MOD-CS-MSG-5] Create Schema Authorization Policy</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This message creates a <strong>draft</strong> <code>SchemaAuthorizationPolicy</code> for a given <code>(schema_id, role)</code>, or overwrites the existing draft policy if one already exists.<br>
 A draft policy is defined as a policy with <code>effective_from == null</code> and MUST NOT be revoked.</p>
-<p>Accordingly, if a credential schema defines one or more active policies for the ISSUER or VERIFIER role, the corresponding authority that grants the ISSUER or VERIFIER role for this schema (ISSUER_GRANTOR, VERIFIER_GRANTOR, or ECOSYSTEM, depending on how schema issuer and verifier modes have been configured) MUST issue an IAC or VAC credential to the candidate upon successful completion of the validation process. Refer to the <a path-0="github.com"path-1="verana-labs"path-2="verifiable-trust-spec"href="https://github.com/verana-labs/verifiable-trust-spec" >Verifiable Trust spec</a> for more information.</p>
+<p>Accordingly, if a credential schema defines one or more active policies for the ISSUER or VERIFIER role, the corresponding corporation that grants the ISSUER or VERIFIER role for this schema (ISSUER_GRANTOR, VERIFIER_GRANTOR, or ECOSYSTEM, depending on how schema issuer and verifier modes have been configured) MUST issue an IAC or VAC credential to the candidate upon successful completion of the validation process. Refer to the <a path-0="github.com"path-1="verana-labs"path-2="verifiable-trust-spec"href="https://github.com/verana-labs/verifiable-trust-spec" >Verifiable Trust spec</a> for more information.</p>
 <h5 id="mod-cs-msg-5-1-create-schema-authorization-policy-parameters"><a class="toc-anchor" href="#mod-cs-msg-5-1-create-schema-authorization-policy-parameters" >§</a> [MOD-CS-MSG-5-1] Create Schema Authorization Policy parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>schema_id</code> (uint64): id of the related <code>CredentialSchema</code> (<em>mandatory</em>).</li>
 <li><code>role</code> (SchemaAuthorizationPolicyRole): <code>ISSUER</code> or <code>VERIFIER</code> (<em>mandatory</em>).</li>
 <li><code>url</code> (string): URL where the policy document is published (<em>mandatory</em>).</li>
@@ -2104,9 +2228,10 @@ A draft policy is defined as a policy with <code>effective_from == null</code> a
 <h6 id="mod-cs-msg-5-2-1-create-schema-authorization-policy-basic-checks"><a class="toc-anchor" href="#mod-cs-msg-5-2-1-create-schema-authorization-policy-basic-checks" >§</a> [MOD-CS-MSG-5-2-1] Create Schema Authorization Policy basic checks</h6>
 <ul>
 <li>if a mandatory parameter is not present, method MUST abort.</li>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
-<li><code>schema_id</code> MUST reference an existing <code>CredentialSchema</code> entry controlled by <code>authority</code>.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
+<li><code>schema_id</code> MUST reference an existing <code>CredentialSchema</code> entry controlled by <code>corporation</code>.</li>
 <li><code>role</code> MUST be a valid <code>SchemaAuthorizationPolicyRole</code>.</li>
 <li><code>url</code> MUST be a non-empty valid URI.</li>
 <li><code>digest_sri</code> MUST be non-empty.</li>
@@ -2144,12 +2269,12 @@ A draft policy is defined as a policy with <code>effective_from == null</code> a
 </li>
 </ul>
 <h4 id="mod-cs-msg-6-increase-active-schema-authorization-policy-version"><a class="toc-anchor" href="#mod-cs-msg-6-increase-active-schema-authorization-policy-version" >§</a> [MOD-CS-MSG-6] Increase Active Schema Authorization Policy Version</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This message activates the current draft <code>SchemaAuthorizationPolicy</code> for the given <code>(schema_id, role)</code> and deactivates any previously active version. Deactivation does not constitute revocation; credentials issued under earlier policies MAY continue to be considered valid.</p>
 <h5 id="mod-cs-msg-6-1-increase-active-schema-authorization-policy-version-parameters"><a class="toc-anchor" href="#mod-cs-msg-6-1-increase-active-schema-authorization-policy-version-parameters" >§</a> [MOD-CS-MSG-6-1] Increase Active Schema Authorization Policy Version parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>schema_id</code> (uint64): id of the related <code>CredentialSchema</code> (<em>mandatory</em>).</li>
 <li><code>role</code> (SchemaAuthorizationPolicyRole): <code>ISSUER</code> or <code>VERIFIER</code> (<em>mandatory</em>).</li>
 </ul>
@@ -2158,9 +2283,10 @@ A draft policy is defined as a policy with <code>effective_from == null</code> a
 <h6 id="mod-cs-msg-6-2-1-basic-checks"><a class="toc-anchor" href="#mod-cs-msg-6-2-1-basic-checks" >§</a> [MOD-CS-MSG-6-2-1] Basic checks</h6>
 <ul>
 <li>if a mandatory parameter is not present, method MUST abort.</li>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
-<li><code>schema_id</code> MUST reference an existing <code>CredentialSchema</code> entry controlled by <code>authority</code>.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
+<li><code>schema_id</code> MUST reference an existing <code>CredentialSchema</code> entry controlled by <code>corporation</code>.</li>
 <li>exactly one draft policy MUST exist for <code>(schema_id, role)</code> with <code>effective_from == null</code> and <code>revoked == false</code>.</li>
 <li>the draft policy MUST have non-empty <code>url</code> and <code>digest_sri</code>.</li>
 </ul>
@@ -2180,12 +2306,12 @@ A draft policy is defined as a policy with <code>effective_from == null</code> a
 </li>
 </ul>
 <h4 id="mod-cs-msg-7-revoke-schema-authorization-policy"><a class="toc-anchor" href="#mod-cs-msg-7-revoke-schema-authorization-policy" >§</a> [MOD-CS-MSG-7] Revoke Schema Authorization Policy</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This message revokes a previously enabled <code>SchemaAuthorizationPolicy</code> version. Revoked means previously issued credential that refer to this policy are automatically considered revoked.</p>
 <h5 id="mod-cs-msg-7-1-revoke-schema-authorization-policy-parameters"><a class="toc-anchor" href="#mod-cs-msg-7-1-revoke-schema-authorization-policy-parameters" >§</a> [MOD-CS-MSG-7-1] Revoke Schema Authorization Policy parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>schema_id</code> (uint64): id of the related <code>CredentialSchema</code> (<em>mandatory</em>).</li>
 <li><code>role</code> (SchemaAuthorizationPolicyRole): <code>ISSUER</code> or <code>VERIFIER</code> (<em>mandatory</em>).</li>
 <li><code>version</code> (integer): policy version to revoke (<em>mandatory</em>).</li>
@@ -2195,8 +2321,9 @@ A draft policy is defined as a policy with <code>effective_from == null</code> a
 <h6 id="mod-cs-msg-7-2-1-basic-checks"><a class="toc-anchor" href="#mod-cs-msg-7-2-1-basic-checks" >§</a> [MOD-CS-MSG-7-2-1] Basic checks</h6>
 <ul>
 <li>if a mandatory parameter is not present, method MUST abort.</li>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li>a policy MUST exist for <code>(schema_id, role, version)</code>.</li>
 <li>the targeted policy MUST have <code>effective_from != null</code> (a policy that has never been enabled MUST NOT be revoked).</li>
 <li>the targeted policy MUST NOT already be revoked.</li>
@@ -2216,8 +2343,9 @@ A draft policy is defined as a policy with <code>effective_from == null</code> a
 <li><code>modified_after</code> (timestamp) (<em>optional</em>): show schemas modified after this timestamp.</li>
 <li><code>response_max_size</code> (small number) (<em>optional</em>): default to 64. Max 1,024.</li>
 <li><code>only_active</code> (boolean): if set to true, returns only not archived entries.</li>
-<li><code>issuer_perm_management_mode</code> (PermissionManagementMode): if set, filter by <code>issuer_perm_management_mode</code>.</li>
-<li><code>verifier_perm_management_mode</code> (PermissionManagementMode): if set, filter by <code>verifier_perm_management_mode</code>.</li>
+<li><code>issuer_onboarding_mode</code> (IssuerOnboardingMode): if set, filter by <code>issuer_onboarding_mode</code>.</li>
+<li><code>verifier_onboarding_mode</code> (VerifierOnboardingMode): if set, filter by <code>verifier_onboarding_mode</code>.</li>
+<li><code>holder_onboarding_mode</code> (HolderOnboardingMode): if set, filter by <code>holder_onboarding_mode</code>.</li>
 </ul>
 <h5 id="mod-cs-qry-1-2-list-credential-schemas-checks"><a class="toc-anchor" href="#mod-cs-qry-1-2-list-credential-schemas-checks" >§</a> [MOD-CS-QRY-1-2] List Credential Schemas checks</h5>
 <ul>
@@ -2250,6 +2378,7 @@ A draft policy is defined as a policy with <code>effective_from == null</code> a
 </ul>
 <h5 id="mod-cs-qry-3-3-render-json-schema-execution"><a class="toc-anchor" href="#mod-cs-qry-3-3-render-json-schema-execution" >§</a> [MOD-CS-QRY-3-3] Render Json Schema execution</h5>
 <p>Render found entry (if any). In case value is returned by a REST API, content type MUST be set to “application/schema+json”.</p>
+<p>Schema MUST be rendered cononized, even if it was not created canonized using the <a path-0="www.rfc-editor.org"path-1="rfc"path-2="rfc8785"href="https://www.rfc-editor.org/rfc/rfc8785" >JSON Canonicalization Scheme (JCS)</a> as defined in RFC 8785.</p>
 <h4 id="mod-cs-qry-4-list-module-parameters"><a class="toc-anchor" href="#mod-cs-qry-4-list-module-parameters" >§</a> [MOD-CS-QRY-4] List Module Parameters</h4>
 <p>Anyone CAN run this <a class="term-reference" href="#term:query">query</a>.</p>
 <h5 id="mod-cs-qry-4-2-list-module-parameters-parameters"><a class="toc-anchor" href="#mod-cs-qry-4-2-list-module-parameters-parameters" >§</a> [MOD-CS-QRY-4-2] List Module Parameters parameters</h5>
@@ -2330,8 +2459,8 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <p><em>This section is non-normative.</em></p>
 <p>Permission are linked to a Credential Schema and representable as a tree.</p>
 <img src="https://www.plantuml.com/plantuml/svg/ZPDTRu8m58Rl-ojEv6QxC24naOMBHKLKacqkm4oscwL0nMvyfQrCi_ZVLwcoBM5rvmOElETzUdhQ4HUOYMsUeL7xncES4SZn3cvC4pve8ZO8K8NZTvmIwBaxd5TIu32Ia49Gd44GRqYEuP6md79Eom92HaWFC8UOmoT28AECtaWie1UoBHVWavHomVOmRcI2WJ5OHqaqb78uHTNwXVkAsE0wo-0v2DrxkFBBKbotmeGcDb7BiWKRDzyFlw0Uvrl2OCvm8Ke6amPAKmtC2u8drt-T--E7SEbtecWw-HlbA8HA36jeMII1YxnkZjE1MH56r_H7JzC6MEjwMhc-D_CkT5MdKntELPXpQfXcPAxDVq2xOMu7Qr5cYRH-WGQrKPancqrCQw01BPPtqnFcW0v8XZnL_VxjSSusfCTjaYFWwgn-5oFvkr6fKUcKPyDQRrWhmtQFj9OdxB50TQfLZqYHDBTLFRy0" alt="uml diagram">
-<p>The ECOSYSTEM type permissions are created by the Credential Schema owner. All other permissions are created by running a Validation Process (or by any account: - for <code>ISSUER</code> permissions if issuer_perm_management_mode is equal to <code>OPEN</code>, - for <code>VERIFIER</code> permissions if verifier_perm_management_mode is equal to <code>OPEN</code>).</p>
-<p>A Validation Process (VP) is a process which involves an <a class="term-reference" href="#term:applicant">applicant</a> (which is the <a class="term-reference" href="#term:authority">authority</a> of validation entry stored in a validation <a class="term-reference" href="#term:keeper">keeper</a>), a <a class="term-reference" href="#term:validator">validator</a> permission, and optional validation fees plus transaction fees.</p>
+<p>The ECOSYSTEM type permissions are created by the Credential Schema owner. All other permissions are created by running a Validation Process (or by any account: - for <code>ISSUER</code> permissions if issuer_onboarding_mode is equal to <code>OPEN</code>, - for <code>VERIFIER</code> permissions if verifier_onboarding_mode is equal to <code>OPEN</code>).</p>
+<p>A Validation Process (VP) is a process which involves an <a class="term-reference" href="#term:applicant">applicant</a> (which is the <a class="term-reference" href="#term:corporation">corporation</a> of validation entry stored in a validation <a class="term-reference" href="#term:keeper">keeper</a>), a <a class="term-reference" href="#term:validator">validator</a> permission, and optional validation fees plus transaction fees.</p>
 <p>Validation is used by <a class="term-reference" href="#term:applicants">applicants</a> that want to:</p>
 <ul>
 <li>be an <a class="term-reference" href="#term:issuer">issuer</a> of a specific <a class="term-reference" href="#term:credential-schema">credential schema</a>;</li>
@@ -2339,16 +2468,16 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li>be an <a class="term-reference" href="#term:issuer-grantor">issuer grantor</a> of a specific <a class="term-reference" href="#term:credential-schema">credential schema</a>;</li>
 <li>be a <a class="term-reference" href="#term:verifier-grantor">verifier grantor</a> of a specific <a class="term-reference" href="#term:credential-schema">credential schema</a>;</li>
 <li>get issued a credential of a specific <a class="term-reference" href="#term:credential-schema">credential schema</a>;</li>
-<li>optionally get created a HOLDER permission (HOLDER permission may be used in combination with credentials, example for User Agent credentials).</li>
+<li>obtain a HOLDER permission from a issuer of a specific <a class="term-reference" href="#term:credential-schema">credential schema</a> and get issued a verifiable credential of this schema (HOLDER permission provide credential status (revoked, etc…));</li>
 </ul>
 <p>In all cases, the process is very similar. Example execution of a validation process:</p>
 <ol>
 <li>Applicant starts a validation process by running the [start new validation] <a class="term-reference" href="#term:transaction">transaction</a>. Validation process may be subject to paying validation fees, as defined by validator.</li>
-<li>Validation process usually requires that <a class="term-reference" href="#term:applicant">applicant</a> connects to a validation <a class="term-reference" href="#term:vs">VS</a> identified by its <a class="term-reference" href="#term:did">DID</a>, and execute a some validation steps, required for the validation process to conclude.</li>
+<li>Validation process requires that <a class="term-reference" href="#term:applicant">applicant</a> connects to a validation <a class="term-reference" href="#term:vs">VS</a> identified by its <a class="term-reference" href="#term:did">DID</a>, and execute a some validation steps, required for the validation process to conclude.</li>
 <li>If <a class="term-reference" href="#term:applicant">applicant</a> qualifies, <a class="term-reference" href="#term:validator">validator</a> updates the validation entry by running the [set to validated] <a class="term-reference" href="#term:transaction">transaction</a>, and <a class="term-reference" href="#term:applicant">applicant</a> is granted new permissions, and/or gets issued a credential.</li>
 </ol>
 <p>Validation is valid for a specific period, for example 365 days, as configured in the <a class="term-reference" href="#term:credential-schema">credential schema</a> for credential schema related validations, or set by trust registry for user-agent validation.</p>
-<div id="note-9" class="notice note"><a class="notice-link" href="#note-9">NOTE</a><p>In some cases, even if the validation is valid for a period of time, the resulting created permission or issued credential might have a shorter expiration timestamp because the validated attribute(s) might expire before validation expiration: in this case, the <a class="term-reference" href="#term:applicant">applicant</a> must provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration, in order to get issued an updated new permission and/or an updated credential.</p>
+<div id="note-84" class="notice note"><a class="notice-link" href="#note-84">NOTE</a><p>In some cases, even if the validation is valid for a period of time, the resulting created permission or issued credential might have a shorter expiration timestamp because the validated attribute(s) might expire before validation expiration: in this case, the <a class="term-reference" href="#term:applicant">applicant</a> must provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration, in order to get issued an updated new permission and/or an updated credential.</p>
 </div>
 <p>If validation is set to expire, <a class="term-reference" href="#term:applicant">applicant</a> that wishes to extend the expiration timestamp must renew its validation.</p>
 <p>At any time, <a class="term-reference" href="#term:applicant">applicant</a> can cancel the validation process.</p>
@@ -2356,15 +2485,14 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <ul>
 <li>if selected validator permission is revoked while applicant’s validation is in PENDING state: Applicant CAN cancel the validation process [MOD-PERM-MSG-6].</li>
 <li>if selected validator permission is revoked while applicant is in VALIDATED state: Applicant CAN renew the validation process by choosing a new validator [MOD-PERM-MSG-2].</li>
-<li>if selected validator permission is revoked while applicant is in TERMINATION_REQUESTED state and validator action is required: applicant MUST be able to set the validation state to TERMINATED.</li>
 </ul>
 <h4 id="mod-perm-msg-1-start-permission-vp"><a class="toc-anchor" href="#mod-perm-msg-1-start-permission-vp" >§</a> [MOD-PERM-MSG-1] Start Permission VP</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <h5 id="mod-perm-msg-1-1-start-permission-vp-parameters"><a class="toc-anchor" href="#mod-perm-msg-1-1-start-permission-vp-parameters" >§</a> [MOD-PERM-MSG-1-1] Start Permission VP parameters</h5>
 <p>An Applicant that would like to start a permission validation process MUST execute this method by specifying:</p>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>vs_operator</code> (account) (<em>optional</em>): the account of the Veriable Service we want to authorize to create permission sessions linked to this permission. If not specified, Verifiable Service will not be able to use the payment delegation feature. <strong>Required</strong> to use the payment delegation feature.</li>
 <li><code>type</code> (PermissionType) (<em>mandatory</em>): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the permission that the applicant would like to get;</li>
 <li><code>validator_perm_id</code> (uint64) (<em>mandatory</em>): the <a class="term-reference" href="#term:validator">validator</a> permission (parent permission in the tree), chosen by the applicant.</li>
@@ -2372,35 +2500,68 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li><code>issuance_fees</code> (number) (<em>optional</em>): Requested issuance_fees for this permission (can be modified by validator).</li>
 <li><code>verification_fees</code> (number) (<em>optional</em>): Requested verification_fees for this permission (can be modified by validator).</li>
 <li><code>did</code> (string) (<em>required</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
-<li><code>vs_operator_authz_enabled</code>: boolean (<em>mandatory</em>): if set to true authorize this vs_operator to execute CreateOrUpdatePermissionSession <em>on behalf</em> of <code>authority</code> account (trust fees will be paid by authority account)</li>
-<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds that the vs_operator is allowed to spend in the context of this permission.
-as a direct consequence of executing authorized messages.</li>
-<li><code>vs_operator_authz_with_feegrant</code>: boolean (<em>mandatory</em>): if set to true, enable feegrant for this permission so vs_operator can pay the fees for CreateOrUpdatePermissionSession with <code>authority</code> account.</li>
-<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of fees that can be spent by vs_operator in the context of this permission.</li>
-<li><code>vs_operator_authz_spend_period</code>: (period) (<em>optional</em>): reset period for vs_operator_authz_spend_limit and vs_operator_authz_fee_spend_limit in the context of this permission.</li>
 </ul>
+<p>The following VS Operator Authorization parameters are <strong>optional</strong> and collectively define the initial <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> that will be created for this permission. Presence of <code>vs_operator_authz_msg_types</code> is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode (the corporation signs and pays for its own permission-related transactions directly). VSOA configuration is <strong>frozen at creation time</strong> and cannot be modified later; to change it, the permission MUST be revoked and re-created.</p>
+<ul>
+<li><code>vs_operator_authz_msg_types[]</code> (msg_type[]) (<em>optional</em>): list of VPR delegable message types <code>vs_operator</code> is authorized to execute on behalf of <code>corporation</code> in the context of this permission. If provided, a <code>PermissionAuthorizationRecord</code> is created (see execution below) and <code>vs_operator</code> MUST be specified. The permitted list of message types is provided below.</li>
+<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds <code>vs_operator</code> is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.</li>
+<li><code>vs_operator_authz_with_feegrant</code> (bool) (<em>optional</em>, default: false): if true, <code>corporation</code> pays transaction fees for <code>vs_operator</code> via an on-chain <code>FeeGrant</code> when executing authorized messages in the context of this permission.</li>
+<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of transaction fees that can be spent by <code>vs_operator</code> (paid by <code>corporation</code> via fee grant) in the context of this permission.</li>
+<li><code>vs_operator_authz_period</code> (duration) (<em>optional</em>): reset period for <code>vs_operator_authz_spend_limit</code> and <code>vs_operator_authz_fee_spend_limit</code> in the context of this permission.</li>
+</ul>
+<p>Permitted message types to be set in <code>vs_operator_authz_msg_types</code> depends on <code>type</code>.</p>
+<table>
+<thead>
+<tr>
+<th>Permission type</th>
+<th>Permitted Messages</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>HOLDER</td>
+<td>TriggerResolver</td>
+</tr>
+<tr>
+<td>ISSUER</td>
+<td>CreateOrUpdatePermissionSession, SetPermissionVPtoValidated</td>
+</tr>
+<tr>
+<td>VERIFIER</td>
+<td>CreateOrUpdatePermissionSession</td>
+</tr>
+<tr>
+<td>ISSUER_GRANTOR</td>
+<td>SetPermissionVPtoValidated</td>
+</tr>
+<tr>
+<td>VERIFIER_GRANTOR</td>
+<td>SetPermissionVPtoValidated</td>
+</tr>
+<tr>
+<td>ECOSYSTEM</td>
+<td>SetPermissionVPtoValidated</td>
+</tr>
+</tbody>
+</table>
 <p>Available compatible perms can be found by using an indexer and presented in a front-end so applicant can choose its validator.</p>
 <h5 id="mod-perm-msg-1-2-start-permission-vp-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-1-2-start-permission-vp-precondition-checks" >§</a> [MOD-PERM-MSG-1-2] Start Permission VP precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <h6 id="mod-perm-msg-1-2-1-start-permission-vp-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-1-2-1-start-permission-vp-basic-checks" >§</a> [MOD-PERM-MSG-1-2-1] Start Permission VP basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>type</code> (PermissionType) (<em>mandatory</em>) MUST be a valid PermissionType: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.</li>
 <li><code>validator_perm_id</code> (uint64) (<em>mandatory</em>): see <a href="#mod-perm-msg-1-2-2-start-permission-vp-permission-checks" >MOD-PERM-MSG-1-2-2</a>.</li>
 <li><code>validation_fees</code> (number) (<em>optional</em>): Requested validation_fees for this permission (can be modified by validator).</li>
 <li><code>issuance_fees</code> (number) (<em>optional</em>): Requested issuance_fees for this permission (can be modified by validator).</li>
 <li><code>verification_fees</code> (number) (<em>optional</em>): Requested verification_fees for this permission (can be modified by validator).</li>
 <li><code>did</code>, if specified, MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
-<li><code>vs_operator_authz_enabled</code>: boolean (<em>mandatory</em>): if set to true, <code>vs_operator</code> MUST NOT be null, else abort.</li>
-<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds that the vs_operator is allowed to spend in the context of this permission.
-as a direct consequence of executing authorized messages.</li>
-<li><code>vs_operator_authz_with_feegrant</code>: boolean (<em>mandatory</em>): if set to true, <code>vs_operator</code> MUST NOT be null, else abort.</li>
-<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of fees that can be spent by vs_operator in the context of this permission.</li>
-<li><code>vs_operator_authz_spend_period</code>: (period) (<em>optional</em>): if not null, <code>vs_operator</code> MUST NOT be null, else abort. Reset period for vs_operator_authz_spend_limit and vs_operator_authz_fee_spend_limit in the context of this permission.</li>
+<li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-perm-msg-1-1-start-permission-vp-parameters" >MOD-PERM-MSG-1-1</a>.</li>
 </ul>
-<div id="note-10" class="notice note"><a class="notice-link" href="#note-10">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the validation process is REQUIRED or not.</p>
+<div id="note-85" class="notice note"><a class="notice-link" href="#note-85">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the validation process is REQUIRED or not.</p>
 </div>
 <h6 id="mod-perm-msg-1-2-2-start-permission-vp-permission-checks"><a class="toc-anchor" href="#mod-perm-msg-1-2-2-start-permission-vp-permission-checks" >§</a> [MOD-PERM-MSG-1-2-2] Start Permission VP permission checks</h6>
 <ul>
@@ -2414,10 +2575,10 @@ as a direct consequence of executing authorized messages.</li>
 <p>if <code>type</code> (PermissionType) is equal to ISSUER:</p>
 <ul>
 <li>
-<p>if <code>cs.issuer_perm_management_mode</code> is equal to GRANTOR: <code>validator_perm.type</code> MUST be ISSUER_GRANTOR, else MUST abort.</p>
+<p>if <code>cs.issuer_onboarding_mode</code> is equal to GRANTOR_VALIDATION_PROCESS: <code>validator_perm.type</code> MUST be ISSUER_GRANTOR, else MUST abort.</p>
 </li>
 <li>
-<p>else if <code>cs.issuer_perm_management_mode</code> is equal to ECOSYSTEM: <code>validator_perm.type</code> MUST be ECOSYSTEM, else MUST abort.</p>
+<p>else if <code>cs.issuer_onboarding_mode</code> is equal to ECOSYSTEM_VALIDATION_PROCESS: <code>validator_perm.type</code> MUST be ECOSYSTEM, else MUST abort.</p>
 </li>
 <li>
 <p>else MUST abort.</p>
@@ -2428,7 +2589,7 @@ as a direct consequence of executing authorized messages.</li>
 <p>else if <code>type</code> (PermissionType) is equal to ISSUER_GRANTOR:</p>
 <ul>
 <li>
-<p>if <code>cs.issuer_perm_management_mode</code> is equal to GRANTOR:  <code>validator_perm.type</code> MUST be ECOSYSTEM, else MUST abort.</p>
+<p>if <code>cs.issuer_onboarding_mode</code> is equal to GRANTOR_VALIDATION_PROCESS:  <code>validator_perm.type</code> MUST be ECOSYSTEM, else MUST abort.</p>
 </li>
 <li>
 <p>else abort.</p>
@@ -2439,10 +2600,10 @@ as a direct consequence of executing authorized messages.</li>
 <p>else if <code>type</code> (PermissionType) is equal to VERIFIER:</p>
 <ul>
 <li>
-<p>if <code>cs.verifier_perm_management_mode</code> is equal to GRANTOR: <code>validator_perm.type</code> MUST be VERIFIER_GRANTOR, else MUST abort.</p>
+<p>if <code>cs.verifier_onboarding_mode</code> is equal to GRANTOR: <code>validator_perm.type</code> MUST be VERIFIER_GRANTOR, else MUST abort.</p>
 </li>
 <li>
-<p>else if <code>cs.verifier_perm_management_mode</code> is equal to ECOSYSTEM: <code>validator_perm.type</code> MUST be ECOSYSTEM, else MUST abort.</p>
+<p>else if <code>cs.verifier_onboarding_mode</code> is equal to ECOSYSTEM_VALIDATION_PROCESS: <code>validator_perm.type</code> MUST be ECOSYSTEM, else MUST abort.</p>
 </li>
 <li>
 <p>else abort.</p>
@@ -2453,7 +2614,7 @@ as a direct consequence of executing authorized messages.</li>
 <p>else if <code>type</code> (PermissionType) is equal to VERIFIER_GRANTOR:</p>
 <ul>
 <li>
-<p>if <code>cs.verifier_perm_management_mode</code> is equal to GRANTOR: <code>validator_perm.type</code> MUST be ECOSYSTEM, else MUST abort.</p>
+<p>if <code>cs.verifier_onboarding_mode</code> is equal to GRANTOR_VALIDATION_PROCESS: <code>validator_perm.type</code> MUST be ECOSYSTEM, else MUST abort.</p>
 </li>
 <li>
 <p>else abort.</p>
@@ -2464,7 +2625,7 @@ as a direct consequence of executing authorized messages.</li>
 <p>else if <code>type</code> (PermissionType) is equal to HOLDER:</p>
 <ul>
 <li>
-<p>if <code>cs.verifier_perm_management_mode</code> is equal to GRANTOR or ECOSYSTEM: <code>validator_perm.type</code> MUST be ISSUER, else MUST abort.</p>
+<p>if <code>cs.holder_onboarding_mode</code> is equal to ISSUER_VALIDATION_PROCESS: <code>validator_perm.type</code> MUST be ISSUER, else MUST abort.</p>
 </li>
 <li>
 <p>else abort.</p>
@@ -2493,7 +2654,7 @@ as a direct consequence of executing authorized messages.</li>
 </ul>
 <p>if <code>(cs.pricing_asset_type, cs.pricing_asset)</code> is set to <code>(COIN, [[ref: native denom]])</code>:</p>
 <ul>
-<li><code>authority</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
+<li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
 <li>the required <code>validation_fees_in_denom</code> = <code>validator_perm.validation_fees</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: <code>validation_fees_in_denom</code> * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
@@ -2502,7 +2663,7 @@ as a direct consequence of executing authorized messages.</li>
 </ul>
 <p>else if <code>(cs.pricing_asset_type, cs.pricing_asset)</code> is set to <code>(TU, &quot;tu&quot;)</code>:</p>
 <ul>
-<li><code>authority</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
+<li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
 <li>the required <code>validation_fees_in_denom</code> = getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validator_perm.validation_fees</code>) in <a class="term-reference" href="#term:native-denom">native denom</a>;</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: <code>validation_fees_in_denom</code> * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
@@ -2511,7 +2672,7 @@ as a direct consequence of executing authorized messages.</li>
 </ul>
 <p>else if <code>(cs.pricing_asset_type, cs.pricing_asset)</code> is set to an arbitrary coin <code>(COIN, [[ref: denom]])</code>:</p>
 <ul>
-<li><code>authority</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
+<li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
 <li>the required <code>validation_fees_in_denom</code> = <code>validator_perm.validation_fees</code> in specified (cs.pricing_asset_type, cs.pricing_asset)</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validation_fees_in_denom</code>) * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
@@ -2520,18 +2681,18 @@ as a direct consequence of executing authorized messages.</li>
 </ul>
 <p>else if <code>(cs.pricing_asset_type, cs.pricing_asset)</code> is set to an arbitrary coin <code>(FIAT, [[ref: denom]])</code>:</p>
 <ul>
-<li><code>authority</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
+<li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
 <li>the required <code>validation_fees_in_denom</code> = 0 in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validator_perm.validation_fees</code>) * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 </li>
 </ul>
-<div id="note-11" class="notice note"><a class="notice-link" href="#note-11">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
+<div id="note-86" class="notice note"><a class="notice-link" href="#note-86">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
 <h6 id="mod-perm-msg-1-2-4-start-permission-vp-overlap-checks"><a class="toc-anchor" href="#mod-perm-msg-1-2-4-start-permission-vp-overlap-checks" >§</a> [MOD-PERM-MSG-1-2-4] Start Permission VP overlap checks</h6>
-<p>We want to make sure that 2 validation processes cannot be active at the same time in the same context. This does not prevent an <code>authority</code> from running different VP with differents validators for the same <code>schema_id</code>, <code>type</code>.</p>
-<p>Find all permission <code>perms[]</code> for <code>schema_id</code>, <code>type</code>, <code>validator_perm_id</code>, <code>authority</code> with vp_state = VALIDATED or PENDING.</p>
+<p>We want to make sure that 2 validation processes cannot be active at the same time in the same context. This does not prevent a <code>corporation</code> from running different VP with differents validators for the same <code>schema_id</code>, <code>type</code>.</p>
+<p>Find all permission <code>perms[]</code> for <code>schema_id</code>, <code>type</code>, <code>validator_perm_id</code>, <code>corporation</code> with vp_state = VALIDATED or PENDING.</p>
 <p>if size of <code>perms[]</code> &gt; 0, it means there is already an existing validation process in this context, so MUST abort.</p>
 <blockquote>
 <p>note: this check was not present in v3.</p>
@@ -2547,7 +2708,7 @@ as a direct consequence of executing authorized messages.</li>
 <p>calculate <code>validation_fees_in_denom</code> and <code>validation_trust_deposit_in_native_denom</code> as explained above in fee checks.</p>
 </li>
 <li>
-<p>use [MOD-TD-MSG-1] to increase by <code>validation_trust_deposit_in_native_denom</code> the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>authority</code> running the method and transfer the corresponding amount to <code>TrustDeposit</code> module.</p>
+<p>use [MOD-TD-MSG-1] to increase by <code>validation_trust_deposit_in_native_denom</code> the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>corporation</code> running the method and transfer the corresponding amount to <code>TrustDeposit</code> module.</p>
 </li>
 <li>
 <p>send <code>validation_fees_in_denom</code> to validation escrow <a class="term-reference" href="#term:account">account</a>, if greater than 0.</p>
@@ -2560,7 +2721,7 @@ as a direct consequence of executing authorized messages.</li>
 <ul>
 <li><code>applicant_perm.id</code>: auto-incremented uint64.</li>
 <li><code>applicant_perm.schema_id</code> = <code>validator_perm.schema_id</code></li>
-<li><code>applicant_perm.authority</code>: <code>authority</code>.</li>
+<li><code>applicant_perm.corporation</code>: <code>corporation</code>.</li>
 <li><code>applicant_perm.vs_operator</code>: <code>vs_operator</code>.</li>
 <li><code>applicant_perm.type</code>: <code>type</code>.</li>
 <li><code>applicant_perm.created</code>: <code>now</code></li>
@@ -2574,16 +2735,30 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>applicant_perm.vp_state</code>: PENDING.</li>
 <li><code>applicant_perm.vp_current_fees</code> (number): <code>validation_fees_in_denom</code>.</li>
 <li><code>applicant_perm.vp_current_deposit</code> (number): <code>validation_trust_deposit_in_native_denom</code>.</li>
-<li><code>applicant_perm.vp_summary_digest_sri</code>: null.</li>
+<li><code>applicant_perm.vp_summary_digest</code>: null.</li>
 <li><code>applicant_perm.vp_validator_deposit</code>: 0.</li>
-<li><code>applicant_perm.vs_operator_authz_enabled</code>: <code>vs_operator_authz_enabled</code></li>
-<li><code>applicant_perm.vs_operator_authz_spend_limit</code>: <code>vs_operator_authz_spend_limit</code></li>
-<li><code>applicant_perm.vs_operator_authz_with_feegrant</code>: <code>vs_operator_authz_with_feegrant</code></li>
-<li><code>applicant_perm.vs_operator_authz_fee_spend_limit</code>: <code>vs_operator_authz_fee_spend_limit</code></li>
-<li><code>applicant_perm.vs_operator_authz_spend_period</code>: <code>vs_operator_authz_spend_period</code></li>
 </ul>
 </li>
 </ul>
+<p>If <code>vs_operator_authz_msg_types</code> is provided, create the <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> in <strong>disabled</strong> state (<code>expiration = now</code>) by calling <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a> Grant VS Operator Authorization with:</p>
+<ul>
+<li><code>corporation</code>: <code>corporation</code></li>
+<li><code>vs_operator</code>: <code>vs_operator</code></li>
+<li><code>record</code>:
+<ul>
+<li><code>record.perm_id</code>: <code>applicant_perm.id</code></li>
+<li><code>record.msg_types</code>: <code>vs_operator_authz_msg_types</code></li>
+<li><code>record.spend_limit</code>: <code>vs_operator_authz_spend_limit</code></li>
+<li><code>record.fee_spend_limit</code>: <code>vs_operator_authz_fee_spend_limit</code></li>
+<li><code>record.with_feegrant</code>: <code>vs_operator_authz_with_feegrant</code> (default: false)</li>
+<li><code>record.expiration</code>: <code>now</code></li>
+<li><code>record.period</code>: <code>vs_operator_authz_period</code></li>
+</ul>
+</li>
+</ul>
+<blockquote>
+<p>Note: the record is created with <code>expiration = now</code> so authorization is <strong>not yet active</strong>. <a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a> will reject any attempt to use it until <a href="#mod-perm-msg-3-set-permission-vp-to-validated" >[MOD-PERM-MSG-3]</a> updates <code>expiration</code> to <code>applicant_perm.effective_until</code>. No on-chain <code>FeeGrant</code> object is created at this stage even if <code>with_feegrant</code> is true (the recompute subroutine in <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a> requires <code>expiration &gt; now</code>).</p>
+</blockquote>
 <h4 id="connecting-to-the-vs-of-the-validator"><a class="toc-anchor" href="#connecting-to-the-vs-of-the-validator" >§</a> Connecting to the VS of the Validator</h4>
 <p><em>This section is non-normative, and provided for understanding only.</em></p>
 <p>This action must be initiated by the <a class="term-reference" href="#term:applicant">applicant</a>.</p>
@@ -2602,20 +2777,21 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>permission expiration</code></li>
 </ul>
 <p>The <a class="term-reference" href="#term:validator">validator</a> may compile a summary file of the validation process, documenting exchanged data, proofs, and decisions, and share it with the <a class="term-reference" href="#term:applicant">applicant</a> via the <a class="term-reference" href="#term:vs">VS</a> connection or another secure channel.</p>
-<p>For audit or governance purposes, the <a class="term-reference" href="#term:validator">validator</a> should register a digest (e.g., hash or SRI) of this summary in <code>applicant_perm.vp_summary_digest_sri</code>.</p>
+<p>For audit or governance purposes, the <a class="term-reference" href="#term:validator">validator</a> should register a digest (e.g., hash or SRI) of this summary in <code>applicant_perm.vp_summary_digest</code>.</p>
 <h4 id="mod-perm-msg-2-renew-permission-vp"><a class="toc-anchor" href="#mod-perm-msg-2-renew-permission-vp" >§</a> [MOD-PERM-MSG-2] Renew Permission VP</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p><em>This section is non-normative.</em></p>
 <ul>
 <li>Requesting a renewal has no effect on permission expiration or issued credentials.</li>
 <li>Renewal is only possible with the same validator.</li>
 <li>If validator permission is not valid anymore, applicant MUST perform a new validation process with another validator.</li>
 <li>Renewal does not allow changing the <code>perm.validation_fees</code>, <code>perm.issuance_fees</code>, <code>perm.verification_fees</code>. To change these values, applicant MUST start a new validation process.</li>
+<li>if permission is revoked, slashed, or repaid, method MUST fail.</li>
 </ul>
 <h5 id="mod-perm-msg-2-1-renew-permission-vp-parameters"><a class="toc-anchor" href="#mod-perm-msg-2-1-renew-permission-vp-parameters" >§</a> [MOD-PERM-MSG-2-1] Renew Permission VP parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uint64) (<em>mandatory</em>): id of the permission for which applicant would like to renew the validation process;</li>
 </ul>
 <h5 id="mod-perm-msg-2-2-renew-permission-vp-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-2-2-renew-permission-vp-precondition-checks" >§</a> [MOD-PERM-MSG-2-2] Renew Permission VP precondition checks</h5>
@@ -2623,13 +2799,14 @@ as a direct consequence of executing authorized messages.</li>
 <h6 id="mod-perm-msg-2-2-1-renew-permission-vp-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-2-2-1-renew-permission-vp-basic-checks" >§</a> [MOD-PERM-MSG-2-2-1] Renew Permission VP basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>id</code> MUST be a valid uint64 and a permission entry with the same id MUST exist.</li>
 </ul>
 <h6 id="mod-perm-msg-2-2-2-renew-permission-vp-permission-checks"><a class="toc-anchor" href="#mod-perm-msg-2-2-2-renew-permission-vp-permission-checks" >§</a> [MOD-PERM-MSG-2-2-2] Renew Permission VP permission checks</h6>
 <ul>
-<li>Load <code>Permission</code> entry <code>applicant_perm</code>. <code>authority</code> running the operation MUST be <code>applicant_perm.authority</code>, else MUST abort. <code>applicant_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a>.</li>
+<li>Load <code>Permission</code> entry <code>applicant_perm</code>. <code>corporation</code> running the operation MUST be <code>applicant_perm.corporation</code>, else MUST abort. <code>applicant_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a>.</li>
 <li>Load <code>Permission</code> entry <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>. It MUST exist, and be a <a class="term-reference" href="#term:active-permission">active permission</a>, else MUST abort.</li>
 </ul>
 <h6 id="mod-perm-msg-2-2-3-renew-permission-vp-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-2-2-3-renew-permission-vp-fee-checks" >§</a> [MOD-PERM-MSG-2-2-3] Renew Permission VP fee checks</h6>
@@ -2652,7 +2829,7 @@ as a direct consequence of executing authorized messages.</li>
 </ul>
 <p>if <code>(cs.pricing_asset_type, cs.pricing_asset)</code> is set to <code>(COIN, [[ref: native denom]])</code>:</p>
 <ul>
-<li><code>authority</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
+<li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
 <li>the required <code>validation_fees_in_denom</code> = <code>validator_perm.validation_fees</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: <code>validation_fees_in_denom</code> * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
@@ -2661,7 +2838,7 @@ as a direct consequence of executing authorized messages.</li>
 </ul>
 <p>else if <code>(cs.pricing_asset_type, cs.pricing_asset)</code> is set to <code>(TU, &quot;tu&quot;)</code>:</p>
 <ul>
-<li><code>authority</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
+<li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
 <li>the required <code>validation_fees_in_denom</code> = getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validator_perm.validation_fees</code>) in <a class="term-reference" href="#term:native-denom">native denom</a>;</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: <code>validation_fees_in_denom</code> * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
@@ -2670,7 +2847,7 @@ as a direct consequence of executing authorized messages.</li>
 </ul>
 <p>else if <code>(cs.pricing_asset_type, cs.pricing_asset)</code> is set to an arbitrary coin <code>(COIN, [[ref: denom]])</code>:</p>
 <ul>
-<li><code>authority</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
+<li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
 <li>the required <code>validation_fees_in_denom</code> = <code>validator_perm.validation_fees</code> in specified (cs.pricing_asset_type, cs.pricing_asset)</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validation_fees_in_denom</code>) * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
@@ -2679,14 +2856,14 @@ as a direct consequence of executing authorized messages.</li>
 </ul>
 <p>else if <code>(cs.pricing_asset_type, cs.pricing_asset)</code> is set to an arbitrary coin <code>(FIAT, [[ref: denom]])</code>:</p>
 <ul>
-<li><code>authority</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
+<li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
 <li>the required <code>validation_fees_in_denom</code> = 0 in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validator_perm.validation_fees</code>) * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 </li>
 </ul>
-<div id="note-12" class="notice note"><a class="notice-link" href="#note-12">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
+<div id="note-87" class="notice note"><a class="notice-link" href="#note-87">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
 <h6 id="mod-perm-msg-2-3-renew-permission-vp-execution"><a class="toc-anchor" href="#mod-perm-msg-2-3-renew-permission-vp-execution" >§</a> [MOD-PERM-MSG-2-3] Renew Permission VP execution</h6>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
@@ -2702,7 +2879,7 @@ as a direct consequence of executing authorized messages.</li>
 <p>calculate <code>validation_fees_in_denom</code> and <code>validation_trust_deposit_in_native_denom</code> as explained above in fee checks.</p>
 </li>
 <li>
-<p>use [MOD-TD-MSG-1] to increase by <code>validation_trust_deposit_in_native_denom</code> the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>authority</code> running the method and transfer the corresponding amount to <code>TrustDeposit</code> module.</p>
+<p>use [MOD-TD-MSG-1] to increase by <code>validation_trust_deposit_in_native_denom</code> the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>corporation</code> running the method and transfer the corresponding amount to <code>TrustDeposit</code> module.</p>
 </li>
 <li>
 <p>send <code>validation_fees_in_denom</code> to validation escrow <a class="term-reference" href="#term:account">account</a>, if greater than 0.</p>
@@ -2723,38 +2900,41 @@ as a direct consequence of executing authorized messages.</li>
 </li>
 </ul>
 <h4 id="mod-perm-msg-3-set-permission-vp-to-validated"><a class="toc-anchor" href="#mod-perm-msg-3-set-permission-vp-to-validated" >§</a> [MOD-PERM-MSG-3] Set Permission VP to Validated</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <h5 id="mod-perm-msg-3-1-set-permission-vp-to-validated-parameters"><a class="toc-anchor" href="#mod-perm-msg-3-1-set-permission-vp-to-validated-parameters" >§</a> [MOD-PERM-MSG-3-1] Set Permission VP to Validated parameters</h5>
 <p>An <a class="term-reference" href="#term:account">account</a> that would like to set a validation entry to VALIDATED MUST execute this method by specifying:</p>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uint64) (<em>mandatory</em>): id of the validation process;</li>
 <li><code>effective_until</code> (timestamp) (<em>optional</em>): timestamp until when (exclusive) this <code>Permission</code> is effective, null if no time limit should been set for this permission or if we want it to be aligned with the validation process expiration timestamp calculated by this method.</li>
 <li><code>validation_fees</code> (number) (<em>mandatory</em>): Agreed validation_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.</li>
 <li><code>issuance_fees</code> (number) (<em>mandatory</em>): Agreed issuance_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.</li>
 <li><code>verification_fees</code> (number) (<em>mandatory</em>): Agreed verification_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.</li>
-<li><code>vp_summary_digest_sri</code> (string) (<em>optional</em>): an optional digest SRI, set by <a class="term-reference" href="#term:validator">validator</a>, of a summary of the information, proofs… provided by the <a class="term-reference" href="#term:applicant">applicant</a>.</li>
-<li><code>issuance_fee_discount</code>: (number) (<em>mandatory</em>): use 0 for no discount. Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR mode) or an ISSUER permission (ECOSYSTEM mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
-<li><code>verification_fee_discount</code>: (number) (<em>mandatory</em>): use 0 for no discount. Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR mode) and/or a VERIFIER permission (ECOSYSTEM mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
+<li><code>vp_summary_digest</code> (string) (<em>optional</em>): an optional digest, set by <a class="term-reference" href="#term:validator">validator</a>, of a summary of the information, proofs… provided by the <a class="term-reference" href="#term:applicant">applicant</a>.</li>
+<li><code>issuance_fee_discount</code>: (number) (<em>mandatory</em>): use 0 for no discount. Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_VALIDATION_PROCESS mode) or an ISSUER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
+<li><code>verification_fee_discount</code>: (number) (<em>mandatory</em>): use 0 for no discount. Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_VALIDATION_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
 </ul>
 <h5 id="mod-perm-msg-3-2-set-permission-vp-to-validated-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-3-2-set-permission-vp-to-validated-precondition-checks" >§</a> [MOD-PERM-MSG-3-2] Set Permission VP to Validated precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <h6 id="mod-perm-msg-3-2-1-set-permission-vp-to-validated-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-3-2-1-set-permission-vp-to-validated-basic-checks" >§</a> [MOD-PERM-MSG-3-2-1] Set Permission VP to Validated basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li>
-<p><code>authority</code> (group): (Signer) signature must be verified.</p>
-</li>
-<li>
-<p><code>operator</code> (account): (Signer) signature must be verified.</p>
-</li>
-<li>
-<p><code>id</code> MUST be a valid uint64.</p>
-</li>
-<li>
-<p>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>. If no entry found, abort.</p>
-</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
+<li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><code>id</code> MUST be a valid uint64.</li>
+<li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>. If no entry found, abort.</li>
+<li>Load <code>Permission</code> entry <code>validator_perm</code> from <code>applicant_perm_validator_perm_id</code>.</li>
+<li>Authorization:</li>
+</ul>
+<p>either (executed by any operator of corporation):
+<a href="#authz-check-1-operator-authorization-checks" >[AUTHZ-CHECK-1]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) tuple and <code>SetPermissionVPtoValidated</code> message.
+<a href="#authz-check-2-fee-grant-checks" >[AUTHZ-CHECK-2]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) tuple and <code>SetPermissionVPtoValidated</code> message.
+OR (executed by vs-agent account defined in validator permission):
+<a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>validator_perm</code>) tuple.
+<a href="#authz-check-4-vs-operator-fee-grant-checks" >[AUTHZ-CHECK-4]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>validator_perm</code>) tuple.
+else MUST abort.</p>
+<ul>
 <li>
 <p><code>applicant_perm.vp_state</code> MUST be equal to PENDING, else abort.</p>
 </li>
@@ -2768,7 +2948,7 @@ as a direct consequence of executing authorized messages.</li>
 <p><code>verification_fees</code> (number) (<em>mandatory</em>): MUST be zero or a positive integer.  If <code>applicant_perm.effective_from</code> is not null (we are in renewal) <code>verification_fees</code> MUST be equal to <code>applicant_perm.verification_fees</code>, else abort.</p>
 </li>
 <li>
-<p><code>vp_summary_digest_sri</code> (string) (<em>optional</em>): MUST be null if <code>validation.type</code> is set to HOLDER (for HOLDER, proofs can be stored in credentials). Else, MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</p>
+<p><code>vp_summary_digest</code> (string) (<em>optional</em>): MUST be null if <code>validation.type</code> is set to HOLDER (for HOLDER, proofs can be stored in credentials). Else, MUST be a valid digest. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</p>
 </li>
 <li>
 <p>Load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_perm.schema_id</code>.</p>
@@ -2780,13 +2960,13 @@ as a direct consequence of executing authorized messages.</li>
 <p><code>issuance_fee_discount</code> : (number) (<em>mandatory</em>):</p>
 <ul>
 <li>if <code>applicant_perm.effective_from</code> is not null (renewal), then <code>issuance_fee_discount</code> must be equal to <code>applicant_perm.issuance_fee_discount</code> else MUST abort.</li>
-<li>if <code>cs.issuer_perm_management_mode</code> is set to GRANTOR:
+<li>if <code>cs.issuer_onboarding_mode</code> is set to GRANTOR_VALIDATION_PROCESS:
 <ul>
 <li>if <code>applicant_perm.type</code> == ISSUER_GRANTOR: <code>issuance_fee_discount</code> can be set between 0 (no discount) and 1 (100% discount) inclusive.</li>
 <li>if <code>applicant_perm.type</code> == ISSUER: if <code>validator_perm.issuance_fee_discount</code> is defined,  <code>issuance_fee_discount</code> can be set between 0 (no discount) and <code>validator_perm.issuance_fee_discount</code> (100% discount) inclusive.</li>
 </ul>
 </li>
-<li>if <code>cs.issuer_perm_management_mode</code> is set to ECOSYSTEM:
+<li>if <code>cs.issuer_onboarding_mode</code> is set to ECOSYSTEM_VALIDATION_PROCESS:
 <ul>
 <li>if <code>applicant_perm.type</code> == ISSUER: <code>issuance_fee_discount</code> can be set between 0 (no discount) and 1 (100% discount) inclusive.</li>
 </ul>
@@ -2798,13 +2978,13 @@ as a direct consequence of executing authorized messages.</li>
 <p><code>verification_fee_discount</code> : (number) (<em>mandatory</em>):</p>
 <ul>
 <li>if <code>applicant_perm.effective_from</code> is not null (renewal), then <code>verification_fee_discount</code> must be equal to <code>applicant_perm.verification_fee_discount</code> else MUST abort.</li>
-<li>if <code>cs.verifier_perm_management_mode</code> is set to GRANTOR:
+<li>if <code>cs.verifier_onboarding_mode</code> is set to GRANTOR_VALIDATION_PROCESS:
 <ul>
 <li>if <code>applicant_perm.type</code> == VERIFIER_GRANTOR: <code>verification_fee_discount</code> can be set between 0 (no discount) and 1 (100% discount) inclusive.</li>
 <li>if <code>applicant_perm.type</code> == VERIFIER: if <code>validator_perm.verification_fee_discount</code> is defined,  <code>verification_fee_discount</code> can be set between 0 (no discount) and <code>validator_perm.verification_fee_discount</code> (100% discount) inclusive.</li>
 </ul>
 </li>
-<li>if <code>cs.verifier_perm_management_mode</code> is set to ECOSYSTEM:
+<li>if <code>cs.verifier_onboarding_mode</code> is set to ECOSYSTEM_VALIDATION_PROCESS:
 <ul>
 <li>if <code>applicant_perm.type</code> == VERIFIER: <code>verification_fee_discount</code> can be set between 0 (no discount) and 1 (100% discount) inclusive.</li>
 </ul>
@@ -2837,17 +3017,17 @@ as a direct consequence of executing authorized messages.</li>
 <h6 id="mod-perm-msg-3-2-2-set-permission-vp-to-validated-validator-perms"><a class="toc-anchor" href="#mod-perm-msg-3-2-2-set-permission-vp-to-validated-validator-perms" >§</a> [MOD-PERM-MSG-3-2-2] Set Permission VP to Validated validator perms</h6>
 <ul>
 <li>load <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>. <code>validator_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a>.</li>
-<li><code>authority</code> running the method MUST be <code>validator_perm.authority</code>.</li>
+<li><code>corporation</code> running the method MUST be <code>validator_perm.corporation</code>.</li>
 </ul>
 <p>If <code>validator_perm</code> is not a <a class="term-reference" href="#term:active-permission">active permission</a> (expired, revoked, slashed…) then applicant MUST start a new validation process.</p>
 <h6 id="mod-perm-msg-3-2-3-set-permission-vp-to-validated-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-3-2-3-set-permission-vp-to-validated-fee-checks" >§</a> [MOD-PERM-MSG-3-2-3] Set Permission VP to Validated fee checks</h6>
 <ul>
 <li>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</li>
-<li>if <code>applicant_perm.vp_current_fees</code> is not in <a class="term-reference" href="#term:native-denom">native denom</a>, <code>authority</code> account MUST have <code>applicant_perm.vp_current_deposit</code> available in <a class="term-reference" href="#term:native-denom">native denom</a> on its account for paying the trust deposit.</li>
+<li>if <code>applicant_perm.vp_current_fees</code> is not in <a class="term-reference" href="#term:native-denom">native denom</a>, <code>corporation</code> account MUST have <code>applicant_perm.vp_current_deposit</code> available in <a class="term-reference" href="#term:native-denom">native denom</a> on its account for paying the trust deposit.</li>
 </ul>
 <h6 id="mod-perm-msg-3-2-4-set-permission-vp-to-validated-overlap-checks"><a class="toc-anchor" href="#mod-perm-msg-3-2-4-set-permission-vp-to-validated-overlap-checks" >§</a> [MOD-PERM-MSG-3-2-4] Set Permission VP to Validated overlap checks</h6>
 <p>We want to make sure that 2 permissions cannot be active at the same time for the same <code>validator_perm_id</code>. That should not occur in this method, but better do the check anyway.</p>
-<p>Find all <a class="term-reference" href="#term:active-permissions">active permissions</a> <code>perms[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, <code>type</code>, <code>validator_perm_id</code>, <code>authority</code>.</p>
+<p>Find all <a class="term-reference" href="#term:active-permissions">active permissions</a> <code>perms[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, <code>type</code>, <code>validator_perm_id</code>, <code>corporation</code>.</p>
 <p>for each <code>Permission</code> entry <code>p</code> from <code>perms[]</code>:</p>
 <ul>
 <li>if <code>p.effective_until</code> is greater than <code>effective_from</code>, method execution MUST abort.</li>
@@ -2908,11 +3088,11 @@ as a direct consequence of executing authorized messages.</li>
 </ul>
 <p>Fees and Trust Deposits:</p>
 <ul>
-<li>transfer the full amount <code>applicant_perm.vp_current_fees</code> in the proper <a class="term-reference" href="#term:denom">denom</a> from escrow <a class="term-reference" href="#term:account">account</a> to validator <code>authority</code> <a class="term-reference" href="#term:account">account</a> <code>validator_perm.authority</code>;</li>
-<li>Increase validator perm trust deposit: use [MOD-TD-MSG-1] to increase by <code>applicant_perm.vp_current_deposit</code> the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>authority</code> running the method and transfer the corresponding amount to <code>TrustDeposit</code> module. Set <code>applicant_perm.vp_validator_deposit</code> to <code>applicant_perm.vp_validator_deposit</code> + <code>applicant_perm.vp_current_deposit</code>.</li>
+<li>transfer the full amount <code>applicant_perm.vp_current_fees</code> in the proper <a class="term-reference" href="#term:denom">denom</a> from escrow <a class="term-reference" href="#term:account">account</a> to validator <code>corporation</code> <a class="term-reference" href="#term:account">account</a> <code>validator_perm.corporation</code>;</li>
+<li>Increase validator perm trust deposit: use [MOD-TD-MSG-1] to increase by <code>applicant_perm.vp_current_deposit</code> the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>corporation</code> running the method and transfer the corresponding amount to <code>TrustDeposit</code> module. Set <code>applicant_perm.vp_validator_deposit</code> to <code>applicant_perm.vp_validator_deposit</code> + <code>applicant_perm.vp_current_deposit</code>.</li>
 </ul>
 <blockquote>
-<p>Important: if <code>applicant_perm.vp_current_fees</code> is not in <a class="term-reference" href="#term:native-denom">native denom</a>, <code>authority</code> account MUST have <code>applicant_perm.vp_current_deposit</code> available for paying the trust deposit.</p>
+<p>Important: if <code>applicant_perm.vp_current_fees</code> is not in <a class="term-reference" href="#term:native-denom">native denom</a>, <code>corporation</code> account MUST have <code>applicant_perm.vp_current_deposit</code> available for paying the trust deposit.</p>
 </blockquote>
 <p>Update <code>Permission</code> <code>applicant_perm</code>:</p>
 <ul>
@@ -2921,7 +3101,7 @@ as a direct consequence of executing authorized messages.</li>
 <li>set <code>applicant_perm.vp_last_state_change</code> to <code>now</code>.</li>
 <li>set <code>applicant_perm.vp_current_fees</code> to 0;</li>
 <li>set <code>applicant_perm.vp_current_deposit</code> to 0;</li>
-<li>set <code>applicant_perm.vp_summary_digest_sri</code> to <code>vp_summary_digest_sri</code>.</li>
+<li>set <code>applicant_perm.vp_summary_digest</code> to <code>vp_summary_digest</code>.</li>
 <li>set <code>applicant_perm.vp_exp</code> to <code>vp_exp</code>.</li>
 <li>set <code>applicant_perm.effective_until</code> to <code>effective_until</code>.</li>
 <li>if <code>applicant_perm.effective_from</code> IS NULL (first time method is called for this perm, and thus we are not in a renewal):
@@ -2935,19 +3115,21 @@ as a direct consequence of executing authorized messages.</li>
 </ul>
 </li>
 </ul>
-<p>If <code>applicant_perm.type</code> is ISSUER or VERIFIER: Create authorization for <code>applicant_perm.vs_operator</code> so that the Verifiable Service will be able to call CreateOrUpdatePermissionSession when issuing or verifying credentials:</p>
+<p>Activate VS Operator Authorization, if any. Call <a href="#mod-de-msg-9-update-vs-operator-authorization-expiration" >[MOD-DE-MSG-9]</a> Update VS Operator Authorization Expiration with:</p>
 <ul>
-<li>if <code>applicant_perm.vs_operator_authz_enabled</code> == true: call <strong>Grant VS Operator Authorization(<code>applicant_perm.id</code>)</strong>.</li>
+<li><code>perm_id</code>: <code>applicant_perm.id</code></li>
+<li><code>new_expiration</code>: <code>applicant_perm.effective_until</code></li>
 </ul>
+<p>This call is a no-op if no record was created at <a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a> (i.e., the applicant did not declare <code>vs_operator_authz_msg_types</code>). If a record exists, its <code>expiration</code> is updated from <code>now</code> (disabled) to <code>applicant_perm.effective_until</code>, and the on-chain <code>FeeGrant</code> for the containing VSOA is granted for the first time (or refreshed) via <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a>.</p>
 <h4 id="mod-perm-msg-4-void"><a class="toc-anchor" href="#mod-perm-msg-4-void" >§</a> [MOD-PERM-MSG-4] Void</h4>
 <h4 id="mod-perm-msg-5-void"><a class="toc-anchor" href="#mod-perm-msg-5-void" >§</a> [MOD-PERM-MSG-5] Void</h4>
 <h4 id="mod-perm-msg-6-cancel-permission-vp-last-request"><a class="toc-anchor" href="#mod-perm-msg-6-cancel-permission-vp-last-request" >§</a> [MOD-PERM-MSG-6] Cancel Permission VP Last Request</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>At any time, <a class="term-reference" href="#term:applicant">applicant</a> of a permission validation process may request cancellation of the process, provided state is PENDING. Upon method execution, the pending validation is cancelled and escrewed <a class="term-reference" href="#term:trust-fees">trust fees</a> are refunded. If <code>vp_exp</code> is not null, <code>vp_state</code> is set back to VALIDATED, else <code>vp_state</code> is set to TERMINATED.</p>
 <h5 id="mod-perm-msg-6-1-cancel-permission-vp-last-request-parameters"><a class="toc-anchor" href="#mod-perm-msg-6-1-cancel-permission-vp-last-request-parameters" >§</a> [MOD-PERM-MSG-6-1] Cancel Permission VP Last Request parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uint64) (<em>mandatory</em>): id of the <code>Permission</code> entry;</li>
 </ul>
 <h5 id="mod-perm-msg-6-2-cancel-permission-vp-last-request-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-6-2-cancel-permission-vp-last-request-precondition-checks" >§</a> [MOD-PERM-MSG-6-2] Cancel Permission VP Last Request precondition checks</h5>
@@ -2955,11 +3137,12 @@ as a direct consequence of executing authorized messages.</li>
 <h6 id="mod-perm-msg-6-2-1-cancel-permission-vp-last-request-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-6-2-1-cancel-permission-vp-last-request-basic-checks" >§</a> [MOD-PERM-MSG-6-2-1] Cancel Permission VP Last Request basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>id</code> MUST be a valid uint64.</li>
 <li>Load <code>Permission</code> entry <code>applicant_perm</code> with this id. It MUST exist.</li>
-<li><code>authority</code> running the <a class="term-reference" href="#term:transaction">transaction</a> MUST be <code>applicant_perm.authority</code>.</li>
+<li><code>corporation</code> running the <a class="term-reference" href="#term:transaction">transaction</a> MUST be <code>applicant_perm.corporation</code>.</li>
 <li><code>applicant_perm.vp_state</code> MUST be PENDING.</li>
 <li>if <code>applicant_perm.deposit</code> has been slashed and not repaid, MUST abort</li>
 </ul>
@@ -2987,27 +3170,29 @@ as a direct consequence of executing authorized messages.</li>
 <li>
 <p>if <code>applicant_perm.vp_current_fees</code> &gt; 0:</p>
 <ul>
-<li>transfer <code>applicant_perm.vp_current_fees</code> in proper <a class="term-reference" href="#term:denom">denom</a> back from escrow <a class="term-reference" href="#term:account">account</a> to <a class="term-reference" href="#term:applicant">applicant</a> <a class="term-reference" href="#term:account">account</a>, <code>applicant_perm.authority</code>.</li>
+<li>transfer <code>applicant_perm.vp_current_fees</code> in proper <a class="term-reference" href="#term:denom">denom</a> back from escrow <a class="term-reference" href="#term:account">account</a> to <a class="term-reference" href="#term:applicant">applicant</a> <a class="term-reference" href="#term:account">account</a>, <code>applicant_perm.corporation</code>.</li>
 <li>set <code>applicant_perm.vp_current_fees</code> to 0;</li>
 </ul>
 </li>
 <li>
 <p>if <code>applicant_perm.vp_current_deposit</code> &gt; 0:</p>
 <ul>
-<li>call [MOD-TD-MSG-1] to reduce trust deposit of <code>applicant_perm.authority</code> by <code>applicant_perm.vp_current_deposit</code></li>
+<li>call [MOD-TD-MSG-1] to reduce trust deposit of <code>applicant_perm.corporation</code> by <code>applicant_perm.vp_current_deposit</code></li>
 <li>set <code>applicant_perm.vp_current_deposit</code> to 0.</li>
 </ul>
 </li>
 </ul>
+<p>If <code>applicant_perm.vp_state</code> was set to TERMINATED (i.e. <code>applicant_perm.vp_exp</code> was null so validation never completed), call <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a> Revoke VS Operator Authorization with <code>perm_id = applicant_perm.id</code> to remove any disabled authorization record created at <a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a>. The call is a no-op if no record exists. If <code>applicant_perm.vp_state</code> was set back to VALIDATED, no VSOA changes are needed (the existing record’s <code>expiration</code> remains at the value set by the previous successful validation).</p>
 <h4 id="mod-perm-msg-7-create-root-permission"><a class="toc-anchor" href="#mod-perm-msg-7-create-root-permission" >§</a> [MOD-PERM-MSG-7] Create Root Permission</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This method is used by controller authorities of Trust Registries. When they create a Credential Schema, they need to create (a) permission(s) of type ECOSYSTEM so that other participants can run validation processes (if schema mode is ECOSYSTEM) or self create their permissions (schema mode set to OPEN).</p>
 <h5 id="mod-perm-msg-7-1-create-root-permission-parameters"><a class="toc-anchor" href="#mod-perm-msg-7-1-create-root-permission-parameters" >§</a> [MOD-PERM-MSG-7-1] Create Root Permission parameters</h5>
 <p>An <a class="term-reference" href="#term:account">account</a> that would like to create a <code>Permission</code> entry MUST call this method by specifying:</p>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>schema_id</code> (uint64) (<em>mandatory</em>)</li>
+<li><code>vs_operator</code> (account) (<em>optional</em>): the account we want to authorize to act on behalf of <code>corporation</code> in the context of this permission. <strong>Required</strong> for payment delegation.</li>
 <li><code>did</code> (string) (<em>mandatory</em>): <a class="term-reference" href="#term:did">DID</a> of the VS.</li>
 <li><code>effective_from</code> (timestamp) (<em>mandatory</em>): timestamp from when (exclusive) this Perm is effective. MUST be in the future.</li>
 <li><code>effective_until</code> (timestamp) (<em>optional</em>): timestamp until when (exclusive) this Perm is effective, null if it doesn’t expire. If not null, MUST be greater than <code>effective_from</code>.</li>
@@ -3015,13 +3200,37 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>issuance_fees</code> (number) (<em>mandatory</em>): price to pay by the issuer of a credential of this schema to the grantee of this perm when a credential is issued, in the denom specified in the credential schema. Default to 0.</li>
 <li><code>verification_fees</code> (number) (<em>mandatory</em>): price to pay by the verifier of a credential of this schema to the grantee of this perm when a credential is verified, in the denom specified in the credential schema. Default to 0.</li>
 </ul>
+<p>The following VS Operator Authorization parameters are <strong>optional</strong> and collectively define the initial <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> for this permission. Presence of <code>vs_operator_authz_msg_types</code> is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is <strong>frozen at creation time</strong> and cannot be modified later; to change it, the permission MUST be revoked and re-created.</p>
+<ul>
+<li><code>vs_operator_authz_msg_types[]</code> (msg_type[]) (<em>optional</em>): list of VPR delegable message types <code>vs_operator</code> is authorized to execute on behalf of <code>corporation</code> in the context of this permission. If provided, a <code>PermissionAuthorizationRecord</code> is created (see execution below) and <code>vs_operator</code> MUST be specified. The permitted list of message types is provided below.</li>
+<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds <code>vs_operator</code> is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.</li>
+<li><code>vs_operator_authz_with_feegrant</code> (bool) (<em>optional</em>, default: false): if true, <code>corporation</code> pays transaction fees for <code>vs_operator</code> via an on-chain <code>FeeGrant</code> when executing authorized messages in the context of this permission.</li>
+<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of transaction fees that can be spent by <code>vs_operator</code> (paid by <code>corporation</code> via fee grant) in the context of this permission.</li>
+<li><code>vs_operator_authz_period</code> (duration) (<em>optional</em>): reset period for <code>vs_operator_authz_spend_limit</code> and <code>vs_operator_authz_fee_spend_limit</code> in the context of this permission.</li>
+</ul>
+<p>Permitted message types to be set in <code>vs_operator_authz_msg_types</code> depends on <code>type</code>. Since <a href="#mod-perm-msg-7-create-root-permission" >Create Root Permission</a> always creates an ECOSYSTEM permission, only the following is allowed:</p>
+<table>
+<thead>
+<tr>
+<th>Permission type</th>
+<th>Permitted Messages</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>ECOSYSTEM</td>
+<td>SetPermissionVPtoValidated</td>
+</tr>
+</tbody>
+</table>
 <h5 id="mod-perm-msg-7-2-create-root-permission-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-7-2-create-root-permission-precondition-checks" >§</a> [MOD-PERM-MSG-7-2] Create Root Permission precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <h6 id="mod-perm-msg-7-2-1-create-root-permission-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-7-2-1-create-root-permission-basic-checks" >§</a> [MOD-PERM-MSG-7-2-1] Create Root Permission basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>schema_id</code> MUST be a valid uint64 and a <a class="term-reference" href="#term:credential-schema">credential schema</a> entry with this id MUST exist.</li>
 <li><code>did</code>, if specified, MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
 <li><code>effective_from</code> must be in the future.</li>
@@ -3029,20 +3238,21 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>validation_fees</code> (number) (<em>mandatory</em>): MUST be &gt;= 0.</li>
 <li><code>issuance_fees</code> (number) (<em>mandatory</em>): MUST be &gt;= 0.</li>
 <li><code>verification_fees</code> (number) (<em>mandatory</em>): MUST be &gt;= 0.</li>
+<li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-perm-msg-7-1-create-root-permission-parameters" >MOD-PERM-MSG-7-1</a>.</li>
 </ul>
 <h6 id="mod-perm-msg-7-2-2-create-root-permission-permission-checks"><a class="toc-anchor" href="#mod-perm-msg-7-2-2-create-root-permission-permission-checks" >§</a> [MOD-PERM-MSG-7-2-2] Create Root Permission permission checks</h6>
 <p>To execute this method, <a class="term-reference" href="#term:account">account</a> MUST match at least one these rules, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li>The related <code>CredentialSchema</code> entry is loaded with <code>schema_id</code>, and will be named <code>cs</code> in this section.</li>
 <li>The related <code>TrustRegistry</code> entry <code>tr</code> is loaded from <code>cs.tr_id</code>.</li>
-<li><code>authority</code> executing the method MUST be <code>tr.authority</code>.</li>
+<li><code>corporation</code> executing the method MUST be <code>tr.corporation</code>.</li>
 <li>else MUST abort.</li>
 </ul>
 <h6 id="mod-perm-msg-7-2-3-create-root-permission-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-7-2-3-create-root-permission-fee-checks" >§</a> [MOD-PERM-MSG-7-2-3] Create Root Permission fee checks</h6>
 <p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> available.</p>
 <h6 id="mod-perm-msg-7-2-4-create-root-permission-overlap-checks"><a class="toc-anchor" href="#mod-perm-msg-7-2-4-create-root-permission-overlap-checks" >§</a> [MOD-PERM-MSG-7-2-4] Create Root Permission overlap checks</h6>
-<p>We want to make sure that 2 permissions cannot be active at the same time. If <code>authority</code> wishes to create a new permission but existing active one never expires (or expire too far from now), <code>authority</code> MUST use first the <a href="#mod-perm-msg-8-adjust-permission" >Extend Perm Msg</a> to set or adjust the <code>effective_until</code> value.</p>
-<p>Find all <a class="term-reference" href="#term:active-permissions">active permissions</a> <code>perms[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, ECOSYSTEM,  <code>authority</code>.</p>
+<p>We want to make sure that 2 permissions cannot be active at the same time. If <code>corporation</code> wishes to create a new permission but existing active one never expires (or expire too far from now), <code>corporation</code> MUST use first the <a href="#mod-perm-msg-8-adjust-permission" >Extend Perm Msg</a> to set or adjust the <code>effective_until</code> value.</p>
+<p>Find all <a class="term-reference" href="#term:active-permissions">active permissions</a> <code>perms[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, ECOSYSTEM,  <code>corporation</code>.</p>
 <blockquote>
 <p>Note: unlike overlap checks from other methods, here we do not need to check for <code>validator_perm_id</code>, as for ECOSYSTEM type permissions it is NULL.</p>
 </blockquote>
@@ -3068,7 +3278,8 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>perm.modified</code> to <code>now</code>.</li>
 <li><code>perm.type</code>: ECOSYSTEM.</li>
 <li><code>perm.did</code>: <code>did</code>.</li>
-<li><code>perm.authority</code>: <code>authority</code>.</li>
+<li><code>perm.corporation</code>: <code>corporation</code>.</li>
+<li><code>perm.vs_operator</code>: <code>vs_operator</code>.</li>
 <li><code>perm.created</code>: <code>now</code></li>
 <li><code>perm.effective_from</code>: <code>effective_from</code></li>
 <li><code>perm.effective_until</code>: <code>effective_until</code></li>
@@ -3077,18 +3288,37 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>perm.verification_fees</code>: <code>verification_fees</code></li>
 <li><code>perm.deposit</code>: 0</li>
 </ul>
+<p>If <code>vs_operator_authz_msg_types</code> is provided, create the <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> in <strong>active</strong> state by calling <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a> Grant VS Operator Authorization with:</p>
+<ul>
+<li><code>corporation</code>: <code>corporation</code></li>
+<li><code>vs_operator</code>: <code>vs_operator</code></li>
+<li><code>record</code>:
+<ul>
+<li><code>record.perm_id</code>: <code>perm.id</code></li>
+<li><code>record.msg_types</code>: <code>vs_operator_authz_msg_types</code></li>
+<li><code>record.spend_limit</code>: <code>vs_operator_authz_spend_limit</code></li>
+<li><code>record.fee_spend_limit</code>: <code>vs_operator_authz_fee_spend_limit</code></li>
+<li><code>record.with_feegrant</code>: <code>vs_operator_authz_with_feegrant</code> (default: false)</li>
+<li><code>record.expiration</code>: <code>perm.effective_until</code></li>
+<li><code>record.period</code>: <code>vs_operator_authz_period</code></li>
+</ul>
+</li>
+</ul>
+<blockquote>
+<p>Note: like <a href="#mod-perm-msg-14-self-create-permission" >[MOD-PERM-MSG-14]</a>, the record is created with <code>expiration = perm.effective_until</code> and is therefore immediately active. If <code>with_feegrant</code> is true and <code>perm.effective_until &gt; now</code>, <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a> grants the on-chain <code>FeeGrant</code> as part of this execution.</p>
+</blockquote>
 <h4 id="mod-perm-msg-8-adjust-permission"><a class="toc-anchor" href="#mod-perm-msg-8-adjust-permission" >§</a> [MOD-PERM-MSG-8] Adjust Permission</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This method can be called:</p>
 <ul>
-<li>by <code>perm.authority</code>, if permission is of type ECOSYSTEM.</li>
-<li>by <code>perm.authority</code>, if it is a self-created permission (schema configuration is open)</li>
-<li>by an <code>authority</code> of a validator permission (if permission is managed by a VP).</li>
+<li>by <code>perm.corporation</code>, if permission is of type ECOSYSTEM.</li>
+<li>by <code>perm.corporation</code>, if it is a self-created permission (schema configuration is open)</li>
+<li>by a <code>corporation</code> of a validator permission (if permission is managed by a VP).</li>
 </ul>
 <h5 id="mod-perm-msg-8-1-adjust-permission-parameters"><a class="toc-anchor" href="#mod-perm-msg-8-1-adjust-permission-parameters" >§</a> [MOD-PERM-MSG-8-1] Adjust Permission parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uint64) (<em>mandatory</em>): id of the permission;</li>
 <li><code>effective_until</code> (timestamp) (<em>mandatory</em>): timestamp until when (exclusive) this <code>Permission</code> will be effective.</li>
 </ul>
@@ -3097,8 +3327,9 @@ as a direct consequence of executing authorized messages.</li>
 <h6 id="mod-perm-msg-8-2-1-adjust-permission-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-8-2-1-adjust-permission-basic-checks" >§</a> [MOD-PERM-MSG-8-2-1] Adjust Permission basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>id</code> MUST be a valid uint64.</li>
 <li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>. If no entry found, abort.</li>
 <li><code>applicant_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a></li>
@@ -3113,26 +3344,26 @@ as a direct consequence of executing authorized messages.</li>
 <li>ECOSYSTEM permissions</li>
 </ol>
 <ul>
-<li>if <code>applicant_perm.validator_perm_id</code> is null and <code>applicant_perm.type</code> is ECOSYSTEM, <code>authority</code> running the method MUST be <code>applicant_perm.authority</code>.</li>
+<li>if <code>applicant_perm.validator_perm_id</code> is null and <code>applicant_perm.type</code> is ECOSYSTEM, <code>corporation</code> running the method MUST be <code>applicant_perm.corporation</code>.</li>
 </ul>
 <ol start="2">
 <li>Self-created permissions</li>
 </ol>
 <ul>
-<li>load <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>. <code>validator_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a> of type ECOSYSTEM. <code>authority</code> running the method MUST be <code>applicant_perm.authority</code>.</li>
+<li>load <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>. <code>validator_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a> of type ECOSYSTEM. <code>corporation</code> running the method MUST be <code>applicant_perm.corporation</code>.</li>
 </ul>
 <ol start="3">
 <li>VP managed permissions</li>
 </ol>
 <ul>
 <li><code>effective_until</code> MUST be lower or equal to <code>applicant_perm.vp_exp</code> else MUST abort.</li>
-<li>load <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>. <code>validator_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a>. <code>authority</code> running the method MUST be <code>validator_perm.authority</code>.</li>
+<li>load <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>. <code>validator_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a>. <code>corporation</code> running the method MUST be <code>validator_perm.corporation</code>.</li>
 </ul>
 <h6 id="mod-perm-msg-8-2-3-adjust-permission-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-8-2-3-adjust-permission-fee-checks" >§</a> [MOD-PERM-MSG-8-2-3] Adjust Permission fee checks</h6>
 <p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <h6 id="mod-perm-msg-8-2-4-adjust-permission-overlap-checks"><a class="toc-anchor" href="#mod-perm-msg-8-2-4-adjust-permission-overlap-checks" >§</a> [MOD-PERM-MSG-8-2-4] Adjust Permission overlap checks</h6>
-<p>We want to make sure that 2 permissions cannot be active at the same time for the same <code>validator_perm_id</code>. If <code>authority</code> wishes to create a new permission but existing active one never expires (or expire too far from now), <code>authority</code> MUST use first the <a href="#mod-perm-msg-8-adjust-permission" >Extend Perm Msg</a> to set or adjust the <code>effective_until</code> value.</p>
-<p>Find all <a class="term-reference" href="#term:active-permissions">active permissions</a> <code>perms[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, <code>type</code>, <code>validator_perm_id</code>, <code>authority</code>.</p>
+<p>We want to make sure that 2 permissions cannot be active at the same time for the same <code>validator_perm_id</code>. If <code>corporation</code> wishes to create a new permission but existing active one never expires (or expire too far from now), <code>corporation</code> MUST use first the <a href="#mod-perm-msg-8-adjust-permission" >Extend Perm Msg</a> to set or adjust the <code>effective_until</code> value.</p>
+<p>Find all <a class="term-reference" href="#term:active-permissions">active permissions</a> <code>perms[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, <code>type</code>, <code>validator_perm_id</code>, <code>corporation</code>.</p>
 <p>for each <code>Permission</code> entry <code>p</code> from <code>perms[]</code>:</p>
 <ul>
 <li>if <code>p.effective_until</code> is greater than <code>effective_from</code>, method execution MUST abort.</li>
@@ -3162,22 +3393,24 @@ as a direct consequence of executing authorized messages.</li>
 <p>set <code>applicant_perm.modified</code> to <code>now</code></p>
 </li>
 </ul>
-<p>If <code>applicant_perm.type</code> is ISSUER or VERIFIER: Update authorization for <code>applicant_perm.vs_operator</code> so that the Verifiable Service will be able to call CreateOrUpdatePermissionSession when issuing or verifying credentials:</p>
+<p>Synchronise VS Operator Authorization expiration, if any. Call <a href="#mod-de-msg-9-update-vs-operator-authorization-expiration" >[MOD-DE-MSG-9]</a> Update VS Operator Authorization Expiration with:</p>
 <ul>
-<li>if <code>applicant_perm.vs_operator_authz_enabled</code> == true: call <strong>Grant VS Operator Authorization(<code>applicant_perm.id</code>)</strong>.</li>
+<li><code>perm_id</code>: <code>applicant_perm.id</code></li>
+<li><code>new_expiration</code>: <code>applicant_perm.effective_until</code></li>
 </ul>
+<p>This call is a no-op if no record exists for <code>applicant_perm.id</code>. If a record exists, its <code>expiration</code> is updated and the on-chain <code>FeeGrant</code> for the containing VSOA is refreshed via <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a>. Adjust Permission does <strong>not</strong> accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see <a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a> and <a href="#mod-perm-msg-14-self-create-permission" >[MOD-PERM-MSG-14]</a>). Adjust also cannot create a record that does not already exist.</p>
 <h4 id="mod-perm-msg-9-revoke-permission"><a class="toc-anchor" href="#mod-perm-msg-9-revoke-permission" >§</a> [MOD-PERM-MSG-9] Revoke Permission</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This method can only be called:</p>
 <ul>
-<li>by an ancestor (<code>authority</code> of a validator in the permission branch until the root permission (GRANTOR, ECOSYSTEM, OPEN schema mode)).</li>
-<li>by the grantee <code>authority</code> (OPEN, GRANTOR, ECOSYSTEM schema mode).</li>
-<li>by the <code>TrustRegistry</code> <code>authority</code> (owner of the credential schema).</li>
+<li>by an ancestor (<code>corporation</code> of a validator in the permission branch until the root permission (GRANTOR, ECOSYSTEM, OPEN schema mode)).</li>
+<li>by the grantee <code>corporation</code> (OPEN, GRANTOR, ECOSYSTEM schema mode).</li>
+<li>by the <code>TrustRegistry</code> <code>corporation</code> (owner of the credential schema).</li>
 </ul>
 <h5 id="mod-perm-msg-9-1-revoke-permission-parameters"><a class="toc-anchor" href="#mod-perm-msg-9-1-revoke-permission-parameters" >§</a> [MOD-PERM-MSG-9-1] Revoke Permission parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uint64) (<em>mandatory</em>): id of the permission;</li>
 </ul>
 <h5 id="mod-perm-msg-9-2-revoke-permission-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-9-2-revoke-permission-precondition-checks" >§</a> [MOD-PERM-MSG-9-2] Revoke Permission precondition checks</h5>
@@ -3185,8 +3418,9 @@ as a direct consequence of executing authorized messages.</li>
 <h6 id="mod-perm-msg-9-2-1-revoke-permission-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-9-2-1-revoke-permission-basic-checks" >§</a> [MOD-PERM-MSG-9-2-1] Revoke Permission basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>id</code> MUST be a valid uint64.</li>
 <li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>. If no entry found, abort.</li>
 <li><code>applicant_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a></li>
@@ -3200,7 +3434,7 @@ as a direct consequence of executing authorized messages.</li>
 <li>while <code>validator_perm.validator_perm_id</code> is defined,
 <ul>
 <li>load <code>validator_perm</code> from <code>validator_perm.validator_perm_id</code>.</li>
-<li>if <code>validator_perm</code> is a <a class="term-reference" href="#term:active-permission">active permission</a> and <code>validator_perm.authority</code> is who is running the method, =&gt; return true.</li>
+<li>if <code>validator_perm</code> is a <a class="term-reference" href="#term:active-permission">active permission</a> and <code>validator_perm.corporation</code> is who is running the method, =&gt; return true.</li>
 </ul>
 </li>
 <li>end</li>
@@ -3210,10 +3444,10 @@ as a direct consequence of executing authorized messages.</li>
 <ul>
 <li>load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_perm.schema_id</code></li>
 <li>load <code>TrustRegistry</code> <code>tr</code> from <code>cs.tr_id</code></li>
-<li>if <code>authority</code> running the method is <code>tr.authority</code>, return true.</li>
+<li>if <code>corporation</code> running the method is <code>tr.corporation</code>, return true.</li>
 <li>else return false.</li>
 </ul>
-<p><em>Option #3</em>: executed by <code>applicant_perm.authority</code>: return true.</p>
+<p><em>Option #3</em>: executed by <code>applicant_perm.corporation</code>: return true.</p>
 <p>Example:</p>
 <p>In the following permission tree, “Verifier E” permission can be revoked:</p>
 <ul>
@@ -3242,68 +3476,71 @@ as a direct consequence of executing authorized messages.</li>
 <p>set <code>applicant_perm.modified</code> to <code>now</code></p>
 </li>
 </ul>
-<p>If <code>applicant_perm.type</code> is ISSUER or VERIFIER: Delete authorization for <code>applicant_perm.vs_operator</code>:</p>
-<ul>
-<li>call <strong>Revoke VS Operator Authorization(<code>applicant_perm.id</code>)</strong>.</li>
-</ul>
+<p>Call <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a> Revoke VS Operator Authorization with <code>perm_id = applicant_perm.id</code> to remove any authorization record for this permission. The call is a no-op if no record exists.</p>
 <h4 id="mod-perm-msg-10-create-or-update-permission-session"><a class="toc-anchor" href="#mod-perm-msg-10-create-or-update-permission-session" >§</a> [MOD-PERM-MSG-10] Create or Update Permission Session</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
-<p>Any credential exchange that requires issuer or verifier to pay fees implies the creation of a <code>PermissionSession</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
+<p>Any credential exchange that requires issuer or verifier to pay fees, register a digest_sri, or produce a proof implies the creation of a <code>PermissionSession</code>.</p>
 <p>If the peer wants to issue a credential, the <code>agent</code>, the Verifiable User Agent or Verifiable Service that receive the request MUST send to peer:</p>
 <ul>
 <li>a <code>uuid</code> for session identification;</li>
-<li>the <code>wallet_agent_perm_id</code> permission id of the agent wallet that will store the credential.</li>
+<li><em>optional</em>: the <code>agent_perm_id</code> permission id of the agent that will receive the credential, if peer is a <strong>Verifiable User Agent</strong>. it MUST NOT be set if peer is a <strong>Verifiable Service</strong>.</li>
+<li><em>optional</em>: the <code>wallet_agent_perm_id</code> permission id of the agent wallet that will store the credential. If this is the same software than the agent, then it should be equal to <code>agent_perm_id</code>. It MUST NOT be set if peer is a <strong>Verifiable Service</strong>.</li>
 </ul>
 <p>If the peer wants to verify a credential, agent must send to peer:</p>
 <ul>
 <li>a <code>uuid</code> for session identification;</li>
-<li>a map of compatible found credentials in available wallets for the requested schema_id: Map&lt;uint64: wallet_agent_perm_id, uint64[] issuer_perm_ids&gt;</li>
+<li><em>optional</em>: the <code>agent_perm_id</code> permission id of the agent that will receive the credential, if peer is a <strong>Verifiable User Agent</strong>. it MUST NOT be set if peer is a <strong>Verifiable Service</strong>.</li>
+<li><em>optional</em>: a map of compatible found credentials in available wallets for the requested schema_id: Map&lt;uint64[] issuer_perm_ids, uint64: wallet_agent_perm_id&gt;. wallet_agent_perm_id MUST NOT be set if peer is a <strong>Verifiable Service</strong>.</li>
 </ul>
+<p>In case peer is a <strong>Verifiable Service</strong> and illegaly set <code>agent_perm_id</code> and/or <code>wallet_agent_perm_id</code>, the other end MUST refuse the request.</p>
 <p><code>payer</code> MUST create a Permission Session using the above information, then, <code>agent</code> MUST check session has been created and is valid before accepting the action (receive and store issued credential, or accept a presentation request).</p>
-<img src="https://www.plantuml.com/plantuml/svg/VPB1QiCm38RlVWhHqmPBw76KCTfRmmuh2-jfK3HRRJGI9zXAixpzx3Hjkb5sjJzz_d_XfHTqqbQbyXfBWWg_uN4-XuwD50grr0vcgmDP-R3RzzKCq4FcVKi6L1CcMNE3Lc2smPvSOF89SN-GxUPjk3msuKQfKVEK92E-W0owI4eD74y0GJiouN764lQkhi3hWYe4Df2cQGJxkZsRakJvObgJeo01AGWyUS-rXRODOsZDSDXXMPBiC5RRDUIg7HirnewY478HNqUv26ubFhjFf7c8UK2ZXICvtlVNqGRZWIG_ZTp5EFVNpW4u2-lFBz9ogrfsSZEPN-rOOj_Nboc2fx7hjCHR5VA8_OEOW8HlSAq1jkC2OLYWMWP7-4G_" alt="uml diagram">
+<img src="https://www.plantuml.com/plantuml/svg/VPB1Ri8m44Jl_eeHfrPg4CSALHNSG3qK5JMdIcXhB-0gSI9x0ytVrmu1qWhr6FljoypAio3afIaB5JGLZ9A-yJYPu6YDx1LfgJn6ynqx-N3v-npnCr-FG07B41esK7MSjzhMv0IZ5RNi8pb0_1yaNxrrbuSwtYZLQvwohCUdMEAOIAbWqma8shE94ImLsFggHD1xBWdMO3mU9x2jchCfovulfWLxZXB8dX4u15ivD4qS8sUwmoCL1Sk6Ki5DpRxSMAFws4aKGqxJtqakWbk9p-uJQHvI7cXoEB2tstOOhJFkMDQdaRiKvtxex82piFhyOYstgYrFRilcLpihgU_hopL2uBxhTOctAgmJzWzY8X8Vmr03w_e5ebkWcaL7V4e_" alt="uml diagram">
 <p>See <a class="term-reference" href="#term:vt-spec">VT spec</a>.</p>
 <h5 id="mod-perm-msg-10-1-create-or-update-permission-session-parameters"><a class="toc-anchor" href="#mod-perm-msg-10-1-create-or-update-permission-session-parameters" >§</a> [MOD-PERM-MSG-10-1] Create or Update Permission Session parameters</h5>
 <p>An <a class="term-reference" href="#term:account">account</a> that would like to create or update a <code>PermissionSession</code> entry MUST send a Msg by specifying:</p>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uuid) (<em>mandatory</em>): id of the <code>PermissionSession</code>.</li>
 <li><code>issuer_perm_id</code> (uint64) (<em>optional</em>): the id of the perm of the issuer, if we are dealing with the issuance of a credential.</li>
 <li><code>verifier_perm_id</code> (uint64) (<em>optional</em>): the id of the perm of the verifier, if we are dealing with the verification of a credential.</li>
-<li><code>agent_perm_id</code> (uint64) (<em>mandatory</em>): the agent credential issuer permission id (extracted from the agent credential that agent has in its wallet) of the agent that received the request (credential offer for issuance, presentation request for verification).</li>
-<li><code>wallet_agent_perm_id</code> (uint64) (<em>mandatory</em>): the wallet credential issuer permission id of the agent where the credential will be or is stored. Can be the same perm than <code>agent_perm_id</code> if agent and wallet_agent are the same agent.</li>
-<li><code>digest_sri</code> (string) (<em>optional</em>): digestSRI derived from an issued or verified credential.</li>
+<li><code>agent_perm_id</code> (uint64) (<em>optional</em>): the agent credential issuer permission id (extracted from the agent credential that VUA has in its wallet) of the agent that received the request (credential offer for issuance, presentation request for verification). Only set by VUAs, MUST NOT be specified when peer is a VS.</li>
+<li><code>wallet_agent_perm_id</code> (uint64) (<em>optional</em>): the wallet credential issuer permission id of the VUA where the credential will be or is stored. Can be the same perm than <code>agent_perm_id</code> if agent and wallet_agent are the same agent. Only set by VUAs, MUST NOT be specified when peer is a VS.</li>
+<li><code>digest</code> (string) (<em>optional</em>): digest derived from an issued or verified credential.</li>
 </ul>
 <h5 id="mod-perm-msg-10-2-create-or-update-permission-session-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-10-2-create-or-update-permission-session-precondition-checks" >§</a> [MOD-PERM-MSG-10-2] Create or Update Permission Session precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
-<li><code>id</code> MUST be a valid uuid. If an entry <code>existing_entry</code> with <code>id</code> already exist, then  <code>existing_entry.authority</code> MUST be equal to <code>authority</code> AND <code>existing_entry.vs_operator</code> MUST be equal to <code>operator</code>, else abort.</li>
+<li><code>id</code> MUST be a valid uuid. If an entry <code>existing_entry</code> with <code>id</code> already exist, then  <code>existing_entry.corporation</code> MUST be equal to <code>corporation</code> AND <code>existing_entry.vs_operator</code> MUST be equal to <code>operator</code>, else abort.</li>
 </ul>
 <p>if <code>issuer_perm_id</code> is null AND <code>verifier_perm_id</code> is null, MUST abort.</p>
 <ul>
 <li>define <code>issuer_perm</code> as null.</li>
 <li>define <code>verifier_perm</code> as null.</li>
 </ul>
-<p>if <code>issuer_perm_id</code> is no null:</p>
+<p>if <code>issuer_perm_id</code> is not null:</p>
 <ul>
 <li>Load <code>issuer_perm</code> from <code>issuer_perm_id</code>.</li>
 <li>if <code>issuer_perm.type</code> is not ISSUER, abort.</li>
 <li>if <code>issuer_perm</code> is not a <a class="term-reference" href="#term:active-permission">active permission</a>, abort.</li>
 <li>if <code>issuer_perm.vs_operator</code> is not equal to <code>operator</code>, abort.</li>
-<li>if <code>issuer_perm.authority</code> is not equal to <code>authority</code>, abort.</li>
+<li>if <code>issuer_perm.corporation</code> is not equal to <code>corporation</code>, abort.</li>
 <li>if <code>digest_sri</code> is present but not a valid digest SRI, abort.</li>
 </ul>
-<p>if <code>verifier_perm_id</code> is no null:</p>
+<p>if <code>verifier_perm_id</code> is not null:</p>
 <ul>
 <li>Load <code>verifier_perm</code> from <code>verifier_perm_id</code>.</li>
 <li>if <code>verifier_perm.type</code> is not VERIFIER, abort.</li>
 <li>if <code>verifier_perm</code> is not a <a class="term-reference" href="#term:active-permission">active permission</a>, abort.</li>
 <li>if <code>verifier_perm.vs_operator</code> is not equal to <code>operator</code>, abort.</li>
-<li>if <code>verifier_perm.authority</code> is not equal to <code>authority</code>, abort.</li>
+<li>if <code>verifier_perm.corporation</code> is not equal to <code>corporation</code>, abort.</li>
 <li>if <code>digest_sri</code> is present but not a valid digest SRI, abort.</li>
 </ul>
+<p>Define the <strong>primary permission</strong> <code>perm</code>: if <code>verifier_perm</code> is not null, <code>perm</code> = <code>verifier_perm</code> (the caller is the <code>vs_operator</code> of the verifier). Else, <code>perm</code> = <code>issuer_perm</code> (the caller is the <code>vs_operator</code> of the issuer).</p>
+<p><a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>perm</code>) tuple.
+<a href="#authz-check-4-vs-operator-fee-grant-checks" >[AUTHZ-CHECK-4]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>perm</code>) tuple.</p>
 <p>agent:</p>
 <ul>
 <li>Load <code>agent_perm</code> from <code>agent_perm_id</code>.</li>
@@ -3316,14 +3553,14 @@ as a direct consequence of executing authorized messages.</li>
 <li>if <code>wallet_agent_perm.type</code> is not ISSUER, abort.</li>
 <li>if <code>wallet_agent_perm</code> is not a <a class="term-reference" href="#term:active-permission">active permission</a>, abort.</li>
 </ul>
-<div id="warning-2" class="notice warning"><a class="notice-link" href="#warning-2">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a permission that is not controlled by its owner.</p>
+<div id="warning-47" class="notice warning"><a class="notice-link" href="#warning-47">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a permission that is not controlled by its owner.</p>
 </div>
 <h6 id="mod-perm-msg-10-3-create-or-update-permission-session-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-10-3-create-or-update-permission-session-fee-checks" >§</a> [MOD-PERM-MSG-10-3] Create or Update Permission Session fee checks</h6>
 <ul>
 <li>Load <code>CredentialSchema</code> entry <code>cs</code> from <code>issuer_perm.schema_id</code> if <code>issuer_perm</code> is not null, else from <code>verifier_perm.schema_id</code>.</li>
 <li>Fee payer MUST have sufficient available balance for the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</li>
 </ul>
-<p>For trust fees, <code>authority</code> account MUST have sufficient available balance as explained below.</p>
+<p>For trust fees, <code>corporation</code> account MUST have sufficient available balance as explained below.</p>
 <p><strong>Step 1: Calculate total beneficiary fees in credential schema pricing asset</strong></p>
 <p>Use “Find Beneficiaries” query method to get the set of beneficiary permissions <code>found_perm_set</code> (all ancestors in the permission tree).</p>
 <ul>
@@ -3349,7 +3586,7 @@ as a direct consequence of executing authorized messages.</li>
 <p>Note: <code>total_beneficiary_fees</code> is expressed in the credential schema pricing asset <code>(cs.pricing_asset_type, cs.pricing_asset)</code>.</p>
 </blockquote>
 <p><strong>Step 2: Calculate amounts payer must have available</strong></p>
-<p>Based on the credential schema pricing configuration, calculate the total amounts the payer (<code>authority</code>) must have available.</p>
+<p>Based on the credential schema pricing configuration, calculate the total amounts the payer (<code>corporation</code>) must have available.</p>
 <p>Define the following variables:</p>
 <table>
 <thead>
@@ -3411,12 +3648,18 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>total_payer_trust_deposit</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.trust_deposit_rate</code></li>
 <li><code>total_payees_trust_deposit</code> = <code>total_payer_trust_deposit</code></li>
 <li><code>total_payees_fees_to_account</code> = <code>total_fees_in_native_denom</code> × (1 - <code>GlobalVariables.trust_deposit_rate</code>)</li>
+</ul>
+<p>if <code>agent_perm_id</code> is set:</p>
+<ul>
 <li><code>total_user_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></li>
+</ul>
+<p>if <code>wallet_agent_perm_id</code> is set:</p>
+<ul>
 <li><code>total_wallet_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></li>
 </ul>
 <p>Required balance check:</p>
 <ul>
-<li><code>authority</code> MUST have available balance ≥ <code>total_fees_in_native_denom</code> + <code>total_payer_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
+<li><code>corporation</code> MUST have available balance ≥ <code>total_fees_in_native_denom</code> + <code>total_payer_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 <hr>
 <p><strong>Case B: <code>(cs.pricing_asset_type, cs.pricing_asset)</code> = <code>(TU, &quot;tu&quot;)</code></strong></p>
@@ -3427,12 +3670,18 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>total_payer_trust_deposit</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.trust_deposit_rate</code></li>
 <li><code>total_payees_trust_deposit</code> = <code>total_payer_trust_deposit</code></li>
 <li><code>total_payees_fees_to_account</code> = <code>total_fees_in_native_denom</code> × (1 - <code>GlobalVariables.trust_deposit_rate</code>)</li>
+</ul>
+<p>if <code>agent_perm_id</code> is set:</p>
+<ul>
 <li><code>total_user_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></li>
+</ul>
+<p>if <code>wallet_agent_perm_id</code> is set:</p>
+<ul>
 <li><code>total_wallet_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></li>
 </ul>
 <p>Required balance check:</p>
 <ul>
-<li><code>authority</code> MUST have available balance ≥ <code>total_fees_in_native_denom</code> + <code>total_payer_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
+<li><code>corporation</code> MUST have available balance ≥ <code>total_fees_in_native_denom</code> + <code>total_payer_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 <hr>
 <p><strong>Case C: <code>(cs.pricing_asset_type, cs.pricing_asset)</code> = <code>(COIN, &lt;arbitrary_denom&gt;)</code></strong></p>
@@ -3443,13 +3692,19 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>total_payer_trust_deposit</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.trust_deposit_rate</code></li>
 <li><code>total_payees_trust_deposit</code> = <code>total_payer_trust_deposit</code></li>
 <li><code>total_payees_fees_to_account</code> = <code>total_fees_in_pricing_asset</code> × (1 - <code>GlobalVariables.trust_deposit_rate</code>)</li>
+</ul>
+<p>if <code>agent_perm_id</code> is set:</p>
+<ul>
 <li><code>total_user_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></li>
+</ul>
+<p>if <code>wallet_agent_perm_id</code> is set:</p>
+<ul>
 <li><code>total_wallet_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></li>
 </ul>
 <p>Required balance check:</p>
 <ul>
-<li><code>authority</code> MUST have available balance ≥ <code>total_payer_trust_deposit</code> + <code>total_payees_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
-<li>AND <code>authority</code> MUST have available balance ≥ <code>total_payees_fees_to_account</code> in <code>&lt;arbitrary_denom&gt;</code>.</li>
+<li><code>corporation</code> MUST have available balance ≥ <code>total_payer_trust_deposit</code> + <code>total_payees_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
+<li>AND <code>corporation</code> MUST have available balance ≥ <code>total_payees_fees_to_account</code> in <code>&lt;arbitrary_denom&gt;</code>.</li>
 </ul>
 <hr>
 <p><strong>Case D: <code>(cs.pricing_asset_type, cs.pricing_asset)</code> = <code>(FIAT, &lt;fiat_denom&gt;)</code></strong></p>
@@ -3460,15 +3715,21 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>total_payer_trust_deposit</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.trust_deposit_rate</code></li>
 <li><code>total_payees_trust_deposit</code> = <code>total_payer_trust_deposit</code></li>
 <li><code>total_payees_fees_to_account</code> = 0 (FIAT payments are managed off-chain)</li>
+</ul>
+<p>if <code>agent_perm_id</code> is set:</p>
+<ul>
 <li><code>total_user_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></li>
+</ul>
+<p>if <code>wallet_agent_perm_id</code> is set:</p>
+<ul>
 <li><code>total_wallet_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></li>
 </ul>
 <p>Required balance check:</p>
 <ul>
-<li><code>authority</code> MUST have available balance ≥ <code>total_payer_trust_deposit</code> + <code>total_payees_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
+<li><code>corporation</code> MUST have available balance ≥ <code>total_payer_trust_deposit</code> + <code>total_payees_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 <hr>
-<div id="warning-3" class="notice warning"><a class="notice-link" href="#warning-3">WARNING</a><ul>
+<div id="warning-48" class="notice warning"><a class="notice-link" href="#warning-48">WARNING</a><ul>
 <li>Trust deposits MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 <li>When paying with COIN ≠ <a class="term-reference" href="#term:native-denom">native denom</a> or with FIAT, payer pays trust deposits on behalf of payees (since payees receive non-native assets that cannot be directly staked).</li>
 </ul>
@@ -3482,7 +3743,7 @@ as a direct consequence of executing authorized messages.</li>
 <li>use “Find Beneficiaries” to build <code>found_perm_set</code>.</li>
 </ul>
 <blockquote>
-<p>Note: All funds are transferred from the <code>authority</code> account executing the method. The steps below describe what each recipient must receive. Implementation details (batching, order of transfers) are left to the implementer.</p>
+<p>Note: All funds are transferred from the <code>corporation</code> account executing the method. The steps below describe what each recipient must receive. Implementation details (batching, order of transfers) are left to the implementer.</p>
 </blockquote>
 <hr>
 <p><strong>Step 1: Process fee distribution to each beneficiary</strong></p>
@@ -3527,43 +3788,53 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>payer_trust_deposit</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.trust_deposit_rate</code></li>
 <li><code>payee_trust_deposit</code> = <code>payer_trust_deposit</code></li>
 <li><code>payee_fees_to_account</code> = <code>fee_in_native_denom</code> × (1 - <code>GlobalVariables.trust_deposit_rate</code>)</li>
-<li><code>user_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></li>
-<li><code>wallet_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></li>
 </ul>
+</li>
+</ol>
+<p>if <code>agent_perm_id</code> is set:
+- <code>user_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></p>
+<p>if <code>wallet_agent_perm_id</code> is set:
+- <code>wallet_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></p>
 <p><strong>Case B: <code>(cs.pricing_asset_type, cs.pricing_asset)</code> = <code>(TU, &quot;tu&quot;)</code></strong></p>
 <ul>
 <li><code>fee_in_native_denom</code> = getPrice(<code>TU</code>, <code>&quot;tu&quot;</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>beneficiary_fee_in_pricing_asset</code>)</li>
 <li><code>payer_trust_deposit</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.trust_deposit_rate</code></li>
 <li><code>payee_trust_deposit</code> = <code>payer_trust_deposit</code></li>
 <li><code>payee_fees_to_account</code> = <code>fee_in_native_denom</code> × (1 - <code>GlobalVariables.trust_deposit_rate</code>)</li>
-<li><code>user_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></li>
-<li><code>wallet_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></li>
 </ul>
+<p>if <code>agent_perm_id</code> is set:
+- <code>user_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></p>
+<p>if <code>wallet_agent_perm_id</code> is set:
+- <code>wallet_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></p>
 <p><strong>Case C: <code>(cs.pricing_asset_type, cs.pricing_asset)</code> = <code>(COIN, &lt;arbitrary_denom&gt;)</code></strong></p>
 <ul>
 <li><code>fee_in_native_denom</code> = getPrice(<code>COIN</code>, <code>&lt;arbitrary_denom&gt;</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>beneficiary_fee_in_pricing_asset</code>)</li>
 <li><code>payer_trust_deposit</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.trust_deposit_rate</code></li>
 <li><code>payee_trust_deposit</code> = <code>payer_trust_deposit</code></li>
 <li><code>payee_fees_to_account</code> = <code>beneficiary_fee_in_pricing_asset</code> × (1 - <code>GlobalVariables.trust_deposit_rate</code>) <em>(in <code>&lt;arbitrary_denom&gt;</code>)</em></li>
-<li><code>user_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></li>
-<li><code>wallet_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></li>
 </ul>
+<p>if <code>agent_perm_id</code> is set:
+- <code>user_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></p>
+<p>if <code>wallet_agent_perm_id</code> is set:
+- <code>wallet_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></p>
 <p><strong>Case D: <code>(cs.pricing_asset_type, cs.pricing_asset)</code> = <code>(FIAT, &lt;fiat_denom&gt;)</code></strong></p>
 <ul>
 <li><code>fee_in_native_denom</code> = getPrice(<code>FIAT</code>, <code>&lt;fiat_denom&gt;</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>beneficiary_fee_in_pricing_asset</code>)</li>
 <li><code>payer_trust_deposit</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.trust_deposit_rate</code></li>
 <li><code>payee_trust_deposit</code> = <code>payer_trust_deposit</code></li>
 <li><code>payee_fees_to_account</code> = 0 <em>(FIAT payments are managed off-chain)</em></li>
-<li><code>user_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></li>
-<li><code>wallet_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></li>
 </ul>
-</li>
+<p>if <code>agent_perm_id</code> is set:
+- <code>user_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></p>
+<p>if <code>wallet_agent_perm_id</code> is set:
+- <code>wallet_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></p>
+<ol start="3">
 <li>
 <p>Execute transfers and deposits for this beneficiary:</p>
 <ul>
-<li>If <code>payee_fees_to_account</code> &gt; 0: transfer <code>payee_fees_to_account</code> to <code>perm.authority</code> (in the appropriate denom).</li>
-<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>perm.authority</code> by <code>payee_trust_deposit</code>. Increase <code>perm.deposit</code> by the same value.</li>
-<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>authority</code> (payer) by <code>payer_trust_deposit</code>. Increase <code>payer_perm.deposit</code> by the same value.</li>
+<li>If <code>payee_fees_to_account</code> &gt; 0: transfer <code>payee_fees_to_account</code> to <code>perm.corporation</code> (in the appropriate denom).</li>
+<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>perm.corporation</code> by <code>payee_trust_deposit</code>. Increase <code>perm.deposit</code> by the same value.</li>
+<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>corporation</code> (payer) by <code>payer_trust_deposit</code>. Increase <code>payer_perm.deposit</code> by the same value.</li>
 </ul>
 </li>
 <li>
@@ -3578,20 +3849,20 @@ as a direct consequence of executing authorized messages.</li>
 <p><strong>Step 2: Process agent rewards</strong></p>
 <p>After processing all beneficiaries, distribute accumulated rewards to agents.</p>
 <p><strong>User Agent Reward:</strong></p>
-<p>If <code>accumulated_user_agent_reward</code> &gt; 0:</p>
+<p>If <code>agent_perm_id</code> is set AND <code>accumulated_user_agent_reward</code> &gt; 0:</p>
 <ul>
 <li><code>agent_trust_deposit</code> = <code>accumulated_user_agent_reward</code> × <code>GlobalVariables.trust_deposit_rate</code></li>
 <li><code>agent_fees_to_account</code> = <code>accumulated_user_agent_reward</code> - <code>agent_trust_deposit</code></li>
-<li>Transfer <code>agent_fees_to_account</code> to <code>agent_perm.authority</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
-<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>agent_perm.authority</code> by <code>agent_trust_deposit</code>. Increase <code>agent_perm.deposit</code> by the same value.</li>
+<li>Transfer <code>agent_fees_to_account</code> to <code>agent_perm.corporation</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
+<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>agent_perm.corporation</code> by <code>agent_trust_deposit</code>. Increase <code>agent_perm.deposit</code> by the same value.</li>
 </ul>
 <p><strong>Wallet Agent Reward:</strong></p>
-<p>If <code>accumulated_wallet_agent_reward</code> &gt; 0:</p>
+<p>If <code>wallet_agent_perm_id</code> is set AND <code>accumulated_wallet_agent_reward</code> &gt; 0:</p>
 <ul>
 <li><code>wallet_agent_trust_deposit</code> = <code>accumulated_wallet_agent_reward</code> × <code>GlobalVariables.trust_deposit_rate</code></li>
 <li><code>wallet_agent_fees_to_account</code> = <code>accumulated_wallet_agent_reward</code> - <code>wallet_agent_trust_deposit</code></li>
-<li>Transfer <code>wallet_agent_fees_to_account</code> to <code>wallet_agent_perm.authority</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
-<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>wallet_agent_perm.authority</code> by <code>wallet_agent_trust_deposit</code>. Increase <code>wallet_agent_perm.deposit</code> by the same value.</li>
+<li>Transfer <code>wallet_agent_fees_to_account</code> to <code>wallet_agent_perm.corporation</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
+<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>wallet_agent_perm.corporation</code> by <code>wallet_agent_trust_deposit</code>. Increase <code>wallet_agent_perm.deposit</code> by the same value.</li>
 </ul>
 <hr>
 <p><strong>Step 3: Create or update session records</strong></p>
@@ -3603,14 +3874,14 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>cspsr.created</code>: <code>now</code></li>
 <li><code>cspsr.issuer_perm_id</code>: <code>issuer_perm_id</code></li>
 <li><code>cspsr.verifier_perm_id</code>: <code>verifier_perm_id</code></li>
+<li><code>cspsr.agent_perm_id</code>: <code>agent_perm_id</code></li>
 <li><code>cspsr.wallet_agent_perm_id</code>: <code>wallet_agent_perm_id</code></li>
 </ul>
 <p>If new, create entry <code>PermissionSession</code> <code>session</code>:</p>
 <ul>
 <li><code>session.id</code>: <code>id</code></li>
-<li><code>session.authority</code>: <code>authority</code></li>
+<li><code>session.corporation</code>: <code>corporation</code></li>
 <li><code>session.vs_operator</code>: <code>operator</code></li>
-<li><code>session.agent_perm_id</code>: <code>agent_perm_id</code></li>
 <li><code>session.modified:</code> : <code>now</code></li>
 <li><code>session.created:</code> : <code>now</code></li>
 </ul>
@@ -3620,7 +3891,7 @@ as a direct consequence of executing authorized messages.</li>
 </ul>
 <p>then, add the <code>cspsr</code> to <code>session.session_records</code></p>
 <p>if current transaction if for issuance of a credential, persist the digest SRI by calling <a href="#mod-di-msg-1-store-digest" >[MOD-DI-MSG-1]</a>.</p>
-<div id="warning-4" class="notice warning"><a class="notice-link" href="#warning-4">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_perm_id</code> OR <code>verifier_perm_id</code></p>
+<div id="warning-49" class="notice warning"><a class="notice-link" href="#warning-49">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_perm_id</code> OR <code>verifier_perm_id</code></p>
 </div>
 <h4 id="mod-perm-msg-11-update-permission-module-parameters"><a class="toc-anchor" href="#mod-perm-msg-11-update-permission-module-parameters" >§</a> [MOD-PERM-MSG-11] Update Permission Module Parameters</h4>
 <p>Update Permission Module Parameters.</p>
@@ -3647,13 +3918,13 @@ as a direct consequence of executing authorized messages.</li>
 <h4 id="mod-perm-msg-12-slash-permission-trust-deposit"><a class="toc-anchor" href="#mod-perm-msg-12-slash-permission-trust-deposit" >§</a> [MOD-PERM-MSG-12] Slash Permission Trust Deposit</h4>
 <p>This method can only be called by either:</p>
 <ul>
-<li>an <code>authority</code> ancestor validator of this permission;</li>
-<li>the <code>authority</code> controller of the <code>TrustRegistry</code> object, owner of the corresponding credential schema.</li>
+<li>a <code>corporation</code> ancestor validator of this permission;</li>
+<li>the <code>corporation</code> controller of the <code>TrustRegistry</code> object, owner of the corresponding credential schema.</li>
 </ul>
 <h5 id="mod-perm-msg-12-1-slash-permission-trust-deposit-parameters"><a class="toc-anchor" href="#mod-perm-msg-12-1-slash-permission-trust-deposit-parameters" >§</a> [MOD-PERM-MSG-12-1] Slash Permission Trust Deposit parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uint64) (<em>mandatory</em>): id of the permission;</li>
 <li><code>amount</code> (number) (<em>mandatory</em>): the amount to slash</li>
 </ul>
@@ -3662,13 +3933,14 @@ as a direct consequence of executing authorized messages.</li>
 <h6 id="mod-perm-msg-12-2-1-slash-permission-trust-deposit-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-12-2-1-slash-permission-trust-deposit-basic-checks" >§</a> [MOD-PERM-MSG-12-2-1] Slash Permission Trust Deposit basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>id</code> MUST be a valid uint64.</li>
 <li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>. If no entry found, abort.</li>
 <li><code>amount</code> MUST be lower or equal to <code>applicant_perm.deposit</code> else MUST abort.</li>
 </ul>
-<div id="note-13" class="notice note"><a class="notice-link" href="#note-13">NOTE</a><p>Even if the permission has expired or is revoked, it is still possible to slash it.</p>
+<div id="note-88" class="notice note"><a class="notice-link" href="#note-88">NOTE</a><p>Even if the permission has expired or is revoked, it is still possible to slash it.</p>
 </div>
 <h6 id="mod-perm-msg-12-2-2-slash-permission-trust-deposit-validator-perms"><a class="toc-anchor" href="#mod-perm-msg-12-2-2-slash-permission-trust-deposit-validator-perms" >§</a> [MOD-PERM-MSG-12-2-2] Slash Permission Trust Deposit validator perms</h6>
 <p>Either Option #1, or #2 MUST return true, else abort.</p>
@@ -3679,7 +3951,7 @@ as a direct consequence of executing authorized messages.</li>
 <li>while <code>validator_perm.validator_perm_id</code> is defined,
 <ul>
 <li>load <code>validator_perm</code> from <code>validator_perm.validator_perm_id</code>.</li>
-<li>if <code>validator_perm</code> is a <a class="term-reference" href="#term:active-permission">active permission</a> and <code>validator_perm.authority</code> is who is running the method, =&gt; return true.</li>
+<li>if <code>validator_perm</code> is a <a class="term-reference" href="#term:active-permission">active permission</a> and <code>validator_perm.corporation</code> is who is running the method, =&gt; return true.</li>
 </ul>
 </li>
 <li>end</li>
@@ -3689,7 +3961,7 @@ as a direct consequence of executing authorized messages.</li>
 <ul>
 <li>load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_perm.schema_id</code></li>
 <li>load <code>TrustRegistry</code> <code>tr</code> from <code>cs.tr_id</code></li>
-<li>if <code>authority</code> running the method is <code>tr.authority</code>, return true.</li>
+<li>if <code>corporation</code> running the method is <code>tr.corporation</code>, return true.</li>
 <li>else return false.</li>
 </ul>
 <h6 id="mod-perm-msg-12-2-3-slash-permission-trust-deposit-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-12-2-3-slash-permission-trust-deposit-fee-checks" >§</a> [MOD-PERM-MSG-12-2-3] Slash Permission Trust Deposit fee checks</h6>
@@ -3717,18 +3989,15 @@ as a direct consequence of executing authorized messages.</li>
 <p>set <code>applicant_perm.slashed_deposit</code> to <code>applicant_perm.slashed_deposit</code> + <code>amount</code></p>
 </li>
 </ul>
-<p>use <a href="#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit" >MOD-TD-MSG-7</a> to burn the slashed <code>amount</code> from the trust deposit of <code>applicant_perm.authority</code>.</p>
-<p>If <code>applicant_perm.type</code> is ISSUER or VERIFIER: Delete authorization for <code>applicant_perm.vs_operator</code>:</p>
-<ul>
-<li>call <strong>Revoke VS Operator Authorization(<code>applicant_perm.id</code>)</strong> with the following parameters:</li>
-</ul>
+<p>use <a href="#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit" >MOD-TD-MSG-7</a> to burn the slashed <code>amount</code> from the trust deposit of <code>applicant_perm.corporation</code>.</p>
+<p>Call <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a> Revoke VS Operator Authorization with <code>perm_id = applicant_perm.id</code> to remove any authorization record for this permission. The call is a no-op if no record exists.</p>
 <h4 id="mod-perm-msg-13-repay-permission-slashed-trust-deposit"><a class="toc-anchor" href="#mod-perm-msg-13-repay-permission-slashed-trust-deposit" >§</a> [MOD-PERM-MSG-13] Repay Permission Slashed Trust Deposit</h4>
-<p>This method can only be called by the <code>authority</code> that want to repay the deposit of a slashed perm they own. This won’t make the perm re-usable: it will be needed for the <code>authority</code> associated to this permission to request a new permission, as slashed permissions cannot be revived (same happen for revoked, etc…).</p>
+<p>This method can only be called by the <code>corporation</code> that want to repay the deposit of a slashed perm they own. This won’t make the perm re-usable: it will be needed for the <code>corporation</code> associated to this permission to request a new permission, as slashed permissions cannot be revived (same happen for revoked, etc…).</p>
 <p>Nevertheless, to get a new permission for a given ecosystem, it is needed, using this method, to repay the deposit of a slashed permission first.</p>
 <h5 id="mod-perm-msg-13-1-repay-permission-slashed-trust-deposit-parameters"><a class="toc-anchor" href="#mod-perm-msg-13-1-repay-permission-slashed-trust-deposit-parameters" >§</a> [MOD-PERM-MSG-13-1] Repay Permission Slashed Trust Deposit parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>id</code> (uint64) (<em>mandatory</em>): id of the permission</li>
 </ul>
 <h5 id="mod-perm-msg-13-2-repay-permission-slashed-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-13-2-repay-permission-slashed-trust-deposit-precondition-checks" >§</a> [MOD-PERM-MSG-13-2] Repay Permission Slashed Trust Deposit precondition checks</h5>
@@ -3736,16 +4005,17 @@ as a direct consequence of executing authorized messages.</li>
 <h6 id="mod-perm-msg-13-2-1-repay-permission-slashed-trust-deposit-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-13-2-1-repay-permission-slashed-trust-deposit-basic-checks" >§</a> [MOD-PERM-MSG-13-2-1] Repay Permission Slashed Trust Deposit basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>id</code> MUST be a valid uint64.</li>
 <li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>. If no entry found, abort.</li>
-<li>if <code>applicant_perm.authority</code> is not equal to <code>authority</code>, abort.</li>
+<li>if <code>applicant_perm.corporation</code> is not equal to <code>corporation</code>, abort.</li>
 </ul>
 <h6 id="mod-perm-msg-13-2-2-repay-permission-slashed-trust-deposit-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-13-2-2-repay-permission-slashed-trust-deposit-fee-checks" >§</a> [MOD-PERM-MSG-13-2-2] Repay Permission Slashed Trust Deposit fee checks</h6>
 <ul>
 <li>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>;</li>
-<li><code>authority</code> MUST have at least <code>applicant_perm.slashed_deposit</code> in its account balance, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</li>
+<li><code>corporation</code> MUST have at least <code>applicant_perm.slashed_deposit</code> in its account balance, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</li>
 </ul>
 <h5 id="mod-perm-msg-13-3-repay-permission-slashed-trust-deposit-execution"><a class="toc-anchor" href="#mod-perm-msg-13-3-repay-permission-slashed-trust-deposit-execution" >§</a> [MOD-PERM-MSG-13-3] Repay Permission Slashed Trust Deposit execution</h5>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
@@ -3753,7 +4023,7 @@ as a direct consequence of executing authorized messages.</li>
 <ul>
 <li>define <code>now</code>: current timestamp.</li>
 </ul>
-<p>use <a href="#mod-td-msg-1-adjust-trust-deposit" >Adjust Trust Deposit</a> to transfer <code>applicant_perm.slashed_deposit</code> to trust deposit of <code>applicant_perm.authority</code>.</p>
+<p>use <a href="#mod-td-msg-1-adjust-trust-deposit" >Adjust Trust Deposit</a> to transfer <code>applicant_perm.slashed_deposit</code> to trust deposit of <code>applicant_perm.corporation</code>.</p>
 <ul>
 <li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>.</li>
 <li>set <code>applicant_perm.repaid</code> to <code>now</code></li>
@@ -3761,41 +4031,65 @@ as a direct consequence of executing authorized messages.</li>
 <li>set <code>applicant_perm.repaid_deposit</code> to <code>applicant_perm.slashed_deposit</code>.</li>
 </ul>
 <h4 id="mod-perm-msg-14-self-create-permission"><a class="toc-anchor" href="#mod-perm-msg-14-self-create-permission" >§</a> [MOD-PERM-MSG-14] Self Create Permission</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This simple permission creation method can be used to self-create an ISSUER (resp. VERIFIER) permission if issuance mode (resp. verification mode) is set to <code>OPEN</code> for a given schema. As permissions are the anchor of ecosystem trust deposit operations, it is required for an issuer/verifier candidate to self-create a permission for being issuer or verifier of a given schema.</p>
-<div id="note-14" class="notice note"><a class="notice-link" href="#note-14">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their permission may be revoked by ecosystem governance authority and their deposit slashed.</p>
+<div id="note-89" class="notice note"><a class="notice-link" href="#note-89">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their permission may be revoked by ecosystem governance authority and their deposit slashed.</p>
 </div>
 <h5 id="mod-perm-msg-14-1-self-create-permission-parameters"><a class="toc-anchor" href="#mod-perm-msg-14-1-self-create-permission-parameters" >§</a> [MOD-PERM-MSG-14-1] Self Create Permission parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
-<li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>type</code> (PermissionType) (<em>mandatory</em>): ISSUER or VERIFIER.</li>
-<li><code>validator_perm_id</code> (uint64) (<em>mandatory</em>): MUST be an ECOSYSTEM <a class="term-reference" href="#term:active-permission">active permission</a> or <a class="term-reference" href="#term:future-permission">future permission</a> of the Credential Schema defined by <code>schema_id</code></li>
-<li><code>schema_id</code> (uint64) (<em>mandatory</em>)</li>
+<li><code>validator_perm_id</code> (uint64) (<em>mandatory</em>): MUST be an ECOSYSTEM <a class="term-reference" href="#term:active-permission">active permission</a> or <a class="term-reference" href="#term:future-permission">future permission</a>.</li>
 <li><code>vs_operator</code> (account) (<em>optional</em>): the account we want to authorize to create permission sessions linked to this permission. <strong>Required</strong> for payment delegation.</li>
 <li><code>did</code> (string) (<em>mandatory</em>): <a class="term-reference" href="#term:did">DID</a> of the VS grantee service.</li>
 <li><code>effective_from</code> (timestamp) (<em>optional</em>): timestamp from when (exclusive) this Perm is effective. MUST be in the future.</li>
 <li><code>effective_until</code> (timestamp) (<em>optional</em>): timestamp until when (exclusive) this Perm is effective, null if it doesn’t expire. If not null, MUST be greater than <code>effective_from</code>.</li>
 <li><code>verification_fees</code> (number) (<em>optional</em>): price to pay by the verifier of a credential of this schema to the grantee of this ISSUER perm when a credential is verified, in the denom specified in the credential schema. Default to 0.</li>
 <li><code>validation_fees</code> (number) (<em>optional</em>): price to pay by the holder of a credential of this schema to the issuer when executing a validation process to obtain a credential, in the denom specified in the credential schema. Default to 0.</li>
-<li><code>vs_operator_authz_enabled</code>: boolean (<em>mandatory</em>): if set to true authorize this vs_operator to execute CreateOrUpdatePermissionSession <em>on behalf</em> of <code>authority</code> account (trust fees will be paid by authority account)</li>
-<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds that the vs_operator is allowed to spend in the context of this permission.
-as a direct consequence of executing authorized messages.</li>
-<li><code>vs_operator_authz_with_feegrant</code>: boolean (<em>mandatory</em>): if set to true, enable feegrant for this permission so vs_operator can pay the fees for CreateOrUpdatePermissionSession with <code>authority</code> account.</li>
-<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of fees that can be spent by vs_operator in the context of this permission.</li>
-<li><code>vs_operator_authz_spend_period</code>: (period) (<em>optional</em>): reset period for vs_operator_authz_spend_limit and vs_operator_authz_fee_spend_limit in the context of this permission.</li>
 </ul>
+<p>The following VS Operator Authorization parameters are <strong>optional</strong> and collectively define the initial <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> for this permission. Presence of <code>vs_operator_authz_msg_types</code> is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is <strong>frozen at creation time</strong> and cannot be modified later; to change it, the permission MUST be revoked and re-created.</p>
+<ul>
+<li><code>vs_operator_authz_msg_types[]</code> (msg_type[]) (<em>optional</em>): list of VPR delegable message types <code>vs_operator</code> is authorized to execute on behalf of <code>corporation</code> in the context of this permission. If provided, a <code>PermissionAuthorizationRecord</code> is created (see execution below) and <code>vs_operator</code> MUST be specified.</li>
+<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds <code>vs_operator</code> is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.</li>
+<li><code>vs_operator_authz_with_feegrant</code> (bool) (<em>optional</em>, default: false): if true, <code>corporation</code> pays transaction fees for <code>vs_operator</code> via an on-chain <code>FeeGrant</code> when executing authorized messages in the context of this permission.</li>
+<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of transaction fees that can be spent by <code>vs_operator</code> (paid by <code>corporation</code> via fee grant) in the context of this permission.</li>
+<li><code>vs_operator_authz_period</code> (duration) (<em>optional</em>): reset period for <code>vs_operator_authz_spend_limit</code> and <code>vs_operator_authz_fee_spend_limit</code> in the context of this permission.</li>
+</ul>
+<p>Permitted message types to be set in <code>vs_operator_authz_msg_types</code> depends on <code>type</code>.</p>
+<table>
+<thead>
+<tr>
+<th>Permission type</th>
+<th>Permitted Messages</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td>HOLDER</td>
+<td>TriggerResolver</td>
+</tr>
+<tr>
+<td>ISSUER</td>
+<td>CreateOrUpdatePermissionSession, SetPermissionVPtoValidated</td>
+</tr>
+<tr>
+<td>VERIFIER</td>
+<td>CreateOrUpdatePermissionSession</td>
+</tr>
+</tbody>
+</table>
 <h5 id="mod-perm-msg-14-2-self-create-permission-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-14-2-self-create-permission-precondition-checks" >§</a> [MOD-PERM-MSG-14-2] Self Create Permission precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <h6 id="mod-perm-msg-14-2-1-self-create-permission-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-14-2-1-self-create-permission-basic-checks" >§</a> [MOD-PERM-MSG-14-2-1] Self Create Permission basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <p>Load <code>Permission</code> <code>validator_perm</code> from <code>validator_perm_id</code>.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>type</code> (PermissionType) (<em>mandatory</em>): MUST be ISSUER or VERIFIER, else abort.</li>
-<li><code>validator_perm_id</code> (uint64) (<em>mandatory</em>): <code>validator_perm</code> MUST be an ECOSYSTEM <a class="term-reference" href="#term:active-permission">active permission</a> or <a class="term-reference" href="#term:future-permission">future permission</a> of the Credential Schema defined by <code>schema_id</code></li>
-<li><code>schema_id</code> MUST be a valid uint64 and a <a class="term-reference" href="#term:credential-schema">credential schema</a> entry with this id MUST exist and MUST be the same than <code>validator_perm.schema_id</code></li>
+<li><code>validator_perm_id</code> (uint64) (<em>mandatory</em>): <code>validator_perm</code> MUST be an ECOSYSTEM <a class="term-reference" href="#term:active-permission">active permission</a> or <a class="term-reference" href="#term:future-permission">future permission</a>.</li>
 <li><code>vs_operator</code> (account) (<em>optional</em>): no check required.</li>
 <li><code>did</code>, MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
 <li><code>effective_from</code> MUST be in the future AND
@@ -3812,27 +4106,22 @@ as a direct consequence of executing authorized messages.</li>
 </li>
 <li><code>verification_fees</code> (number) (<em>optional</em>): If specified, MUST be &gt;= 0 and MUST be a ISSUER permission.</li>
 <li><code>validation_fees</code> (number) (<em>optional</em>): If specified, MUST be &gt;= 0 and MUST be a ISSUER permission.</li>
-<li><code>vs_operator_authz_enabled</code>: boolean (<em>mandatory</em>): if set to true, <code>vs_operator</code> MUST NOT be null, else abort.</li>
-<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds that the vs_operator is allowed to spend in the context of this permission.
-as a direct consequence of executing authorized messages.</li>
-<li><code>vs_operator_authz_with_feegrant</code>: boolean (<em>mandatory</em>): if set to true, <code>vs_operator</code> MUST NOT be null, else abort.</li>
-<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of fees that can be spent by vs_operator in the context of this permission.</li>
-<li><code>vs_operator_authz_spend_period</code>: (period) (<em>optional</em>): if not null, <code>vs_operator</code> MUST NOT be null, else abort. Reset period for vs_operator_authz_spend_limit and vs_operator_authz_fee_spend_limit in the context of this permission.</li>
+<li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-perm-msg-14-1-self-create-permission-parameters" >MOD-PERM-MSG-14-1</a>.</li>
 </ul>
 <h6 id="mod-perm-msg-14-2-2-self-create-permission-permission-checks"><a class="toc-anchor" href="#mod-perm-msg-14-2-2-self-create-permission-permission-checks" >§</a> [MOD-PERM-MSG-14-2-2] Self Create Permission permission checks</h6>
 <p>To execute this method, <a class="term-reference" href="#term:account">account</a> MUST match at least one these rules, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li>The related <code>CredentialSchema</code> entry is loaded with <code>schema_id</code>, and will be named <code>cs</code> in this section.</li>
-<li>if <code>type</code> is equal to ISSUER: if <code>cs.issuer_perm_management_mode</code> is not equal to OPEN, MUST abort.</li>
-<li>if <code>type</code> is equal to VERIFIER: if <code>cs.verifier_perm_management_mode</code> is not equal to OPEN, MUST abort.</li>
+<li>The related <code>CredentialSchema</code> entry is loaded with <code>validator_perm.schema_id</code>, and will be named <code>cs</code> in this section.</li>
+<li>if <code>type</code> is equal to ISSUER: if <code>cs.issuer_onboarding_mode</code> is not equal to OPEN, MUST abort.</li>
+<li>if <code>type</code> is equal to VERIFIER: if <code>cs.verifier_onboarding_mode</code> is not equal to OPEN, MUST abort.</li>
 <li>if <code>type</code> is equal to VERIFIER and <code>validation_fees</code> is specified and different than 0, MUST abort.</li>
 <li>if <code>type</code> is equal to VERIFIER and <code>verification_fees</code> is specified and different than 0, MUST abort.</li>
 </ul>
 <h6 id="mod-perm-msg-14-2-3-self-create-permission-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-14-2-3-self-create-permission-fee-checks" >§</a> [MOD-PERM-MSG-14-2-3] Self Create Permission fee checks</h6>
 <p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> available.</p>
 <h6 id="mod-perm-msg-14-2-4-self-create-permission-overlap-checks"><a class="toc-anchor" href="#mod-perm-msg-14-2-4-self-create-permission-overlap-checks" >§</a> [MOD-PERM-MSG-14-2-4] Self Create Permission overlap checks</h6>
-<p>We want to make sure that 2 permissions cannot be active at the same time for the same <code>validator_perm_id</code>. If <code>authority</code> wishes to create a new permission but existing active one never expires (or expire too far from now), <code>authority</code> MUST use first the <a href="#mod-perm-msg-8-adjust-permission" >Extend Perm Msg</a> to set or adjust the <code>effective_until</code> value.</p>
-<p>Find all <a class="term-reference" href="#term:active-permissions">active permissions</a> <code>perms[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, <code>type</code>, <code>validator_perm_id</code>, <code>authority</code>.</p>
+<p>We want to make sure that 2 permissions cannot be active at the same time for the same <code>validator_perm_id</code>. If <code>corporation</code> wishes to create a new permission but existing active one never expires (or expire too far from now), <code>corporation</code> MUST use first the <a href="#mod-perm-msg-8-adjust-permission" >Extend Perm Msg</a> to set or adjust the <code>effective_until</code> value.</p>
+<p>Find all <a class="term-reference" href="#term:active-permissions">active permissions</a> <code>perms[]</code> (not revoked, not slashed, not repaid) for <code>cs.id</code>, <code>type</code>, <code>validator_perm_id</code>, <code>corporation</code>.</p>
 <p>for each <code>Permission</code> entry <code>p</code> from <code>perms[]</code>:</p>
 <ul>
 <li>if <code>p.effective_until</code> is greater than <code>effective_from</code>, method execution MUST abort.</li>
@@ -3842,21 +4131,22 @@ as a direct consequence of executing authorized messages.</li>
 <blockquote>
 <p>note: this check was not present in v3.</p>
 </blockquote>
-<h5 id="mod-perm-msg-14-3-create-permission-execution"><a class="toc-anchor" href="#mod-perm-msg-14-3-create-permission-execution" >§</a> [MOD-PERM-MSG-14-3] Create Permission execution</h5>
+<h5 id="mod-perm-msg-14-3-self-create-permission-execution"><a class="toc-anchor" href="#mod-perm-msg-14-3-self-create-permission-execution" >§</a> [MOD-PERM-MSG-14-3] Self Create Permission execution</h5>
 <p>If all precondition checks passed, method is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>define <code>now</code>: current timestamp.</li>
+<li>Load <code>Permission</code> <code>validator_perm</code> from <code>validator_perm_id</code>.</li>
 </ul>
 <p>A new entry <code>Permission</code> <code>perm</code> MUST be created:</p>
 <ul>
 <li><code>perm.id</code>: auto-incremented uint64.</li>
 <li><code>perm.validator_perm_id</code>: <code>validator_perm_id</code></li>
-<li><code>perm.schema_id</code>: <code>schema_id</code>.</li>
+<li><code>perm.schema_id</code>: <code>validator_perm.schema_id</code></li>
 <li><code>perm.modified</code> to <code>now</code>.</li>
 <li><code>perm.type</code>: <code>type</code>.</li>
 <li><code>perm.did</code>: <code>did</code>.</li>
-<li><code>perm.authority</code>: <code>authority</code>.</li>
+<li><code>perm.corporation</code>: <code>corporation</code>.</li>
 <li><code>perm.vs_operator</code>: <code>vs_operator</code>.</li>
 <li><code>perm.created</code>: <code>now</code></li>
 <li><code>perm.effective_from</code>: <code>effective_from</code></li>
@@ -3865,16 +4155,91 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>perm.issuance_fees</code>: 0</li>
 <li><code>perm.verification_fees</code>: <code>verification_fees</code> if specified and <code>type</code> is ISSUER, else 0.</li>
 <li><code>perm.deposit</code>: 0</li>
-<li><code>perm.vs_operator_authz_enabled</code>: <code>vs_operator_authz_enabled</code></li>
-<li><code>perm.vs_operator_authz_spend_limit</code>: <code>vs_operator_authz_spend_limit</code></li>
-<li><code>perm.vs_operator_authz_with_feegrant</code>: <code>vs_operator_authz_with_feegrant</code></li>
-<li><code>perm.vs_operator_authz_fee_spend_limit</code>: <code>vs_operator_authz_fee_spend_limit</code></li>
-<li><code>perm.vs_operator_authz_spend_period</code>: <code>vs_operator_authz_spend_period</code></li>
 </ul>
-<p>Create authorization for <code>vs_operator</code> so that the Verifiable Service will be able to call CreateOrUpdatePermissionSession when issuing or verifying credentials:</p>
+<p>If <code>vs_operator_authz_msg_types</code> is provided, create the <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> in <strong>active</strong> state by calling <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a> Grant VS Operator Authorization with:</p>
 <ul>
-<li>if <code>perm.vs_operator_authz_enabled</code> == true: call <strong>Grant VS Operator Authorization(<code>perm.id</code>)</strong>.</li>
+<li><code>corporation</code>: <code>corporation</code></li>
+<li><code>vs_operator</code>: <code>vs_operator</code></li>
+<li><code>record</code>:
+<ul>
+<li><code>record.perm_id</code>: <code>perm.id</code></li>
+<li><code>record.msg_types</code>: <code>vs_operator_authz_msg_types</code></li>
+<li><code>record.spend_limit</code>: <code>vs_operator_authz_spend_limit</code></li>
+<li><code>record.fee_spend_limit</code>: <code>vs_operator_authz_fee_spend_limit</code></li>
+<li><code>record.with_feegrant</code>: <code>vs_operator_authz_with_feegrant</code> (default: false)</li>
+<li><code>record.expiration</code>: <code>perm.effective_until</code></li>
+<li><code>record.period</code>: <code>vs_operator_authz_period</code></li>
 </ul>
+</li>
+</ul>
+<blockquote>
+<p>Note: unlike <a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a>, the record is created with <code>expiration = perm.effective_until</code> and is therefore immediately active. If <code>with_feegrant</code> is true and <code>perm.effective_until &gt; now</code>, <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a> grants the on-chain <code>FeeGrant</code> as part of this execution.</p>
+</blockquote>
+<h4 id="mod-perm-msg-15-trigger-resolver"><a class="toc-anchor" href="#mod-perm-msg-15-trigger-resolver" >§</a> [MOD-PERM-MSG-15] Trigger Resolver</h4>
+<p>This method CAN be executed by:</p>
+<ul>
+<li>the <code>vs_operator</code> of the permission, acting on behalf of <code>perm.corporation</code>; or</li>
+<li>any ancestor validator of the permission in the permission tree (from the direct parent up to the root permission). For an ancestor validator <code>v</code>, the method CAN be executed by the <code>vs_operator</code> defined in <code>v</code>, or by any <code>operator</code> authorized by <code>v.corporation</code> for this message type.</li>
+</ul>
+<p>This method is intended to be used by external services (such as the Verana indexer) to be notified that a trust resolution must be performed for the <code>did</code> registered in the permission. Typical use cases include:</p>
+<ul>
+<li>a new <a class="term-reference" href="#term:verifiable-service">verifiable service</a> has been onboarded and its credentials are now present in the DID Document, so trust can be (re-)evaluated;</li>
+<li>an issuer has revoked a credential issued to a holder: the issuer (acting as the validator of the corresponding HOLDER permission) notifies the trust resolver to re-evaluate trust for the revoked HOLDER permission;</li>
+<li>an issuer is no longer operating: a parent issuer grantor or root ecosystem permission triggers a re-evaluation.</li>
+</ul>
+<p>The method does not modify the <a class="term-reference" href="#term:vpr">VPR</a> state; it only emits an event that off-chain components MAY consume.</p>
+<h5 id="mod-perm-msg-15-1-trigger-resolver-parameters"><a class="toc-anchor" href="#mod-perm-msg-15-1-trigger-resolver-parameters" >§</a> [MOD-PERM-MSG-15-1] Trigger Resolver parameters</h5>
+<ul>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): id of the permission for which a trust resolution must be triggered.</li>
+</ul>
+<h5 id="mod-perm-msg-15-2-trigger-resolver-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-15-2-trigger-resolver-precondition-checks" >§</a> [MOD-PERM-MSG-15-2] Trigger Resolver precondition checks</h5>
+<p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<h6 id="mod-perm-msg-15-2-1-trigger-resolver-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-15-2-1-trigger-resolver-basic-checks" >§</a> [MOD-PERM-MSG-15-2-1] Trigger Resolver basic checks</h6>
+<p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<ul>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
+<li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><code>id</code> MUST be a valid uint64.</li>
+<li>Load <code>Permission</code> entry <code>perm</code> from <code>id</code>. If no entry found, abort.</li>
+<li><code>perm</code> MUST be an <a class="term-reference" href="#term:active-permission">active permission</a>, else abort.</li>
+<li><code>perm.did</code> MUST NOT be null, else abort.</li>
+</ul>
+<h6 id="mod-perm-msg-15-2-2-trigger-resolver-authorization-checks"><a class="toc-anchor" href="#mod-perm-msg-15-2-2-trigger-resolver-authorization-checks" >§</a> [MOD-PERM-MSG-15-2-2] Trigger Resolver authorization checks</h6>
+<p>At least one of the two authorization paths below MUST pass, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<p><em>Path 1 — vs_operator of the target permission</em></p>
+<ul>
+<li><code>corporation</code> MUST be equal to <code>perm.corporation</code>.</li>
+<li><code>operator</code> MUST be equal to <code>perm.vs_operator</code>.</li>
+<li><a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>perm</code>) tuple.</li>
+<li><a href="#authz-check-4-vs-operator-fee-grant-checks" >[AUTHZ-CHECK-4]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>perm</code>) tuple.</li>
+</ul>
+<p><em>Path 2 — ancestor validator in the permission tree</em></p>
+<p>The target <code>perm</code> itself is excluded from this walk; only its ancestors (from the direct parent up to the root) are considered. Walk the tree:</p>
+<ul>
+<li>set <code>v</code> = <code>perm</code>.</li>
+<li>while <code>v.validator_perm_id</code> is defined:
+<ul>
+<li>load <code>v</code> from <code>v.validator_perm_id</code>.</li>
+<li>if <code>v</code> is not an <a class="term-reference" href="#term:active-permission">active permission</a>, continue with the next iteration.</li>
+<li><code>corporation</code> MUST be equal to <code>v.corporation</code>.</li>
+<li>if <a href="#authz-check-1-operator-authorization-checks" >AUTHZ-CHECK-1</a> pass for this (<code>corporation</code>, <code>operator</code>) tuple and message <code>TriggerResolver</code> AND <a href="#authz-check-2-fee-grant-checks" >AUTHZ-CHECK-2</a> pass for this (<code>corporation</code>, <code>operator</code>) tuple and message <code>TriggerResolver</code>, then authorization is granted =&gt; match.</li>
+</ul>
+</li>
+</ul>
+<p>If the walk terminates without a match, Path 2 fails.</p>
+<h6 id="mod-perm-msg-15-2-3-trigger-resolver-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-15-2-3-trigger-resolver-fee-checks" >§</a> [MOD-PERM-MSG-15-2-3] Trigger Resolver fee checks</h6>
+<p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<h5 id="mod-perm-msg-15-3-trigger-resolver-execution"><a class="toc-anchor" href="#mod-perm-msg-15-3-trigger-resolver-execution" >§</a> [MOD-PERM-MSG-15-3] Trigger Resolver execution</h5>
+<p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
+<p>This method does not modify the state of the <a class="term-reference" href="#term:vpr">VPR</a>. It MUST emit an event signaling that a trust resolution has been triggered for <code>perm</code>. The event MUST include at least:</p>
+<ul>
+<li><code>perm_id</code>: equal to <code>id</code>.</li>
+</ul>
+<blockquote>
+<p>Note: the identity of the signers (<code>corporation</code>, <code>operator</code>), the fee payer, the block height and timestamp, and the full Msg payload are already observable from the transaction itself. Indexers MAY use the <code>Permission</code> entry queried by <code>perm_id</code> to resolve <code>did</code>, <code>corporation</code>, <code>vs_operator</code>, and ancestor chain without duplicating them in the event payload.</p>
+</blockquote>
 <h4 id="mod-perm-qry-1-list-permissions"><a class="toc-anchor" href="#mod-perm-qry-1-list-permissions" >§</a> [MOD-PERM-QRY-1] List Permissions</h4>
 <p>Anyone CAN execute this method.</p>
 <p>Generic query used for (at least):</p>
@@ -3978,7 +4343,7 @@ as a direct consequence of executing authorized messages.</li>
 </li>
 </ul>
 <p>return <code>found_perms</code>.</p>
-<div id="note-15" class="notice note"><a class="notice-link" href="#note-15">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
+<div id="note-90" class="notice note"><a class="notice-link" href="#note-90">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
 </div>
 <h4 id="mod-perm-qry-5-get-permissionsession"><a class="toc-anchor" href="#mod-perm-qry-5-get-permissionsession" >§</a> [MOD-PERM-QRY-5] Get PermissionSession</h4>
 <h5 id="mod-perm-qry-5-1-get-permissionsession-parameters"><a class="toc-anchor" href="#mod-perm-qry-5-1-get-permissionsession-parameters" >§</a> [MOD-PERM-QRY-5-1] Get PermissionSession parameters</h5>
@@ -4105,11 +4470,11 @@ as a direct consequence of executing authorized messages.</li>
 <p>Each time there is a block reward to be distributed, <code>trust_deposit_block_reward_share</code> percent MUST be directed to trust deposit holders, based on their trust deposit share.</p>
 <p>Implementers MUST make sure, for each processed block reward, that the yearly effective yield is lower or equal than <code>trust_deposit_max_yield_rate</code>.</p>
 <h4 id="mod-td-msg-1-adjust-trust-deposit"><a class="toc-anchor" href="#mod-td-msg-1-adjust-trust-deposit" >§</a> [MOD-TD-MSG-1] Adjust Trust Deposit</h4>
-<p>This method is used to increase or decrease the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of a specific authority account.</p>
+<p>This method is used to increase or decrease the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of a specific corporation account.</p>
 <p>Only the modules that require trust deposit manipulation CAN call this method. If trust deposit has been slashed and not repaid, method execution MUST abort.</p>
 <h5 id="mod-td-msg-1-1-adjust-trust-deposit-method-parameters"><a class="toc-anchor" href="#mod-td-msg-1-1-adjust-trust-deposit-method-parameters" >§</a> [MOD-TD-MSG-1-1] Adjust Trust Deposit method parameters</h5>
 <ul>
-<li><code>authority</code> (group) (<em>mandatory</em>): authority owner of the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> we want to adjust.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): corporation owner of the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> we want to adjust.</li>
 <li><code>augend</code> (number) (<em>mandatory</em>): value to add to the deposit, in <a class="term-reference" href="#term:denom">denom</a>.</li>
 </ul>
 <h5 id="mod-td-msg-1-2-adjust-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-td-msg-1-2-adjust-trust-deposit-precondition-checks" >§</a> [MOD-TD-MSG-1-2] Adjust Trust Deposit precondition checks</h5>
@@ -4124,7 +4489,7 @@ as a direct consequence of executing authorized messages.</li>
 <p><code>augend</code> (number) (<em>mandatory</em>): MUST be strictly positive or strictly negative.</p>
 </li>
 <li>
-<p>load <code>TrustDeposit</code> entry <code>td</code> for <code>authority</code>.</p>
+<p>load <code>TrustDeposit</code> entry <code>td</code> for <code>corporation</code>.</p>
 <ul>
 <li>if <code>td</code> does not exist:
 <ul>
@@ -4146,7 +4511,7 @@ as a direct consequence of executing authorized messages.</li>
 <p>Additionally:</p>
 <ul>
 <li>
-<p>load <code>TrustDeposit</code> entry <code>td</code> for <code>authority</code>.</p>
+<p>load <code>TrustDeposit</code> entry <code>td</code> for <code>corporation</code>.</p>
 </li>
 <li>
 <p>if <code>td</code> exists:</p>
@@ -4164,7 +4529,7 @@ as a direct consequence of executing authorized messages.</li>
 <p>else <code>needed_deposit</code> = <code>augend</code>.</p>
 </li>
 <li>
-<p><code>authority</code> MUST have <code>needed_deposit</code> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<p><code>corporation</code> MUST have <code>needed_deposit</code> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 </li>
 </ul>
 <h5 id="mod-td-msg-1-3-adjust-trust-deposit-execution-of-the-method"><a class="toc-anchor" href="#mod-td-msg-1-3-adjust-trust-deposit-execution-of-the-method" >§</a> [MOD-TD-MSG-1-3] Adjust Trust Deposit execution of the method</h5>
@@ -4172,11 +4537,11 @@ as a direct consequence of executing authorized messages.</li>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>
-<p>if a <code>TrustDeposit</code> entry <code>td</code> does not exist for this <code>authority</code>, create entry <code>td</code>:</p>
+<p>if a <code>TrustDeposit</code> entry <code>td</code> does not exist for this <code>corporation</code>, create entry <code>td</code>:</p>
 <ul>
-<li>transfer <code>augend</code> from <code>authority</code> account to <code>TrustDeposit</code> account.</li>
+<li>transfer <code>augend</code> from <code>corporation</code> account to <code>TrustDeposit</code> account.</li>
 <li>calculate <code>augend_share</code> = <code>augend</code> / <code>GlobalVariables.trust_deposit_share_value</code>.</li>
-<li>set <code>td.authority</code> to <code>authority</code>;</li>
+<li>set <code>td.corporation</code> to <code>corporation</code>;</li>
 <li>set <code>td.deposit</code> to <code>augend</code>;</li>
 <li>set <code>td.share</code> to <code>augend_share</code>;</li>
 <li>set <code>td.claimable</code> to 0.</li>
@@ -4201,7 +4566,7 @@ as a direct consequence of executing authorized messages.</li>
 </li>
 <li>else
 <ul>
-<li>use bank? to transfer <code>augend</code> - <code>td.claimable</code> from authority account to authority <code>TrustDeposit</code> account.</li>
+<li>use bank? to transfer <code>augend</code> - <code>td.claimable</code> from corporation account to corporation <code>TrustDeposit</code> account.</li>
 <li>set <code>td.deposit</code> to <code>td.deposit</code> + <code>augend</code> - <code>td.claimable</code></li>
 <li>set <code>td.claimable</code> to 0</li>
 <li>calculate <code>missing_augend_share</code> from missing tokens :  <code>missing_augend_share</code> = (<code>augend</code> - <code>td.claimable</code>) / <code>GlobalVariables.trust_deposit_share_value</code>.</li>
@@ -4236,17 +4601,18 @@ as a direct consequence of executing authorized messages.</li>
 <p>If <code>claimable_yield</code> is positive, it can be claimed.</p>
 <h5 id="mod-td-msg-2-1-reclaim-trust-deposit-yield-method-parameters"><a class="toc-anchor" href="#mod-td-msg-2-1-reclaim-trust-deposit-yield-method-parameters" >§</a> [MOD-TD-MSG-2-1] Reclaim Trust Deposit Yield method parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 </ul>
 <h5 id="mod-td-msg-2-2-reclaim-trust-deposit-yield-precondition-checks"><a class="toc-anchor" href="#mod-td-msg-2-2-reclaim-trust-deposit-yield-precondition-checks" >§</a> [MOD-TD-MSG-2-2] Reclaim Trust Deposit Yield precondition checks</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 </ul>
 <h6 id="mod-td-msg-2-2-1-reclaim-trust-deposit-yield-basic-checks"><a class="toc-anchor" href="#mod-td-msg-2-2-1-reclaim-trust-deposit-yield-basic-checks" >§</a> [MOD-TD-MSG-2-2-1] Reclaim Trust Deposit Yield basic checks</h6>
 <ul>
-<li>Load <code>TrustDeposit</code> entry <code>td</code> from <code>authority</code>.</li>
+<li>Load <code>TrustDeposit</code> entry <code>td</code> from <code>corporation</code>.</li>
 <li>if <code>td.slashed_deposit</code> &gt; 0 and <code>td.repaid_deposit</code> &lt; <code>td.slashed_deposit</code> =&gt; deposit has been slashed and not repaid, so MUST abort.</li>
 <li>calculate <code>claimable_yield</code> = <code>td.share</code> * <code>GlobalVariables.trust_deposit_share_value</code> - <code>td.deposit</code>.</li>
 <li>if <code>claimable_yield</code> &lt;= 0, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</li>
@@ -4255,12 +4621,12 @@ as a direct consequence of executing authorized messages.</li>
 <p>Fee payer running the <a class="term-reference" href="#term:transaction">transaction</a> MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <h5 id="mod-td-msg-2-3-reclaim-trust-deposit-yield-execution-of-the-method"><a class="toc-anchor" href="#mod-td-msg-2-3-reclaim-trust-deposit-yield-execution-of-the-method" >§</a> [MOD-TD-MSG-2-3] Reclaim Trust Deposit Yield execution of the method</h5>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
-<p>For the <code>TrustDeposit</code> entry <code>td</code> linked to <code>authority</code>:</p>
+<p>For the <code>TrustDeposit</code> entry <code>td</code> linked to <code>corporation</code>:</p>
 <ul>
-<li>Load <code>TrustDeposit</code> entry <code>td</code> from <code>authority</code>.</li>
+<li>Load <code>TrustDeposit</code> entry <code>td</code> from <code>corporation</code>.</li>
 <li>calculate <code>claimable_yield</code> = <code>td.share</code> * <code>GlobalVariables.trust_deposit_share_value</code> - <code>td.deposit</code>.</li>
 <li>update <code>td.share</code> = <code>td.share</code> - <code>claimable_yield</code> / <code>GlobalVariables.trust_deposit_share_value</code></li>
-<li>transfer <code>claimable_yield</code> from <code>TrustDeposit</code> account to authority account.</li>
+<li>transfer <code>claimable_yield</code> from <code>TrustDeposit</code> account to corporation account.</li>
 </ul>
 <h4 id="mod-td-msg-3-void"><a class="toc-anchor" href="#mod-td-msg-3-void" >§</a> [MOD-TD-MSG-3] Void</h4>
 <h4 id="mod-td-msg-4-update-module-parameters"><a class="toc-anchor" href="#mod-td-msg-4-update-module-parameters" >§</a> [MOD-TD-MSG-4] Update Module Parameters</h4>
@@ -4286,12 +4652,12 @@ as a direct consequence of executing authorized messages.</li>
 <li>update parameter set value = <code>value</code> where key = <code>key</code>.</li>
 </ul>
 <h4 id="mod-td-msg-5-slash-trust-deposit"><a class="toc-anchor" href="#mod-td-msg-5-slash-trust-deposit" >§</a> [MOD-TD-MSG-5] Slash Trust Deposit</h4>
-<p>This method is used by the network governance authority to <strong>globally slash</strong> an authority <code>account</code> trust deposit.</p>
+<p>This method is used by the network governance authority to <strong>globally slash</strong> a corporation <code>account</code> trust deposit.</p>
 <p>This method can only be called by a governance proposal. A globally slashed account MUST repay the slashed deposit in order to continue to use the services provided by the VPR. When and account is slashed, and while slashed deposit has not been repaid, all account linked permissions MUST be considered non trustable.</p>
 <p>This method is for network governance authority slash. For ecosystem slash, see <a href="#mod-perm-msg-12-slash-permission-trust-deposit" >Slash Permission Trust Deposit</a>.</p>
 <h5 id="mod-td-msg-5-1-slash-trust-deposit-method-parameters"><a class="toc-anchor" href="#mod-td-msg-5-1-slash-trust-deposit-method-parameters" >§</a> [MOD-TD-MSG-5-1] Slash Trust Deposit method parameters</h5>
 <ul>
-<li><code>authority</code> (group) (<em>mandatory</em>): authority we want to slash.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): corporation we want to slash.</li>
 <li><code>amount</code> (number) (<em>mandatory</em>): value to slash, in <a class="term-reference" href="#term:denom">denom</a>.</li>
 </ul>
 <h5 id="mod-td-msg-5-2-slash-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-td-msg-5-2-slash-trust-deposit-precondition-checks" >§</a> [MOD-TD-MSG-5-2] Slash Trust Deposit precondition checks</h5>
@@ -4300,7 +4666,7 @@ as a direct consequence of executing authorized messages.</li>
 <p>if any of these conditions is not satisfied, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>amount</code> must be &gt; 0.</li>
-<li><code>TrustDeposit</code> entry <code>td</code> MUST exist for this <code>authority</code>, and <code>td.deposit</code> MUST be greater or equal to <code>amount</code>.</li>
+<li><code>TrustDeposit</code> entry <code>td</code> MUST exist for this <code>corporation</code>, and <code>td.deposit</code> MUST be greater or equal to <code>amount</code>.</li>
 </ul>
 <h6 id="mod-td-msg-5-2-2-slash-trust-deposit-fee-checks"><a class="toc-anchor" href="#mod-td-msg-5-2-2-slash-trust-deposit-fee-checks" >§</a> [MOD-TD-MSG-5-2-2] Slash Trust Deposit fee checks</h6>
 <p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
@@ -4309,7 +4675,7 @@ as a direct consequence of executing authorized messages.</li>
 <ul>
 <li>define <code>now</code>: current timestamp.</li>
 </ul>
-<p>For the <code>TrustDeposit</code> entry <code>td</code> linked to <code>authority</code>:</p>
+<p>For the <code>TrustDeposit</code> entry <code>td</code> linked to <code>corporation</code>:</p>
 <ul>
 <li>set <code>td.deposit</code> to <code>td.deposit</code> - <code>amount</code>.</li>
 <li>set <code>td.share</code> to <code>td.share</code> - <code>amount</code> / <code>GlobalVariables.trust_deposit_share_value</code></li>
@@ -4319,11 +4685,11 @@ as a direct consequence of executing authorized messages.</li>
 <li>if <code>td.slash_count</code> is undefined, set it to <code>1</code>, else set it to <code>td.slash_count</code> + 1</li>
 </ul>
 <h4 id="mod-td-msg-6-repay-slashed-trust-deposit"><a class="toc-anchor" href="#mod-td-msg-6-repay-slashed-trust-deposit" >§</a> [MOD-TD-MSG-6] Repay Slashed Trust Deposit</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</p>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <h5 id="mod-td-msg-6-1-repay-slashed-trust-deposit-method-parameters"><a class="toc-anchor" href="#mod-td-msg-6-1-repay-slashed-trust-deposit-method-parameters" >§</a> [MOD-TD-MSG-6-1] Repay Slashed Trust Deposit method parameters</h5>
 <ul>
-<li><code>authority</code> (group): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>amount</code> (number) (<em>mandatory</em>): value to repay, in <a class="term-reference" href="#term:denom">denom</a>.</li>
 </ul>
 <h5 id="mod-td-msg-6-2-repay-slashed-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-td-msg-6-2-repay-slashed-trust-deposit-precondition-checks" >§</a> [MOD-TD-MSG-6-2] Repay Slashed Trust Deposit precondition checks</h5>
@@ -4331,22 +4697,23 @@ as a direct consequence of executing authorized messages.</li>
 <h6 id="mod-td-msg-6-2-1-repay-slashed-trust-deposit-basic-checks"><a class="toc-anchor" href="#mod-td-msg-6-2-1-repay-slashed-trust-deposit-basic-checks" >§</a> [MOD-TD-MSG-6-2-1] Repay Slashed Trust Deposit basic checks</h6>
 <p>if any of these conditions is not satisfied, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>amount</code> must be &gt; 0.</li>
-<li><code>TrustDeposit</code> entry <code>td</code> MUST exist for this <code>authority</code>, and <code>amount</code> MUST be exactly equal to <code>td.slashed_deposit</code> - <code>td.repaid_deposit</code>.</li>
+<li><code>TrustDeposit</code> entry <code>td</code> MUST exist for this <code>corporation</code>, and <code>amount</code> MUST be exactly equal to <code>td.slashed_deposit</code> - <code>td.repaid_deposit</code>.</li>
 </ul>
 <h6 id="mod-td-msg-6-2-2-repay-slashed-trust-deposit-fee-checks"><a class="toc-anchor" href="#mod-td-msg-6-2-2-repay-slashed-trust-deposit-fee-checks" >§</a> [MOD-TD-MSG-6-2-2] Repay Slashed Trust Deposit fee checks</h6>
 <ul>
 <li>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>;</li>
-<li><code>authority</code> MUST have the required <code>amount</code> in its account, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</li>
+<li><code>corporation</code> MUST have the required <code>amount</code> in its account, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</li>
 </ul>
 <h5 id="mod-td-msg-6-3-repay-slashed-trust-deposit-execution-of-the-method"><a class="toc-anchor" href="#mod-td-msg-6-3-repay-slashed-trust-deposit-execution-of-the-method" >§</a> [MOD-TD-MSG-6-3] Repay Slashed Trust Deposit execution of the method</h5>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>define <code>now</code>: current timestamp.</li>
 </ul>
-<p>For the <code>TrustDeposit</code> entry <code>td</code> linked to authority <code>account</code>:</p>
+<p>For the <code>TrustDeposit</code> entry <code>td</code> linked to corporation <code>account</code>:</p>
 <ul>
 <li>set <code>td.deposit</code> to <code>td.deposit</code> + <code>amount</code>.</li>
 <li>set <code>td.share</code> to <code>td.share</code> + <code>amount</code> / <code>GlobalVariables.trust_deposit_share_value</code></li>
@@ -4356,14 +4723,14 @@ as a direct consequence of executing authorized messages.</li>
 </ul>
 <h4 id="mod-td-msg-7-burn-ecosystem-slashed-trust-deposit"><a class="toc-anchor" href="#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit" >§</a> [MOD-TD-MSG-7] Burn Ecosystem Slashed Trust Deposit</h4>
 <p>Burn the portion of the trust deposit of a given account. This method can only be called by the permission module when performing an ecosystem-related slash.</p>
-<div id="warning-5" class="notice warning"><a class="notice-link" href="#warning-5">WARNING</a><p>Make sure to <strong>properly protect access to the execution of this method</strong> else it may lead to very destructive actions.</p>
+<div id="warning-50" class="notice warning"><a class="notice-link" href="#warning-50">WARNING</a><p>Make sure to <strong>properly protect access to the execution of this method</strong> else it may lead to very destructive actions.</p>
 </div>
 <h5 id="mod-td-msg-7-1-burn-ecosystem-slashed-trust-deposit-method-parameters"><a class="toc-anchor" href="#mod-td-msg-7-1-burn-ecosystem-slashed-trust-deposit-method-parameters" >§</a> [MOD-TD-MSG-7-1] Burn Ecosystem Slashed Trust Deposit method parameters</h5>
 <ul>
-<li><code>authority</code> (group) (<em>mandatory</em>): authority of the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> we want to burn.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): corporation of the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> we want to burn.</li>
 <li><code>amount</code> (number) (<em>mandatory</em>): value to burn, in <a class="term-reference" href="#term:denom">denom</a>.</li>
 </ul>
-<div id="warning-6" class="notice warning"><a class="notice-link" href="#warning-6">WARNING</a><p><strong>Alternative approach</strong>: For security and consistency, implementers MAY choose to reference the <strong>ID of the slashed permission</strong>, load it and use its defined <code>slashed_deposit</code> value as the slashing amount.
+<div id="warning-51" class="notice warning"><a class="notice-link" href="#warning-51">WARNING</a><p><strong>Alternative approach</strong>: For security and consistency, implementers MAY choose to reference the <strong>ID of the slashed permission</strong>, load it and use its defined <code>slashed_deposit</code> value as the slashing amount.
 The decision between this method and specifying the amount directly is left to implementers.</p>
 </div>
 <h5 id="mod-td-msg-7-2-burn-ecosystem-slashed-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-td-msg-7-2-burn-ecosystem-slashed-trust-deposit-precondition-checks" >§</a> [MOD-TD-MSG-7-2] Burn Ecosystem Slashed Trust Deposit precondition checks</h5>
@@ -4372,7 +4739,7 @@ The decision between this method and specifying the amount directly is left to i
 <p>if any of these conditions is not satisfied, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>amount</code> must be &gt; 0.</li>
-<li><code>TrustDeposit</code> entry <code>td</code> MUST exist for this <code>authority</code>, and <code>amount</code> MUST be lower or equal than <code>td.deposit</code>.</li>
+<li><code>TrustDeposit</code> entry <code>td</code> MUST exist for this <code>corporation</code>, and <code>amount</code> MUST be lower or equal than <code>td.deposit</code>.</li>
 </ul>
 <h6 id="mod-td-msg-7-2-2-burn-ecosystem-slashed-trust-deposit-fee-checks"><a class="toc-anchor" href="#mod-td-msg-7-2-2-burn-ecosystem-slashed-trust-deposit-fee-checks" >§</a> [MOD-TD-MSG-7-2-2] Burn Ecosystem Slashed Trust Deposit fee checks</h6>
 <p>Fee payer running the <a class="term-reference" href="#term:transaction">transaction</a> MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a> else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
@@ -4419,14 +4786,13 @@ The decision between this method and specifying the amount directly is left to i
 <h4 id="mod-de-msg-1-grant-fee-allowance"><a class="toc-anchor" href="#mod-de-msg-1-grant-fee-allowance" >§</a> [MOD-DE-MSG-1] Grant Fee Allowance</h4>
 <p>This method can only be called directly by the following methods:</p>
 <ul>
-<li>Grant Operator Authorization</li>
-<li>Grant VS Operator Authorization</li>
-<li>Revoke VS Operator Authorization</li>
+<li><a href="#mod-de-msg-3-grant-operator-authorization" >Grant Operator Authorization</a></li>
+<li>the VS Operator Authorization feegrant subroutine <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a> (invoked by <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a>, <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a> and <a href="#mod-de-msg-9-update-vs-operator-authorization-expiration" >[MOD-DE-MSG-9]</a>)</li>
 </ul>
 <h5 id="mod-de-msg-1-1-grant-fee-allowance-method-parameters"><a class="toc-anchor" href="#mod-de-msg-1-1-grant-fee-allowance-method-parameters" >§</a> [MOD-DE-MSG-1-1] Grant Fee Allowance method parameters</h5>
 <ul>
-<li><code>authority</code> (group) (<em>mandatory</em>): the authority that grants the fees.</li>
-<li><code>grantee</code> (account) (<em>mandatory</em>): the account that receives the fee grant from <code>authority</code>.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): the corporation that grants the fees.</li>
+<li><code>grantee</code> (account) (<em>mandatory</em>): the account that receives the fee grant from <code>corporation</code>.</li>
 <li><code>msg_types</code> (Msg[]) (<em>mandatory</em>): the type of messages for which we want to grant the fee allowance.</li>
 <li><code>expiration</code> (timestamp) (<em>optional</em>): when the grant expires.</li>
 <li><code>spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum spendable</li>
@@ -4448,7 +4814,7 @@ The decision between this method and specifying the amount directly is left to i
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <p>Create (or update if it already exist) FeeGrant <code>feegrant</code>:</p>
 <ul>
-<li>set <code>feegrant.grantor</code> to <code>authority</code></li>
+<li>set <code>feegrant.grantor</code> to <code>corporation</code></li>
 <li>set <code>feegrant.grantee</code> to <code>grantee</code></li>
 <li>set <code>feegrant.msg_types</code> to <code>msg_types</code></li>
 <li>set <code>feegrant.expiration</code> to <code>expiration</code></li>
@@ -4458,19 +4824,19 @@ The decision between this method and specifying the amount directly is left to i
 <h4 id="mod-de-msg-2-revoke-fee-allowance"><a class="toc-anchor" href="#mod-de-msg-2-revoke-fee-allowance" >§</a> [MOD-DE-MSG-2] Revoke Fee Allowance</h4>
 <p>This method can only be called directly by the following methods:</p>
 <ul>
-<li>Grant Operator Authorization</li>
-<li>Revoke Operator Authorization</li>
-<li>Revoke VS Operator Authorization</li>
+<li><a href="#mod-de-msg-3-grant-operator-authorization" >Grant Operator Authorization</a></li>
+<li><a href="#mod-de-msg-4-revoke-operator-authorization" >Revoke Operator Authorization</a></li>
+<li>the VS Operator Authorization feegrant subroutine <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a> (invoked by <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a>, <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a> and <a href="#mod-de-msg-9-update-vs-operator-authorization-expiration" >[MOD-DE-MSG-9]</a>)</li>
 </ul>
 <h5 id="mod-de-msg-2-1-revoke-allowance-method-parameters"><a class="toc-anchor" href="#mod-de-msg-2-1-revoke-allowance-method-parameters" >§</a> [MOD-DE-MSG-2-1] Revoke Allowance method parameters</h5>
 <ul>
-<li><code>authority</code> (group) (<em>mandatory</em>): the authority.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): the corporation.</li>
 <li><code>grantee</code> (account) (<em>mandatory</em>): the grantee we want to revoke.</li>
 </ul>
 <h5 id="mod-de-msg-2-2-revoke-fee-allowance-basic-checks"><a class="toc-anchor" href="#mod-de-msg-2-2-revoke-fee-allowance-basic-checks" >§</a> [MOD-DE-MSG-2-2] Revoke Fee Allowance basic checks</h5>
 <p>MUST abort if one of these conditions fails:</p>
 <ul>
-<li><code>authority</code> (group) (<em>mandatory</em>): MUST be specified.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): MUST be specified.</li>
 <li><code>grantee</code> (account) (<em>mandatory</em>): MUST be specified.</li>
 </ul>
 <h5 id="mod-de-msg-2-3-revoke-fee-allowance-fee-checks"><a class="toc-anchor" href="#mod-de-msg-2-3-revoke-fee-allowance-fee-checks" >§</a> [MOD-DE-MSG-2-3] Revoke Fee Allowance fee checks</h5>
@@ -4478,17 +4844,17 @@ The decision between this method and specifying the amount directly is left to i
 <li>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>;</li>
 </ul>
 <h5 id="mod-de-msg-2-4-revoke-fee-allowance-execution-of-the-method"><a class="toc-anchor" href="#mod-de-msg-2-4-revoke-fee-allowance-execution-of-the-method" >§</a> [MOD-DE-MSG-2-4] Revoke Fee Allowance execution of the method</h5>
-<p>If FeeGrant entry for this (<code>authority</code>, <code>grantee</code>) exist, delete it, else do nothing.</p>
+<p>If FeeGrant entry for this (<code>corporation</code>, <code>grantee</code>) exist, delete it, else do nothing.</p>
 <h4 id="mod-de-msg-3-grant-operator-authorization"><a class="toc-anchor" href="#mod-de-msg-3-grant-operator-authorization" >§</a> [MOD-DE-MSG-3] Grant Operator Authorization</h4>
 <ul>
-<li>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</li>
-<li><code>authority</code> CAN execute this method alone through a group proposal</li>
+<li>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</li>
+<li><code>corporation</code> CAN execute this method alone through a group proposal</li>
 </ul>
 <h5 id="mod-de-msg-3-1-grant-operator-authorization-method-parameters"><a class="toc-anchor" href="#mod-de-msg-3-1-grant-operator-authorization-method-parameters" >§</a> [MOD-DE-MSG-3-1] Grant Operator Authorization method parameters</h5>
 <ul>
-<li><code>authority</code> (group) (<em>mandatory</em>): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account) (<em>optional</em>): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
-<li><code>grantee</code> (account) (<em>mandatory</em>): the account that receives the authorization from <code>authority</code>.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account) (<em>optional</em>): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
+<li><code>grantee</code> (account) (<em>mandatory</em>): the account that receives the authorization from <code>corporation</code>.</li>
 <li><code>msg_types</code> (Msg[]) (<em>mandatory</em>): the type of messages for which we want to grant the fee allowance.</li>
 <li><code>expiration</code> (timestamp) (<em>optional</em>): when the authorization (and its optional feegrant) expires.</li>
 <li><code>authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum spendable</li>
@@ -4501,10 +4867,13 @@ The decision between this method and specifying the amount directly is left to i
 <p>if any of these conditions is not satisfied, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li>
-<p><code>authority</code> (group): (Signer) signature must be verified.</p>
+<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
 </li>
 <li>
 <p><code>operator</code> (account): (Signer) signature must be verified.</p>
+</li>
+<li>
+<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
 </li>
 <li>
 <p><code>msg_types</code> (Msg[]) (<em>mandatory</em>): MUST be a list of <strong>VPR delegable messages only</strong>, excepted <code>CreateOrUpdatePermissionSession</code> which is not allowed.</p>
@@ -4525,10 +4894,10 @@ The decision between this method and specifying the amount directly is left to i
 <p><code>feegrant_spend_limit_period</code> (duration): if specified MUST be a valid period. Ignored if <code>feegrant_spend_limit</code> is not set or if <code>with_feegrant</code> is false.</p>
 </li>
 <li>
-<p>Check if a <strong>VS Operator Authorization</strong> exists for <code>authority</code> and <code>grantee</code>. If this is the case, MUST abort.</p>
+<p>Check if a <strong>VS Operator Authorization</strong> exists for <code>corporation</code> and <code>grantee</code>. If this is the case, MUST abort.</p>
 </li>
 </ul>
-<div id="warning-7" class="notice warning"><a class="notice-link" href="#warning-7">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>perm.authority</code> and <code>perm.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-52" class="notice warning"><a class="notice-link" href="#warning-52">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>perm.corporation</code> and <code>perm.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-3-3-grant-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-3-3-grant-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-3-3] Grant Operator Authorization fee checks</h5>
 <ul>
@@ -4538,7 +4907,7 @@ The decision between this method and specifying the amount directly is left to i
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <p>Create (or update if it already exist) Authorization <code>authz</code>:</p>
 <ul>
-<li>set <code>authz.authority</code> to <code>authority</code></li>
+<li>set <code>authz.corporation</code> to <code>corporation</code></li>
 <li>set <code>authz.operator</code> to <code>grantee</code></li>
 <li>set <code>authz.msg_types</code> to <code>msg_types</code></li>
 <li>set <code>authz.expiration</code> to <code>expiration</code></li>
@@ -4547,29 +4916,30 @@ The decision between this method and specifying the amount directly is left to i
 </ul>
 <p>if <code>with_feegrant</code> is false:</p>
 <ul>
-<li>call Revoke Fee Allowance (<code>authority</code>, <code>grantee</code>).</li>
+<li>call Revoke Fee Allowance (<code>corporation</code>, <code>grantee</code>).</li>
 </ul>
 <p>else if <code>with_feegrant</code> is true:</p>
 <ul>
-<li>grant Fee Allowance (<code>authority</code>, <code>grantee</code>, <code>msg_types</code>, <code>expiration</code>, <code>feegrant_spend_limit</code>, <code>feegrant_spend_limit_period</code>).</li>
+<li>grant Fee Allowance (<code>corporation</code>, <code>grantee</code>, <code>msg_types</code>, <code>expiration</code>, <code>feegrant_spend_limit</code>, <code>feegrant_spend_limit_period</code>).</li>
 </ul>
 <h4 id="mod-de-msg-4-revoke-operator-authorization"><a class="toc-anchor" href="#mod-de-msg-4-revoke-operator-authorization" >§</a> [MOD-DE-MSG-4] Revoke Operator Authorization</h4>
 <ul>
-<li>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</li>
-<li><code>authority</code> CAN execute this method alone through a group proposal</li>
+<li>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</li>
+<li><code>corporation</code> CAN execute this method alone through a group proposal</li>
 </ul>
 <h5 id="mod-de-msg-4-1-revoke-operator-authorization-method-parameters"><a class="toc-anchor" href="#mod-de-msg-4-1-revoke-operator-authorization-method-parameters" >§</a> [MOD-DE-MSG-4-1] Revoke Operator Authorization method parameters</h5>
 <ul>
-<li><code>authority</code> (group) (<em>mandatory</em>): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account) (<em>mandatory</em>): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account) (<em>mandatory</em>): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>grantee</code> (account) (<em>mandatory</em>): the account that will be revoked its authorization`.</li>
 </ul>
 <h5 id="mod-de-msg-4-2-revoke-operator-authorization-basic-checks"><a class="toc-anchor" href="#mod-de-msg-4-2-revoke-operator-authorization-basic-checks" >§</a> [MOD-DE-MSG-4-2] Revoke Operator Authorization basic checks</h5>
 <p>MUST abort if one of these conditions fails:</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
-<li>An Authorization entry MUST exist for this (<code>authority</code>, <code>grantee</code>)</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
+<li>An Authorization entry MUST exist for this (<code>corporation</code>, <code>grantee</code>)</li>
 </ul>
 <h5 id="mod-de-msg-4-3-revoke-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-4-3-revoke-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-4-3] Revoke Operator Authorization fee checks</h5>
 <ul>
@@ -4577,143 +4947,180 @@ The decision between this method and specifying the amount directly is left to i
 </ul>
 <h5 id="mod-de-msg-4-4-revoke-operator-authorization-execution-of-the-method"><a class="toc-anchor" href="#mod-de-msg-4-4-revoke-operator-authorization-execution-of-the-method" >§</a> [MOD-DE-MSG-4-4] Revoke Operator Authorization execution of the method</h5>
 <ul>
-<li>Delete Authorization entry for this (<code>authority</code>, <code>grantee</code>).</li>
-<li>revoke Fee Allowance (<code>authority</code>, <code>grantee</code>).</li>
+<li>Delete Authorization entry for this (<code>corporation</code>, <code>grantee</code>).</li>
+<li>revoke Fee Allowance (<code>corporation</code>, <code>grantee</code>).</li>
 </ul>
 <h4 id="mod-de-msg-5-grant-vs-operator-authorization"><a class="toc-anchor" href="#mod-de-msg-5-grant-vs-operator-authorization" >§</a> [MOD-DE-MSG-5] Grant VS Operator Authorization</h4>
-<p>This method can only be called directly by the following methods with no signer check:</p>
+<p>This method can only be called directly by the following Permission module methods, with no signer check:</p>
 <ul>
-<li>Self Create Permission</li>
-<li>Adjust Permission</li>
-<li>Set Permission VP to Validated</li>
+<li><a href="#mod-perm-msg-1-start-permission-vp" >Start Permission VP</a></li>
+<li><a href="#mod-perm-msg-14-self-create-permission" >Self Create Permission</a></li>
 </ul>
-<blockquote>
-<p>Note: This methid can only grant authorization for the <code>CreateOrUpdatePermissionSession</code> Msg.</p>
-</blockquote>
+<p>It creates a new <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> inside <code>VSOperatorAuthorization[corporation, vs_operator]</code> and, if the record enables a fee grant and its <code>expiration</code> is in the future, synchronises the on-chain <code>FeeGrant</code> for the containing VSOA.</p>
+<p>This method does NOT read <code>Permission</code> state. All authorization configuration is provided by the caller.</p>
 <h5 id="mod-de-msg-5-1-grant-vs-operator-authorization-method-parameters"><a class="toc-anchor" href="#mod-de-msg-5-1-grant-vs-operator-authorization-method-parameters" >§</a> [MOD-DE-MSG-5-1] Grant VS Operator Authorization method parameters</h5>
 <ul>
-<li><code>perm_id</code> (uint64) (<em>mandatory</em>): the permission this authorization is referring to.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): the corporation delegating the authorization.</li>
+<li><code>vs_operator</code> (account) (<em>mandatory</em>): the account receiving the authorization.</li>
+<li><code>record</code> (<a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a>) (<em>mandatory</em>): the full record to store.</li>
 </ul>
 <h5 id="mod-de-msg-5-2-grant-vs-operator-authorization-basic-checks"><a class="toc-anchor" href="#mod-de-msg-5-2-grant-vs-operator-authorization-basic-checks" >§</a> [MOD-DE-MSG-5-2] Grant VS Operator Authorization basic checks</h5>
-<p>if any of these conditions is not satisfied, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<p>If any of these conditions is not satisfied, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><code>perm_id</code> (uint64) (<em>mandatory</em>): Permission MUST exist.</li>
-<li>load Permission <code>perm</code> with <code>perm_id</code>. <code>perm.authority</code> and <code>perm.vs_operator</code> MUST NOT be null.</li>
-<li>Check if a <strong>Operator Authorization</strong> exists for <code>perm.authority</code> and <code>perm.vs_operator</code>. If this is the case, MUST abort.</li>
+<li><code>corporation</code> and <code>vs_operator</code> MUST NOT be null.</li>
+<li><code>record.perm_id</code> MUST NOT match an existing <code>PermissionAuthorizationRecord</code> anywhere in the store (each record is globally unique by <code>perm_id</code>).</li>
+<li><code>record.msg_types</code> MUST be non-empty and MUST contain only VPR delegable message types.</li>
+<li>No <code>OperatorAuthorization</code> <code>oauthz</code> where <code>oauthz.corporation</code> = <code>corporation</code> and <code>oauthz.operator</code> = <code>vs_operator</code> MUST exist.</li>
 </ul>
-<div id="warning-8" class="notice warning"><a class="notice-link" href="#warning-8">WARNING</a><p>A <strong>VS Operator Authorization</strong> CAN be granted ONLY IF no <strong>Operator Authorization</strong> exists for <code>perm.authority</code> and <code>perm.vs_operator</code>. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-53" class="notice warning"><a class="notice-link" href="#warning-53">WARNING</a><p>A <strong>VS Operator Authorization</strong> record CAN be granted ONLY IF no <strong>OperatorAuthorization</strong> exists for the same <code>(corporation, vs_operator)</code> pair. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-5-3-grant-vs-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-5-3-grant-vs-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-5-3] Grant VS Operator Authorization fee checks</h5>
 <ul>
-<li>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>;</li>
+<li>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>.</li>
 </ul>
 <h5 id="mod-de-msg-5-4-grant-vs-operator-authorization-execution-of-the-method"><a class="toc-anchor" href="#mod-de-msg-5-4-grant-vs-operator-authorization-execution-of-the-method" >§</a> [MOD-DE-MSG-5-4] Grant VS Operator Authorization execution of the method</h5>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
-<p>Load Permission <code>perm</code> with <code>perm_id</code>.</p>
-<p>Create VSOperatorAuthorization <code>vs_operator_authz</code> if it doesn’t exist yet:</p>
 <ul>
-<li>set <code>vs_operator_authz.grantor</code> to <code>perm.authority</code></li>
-<li>set <code>vs_operator_authz.grantee</code> to <code>perm.vs_operator</code></li>
+<li>Load <code>VSOperatorAuthorization</code> <code>vsoa</code> with <code>(corporation, vs_operator)</code>. If it does not exist, create a new <code>vsoa</code> with <code>vsoa.corporation = corporation</code>, <code>vsoa.vs_operator = vs_operator</code>, <code>vsoa.records = []</code>.</li>
+<li>Append <code>record</code> to <code>vsoa.records</code>.</li>
+<li>Call <strong><a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >Recompute VS Operator Fee Allowance</a></strong> for <code>vsoa</code>.</li>
 </ul>
-<p>then, add the perm_id to the list of authorized permissions:</p>
+<h5 id="mod-de-msg-5-5-recompute-vs-operator-fee-allowance"><a class="toc-anchor" href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >§</a> [MOD-DE-MSG-5-5] Recompute VS Operator Fee Allowance</h5>
+<p>This is a shared subroutine invoked by <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a>, <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a> and <a href="#mod-de-msg-9-update-vs-operator-authorization-expiration" >[MOD-DE-MSG-9]</a> after they mutate <code>vsoa.records</code>.</p>
 <ul>
-<li>Add <code>perm_id</code> to <code>vs_operator_authz.permissions</code></li>
-</ul>
-<p>Then check for feegrant:</p>
+<li>define <code>max_expire</code> = null.</li>
+<li>define <code>feegrant_msg_types</code> = empty set.</li>
+<li>for each <code>r</code> in <code>vsoa.records</code>:
 <ul>
-<li>if <code>perm.vs_operator_authz_with_feegrant</code> is true:
+<li>if <code>r.with_feegrant</code> is true AND <code>r.expiration</code> &gt; now():
 <ul>
-<li>set <code>max_expire</code> = <code>perm.effective_until</code></li>
-<li>if <code>max_expire</code> == null: call Grant Fee Allowance (<code>authority</code>, <code>grantee</code>, <code>CreateOrUpdatePermissionSession</code>, null, null, null) and EXIT.</li>
-<li>else foreach <code>current_perm_id</code> of <code>vs_operator_authz.permissions</code>
-<ul>
-<li>load Permission <code>current_perm</code> from <code>current_perm_id</code></li>
-<li>if <code>current_perm.vs_operator_authz_with_feegrant</code> is true:
-<ul>
-<li>if <code>current_perm.effective_until</code> == null: call Grant Fee Allowance (<code>authority</code>, <code>grantee</code>, <code>CreateOrUpdatePermissionSession</code>, null, null, null) and EXIT.</li>
-<li>else if <code>current_perm.effective_until</code> &gt; <code>max_expire</code> =&gt; set <code>max_expire</code> = <code>current_perm.effective_until</code></li>
+<li>if <code>max_expire</code> is null OR <code>r.expiration</code> &gt; <code>max_expire</code>, set <code>max_expire</code> = <code>r.expiration</code>.</li>
+<li>add all entries of <code>r.msg_types</code> to <code>feegrant_msg_types</code>.</li>
 </ul>
 </li>
 </ul>
 </li>
-<li>if <code>max_expire</code> &gt; now, call Grant Fee Allowance (<code>authority</code>, <code>grantee</code>, <code>CreateOrUpdatePermissionSession</code>, <code>max_expire</code>, null, null).</li>
+<li>if <code>max_expire</code> is null (no active feegrant-enabled record remains): call <a href="#mod-de-msg-2-revoke-fee-allowance" >Revoke Fee Allowance</a>(<code>vsoa.corporation</code>, <code>vsoa.vs_operator</code>).</li>
+<li>else: call <a href="#mod-de-msg-1-grant-fee-allowance" >Grant Fee Allowance</a>(<code>vsoa.corporation</code>, <code>vsoa.vs_operator</code>, <code>feegrant_msg_types</code>, <code>max_expire</code>, null, null).</li>
 </ul>
-</li>
-</ul>
-<div id="note-16" class="notice note"><a class="notice-link" href="#note-16">NOTE</a><p>We MUST align to the farthest effective_until for the feegrant, for the permissions that have <code>current_perm.effective_until</code> set.</p>
-</div>
+<blockquote>
+<p>Note: <code>max_expire</code> is bounded by the farthest <code>record.expiration</code> among feegrant-enabled records. The chain-level <code>FeeGrant</code> <code>msg_types</code> is the union of all such records’ <code>msg_types</code>. Per-record spend limits are enforced at <a href="#authz-check-4-vs-operator-fee-grant-checks" >[AUTHZ-CHECK-4]</a> time; they are not replicated on the <code>FeeGrant</code> object.</p>
+</blockquote>
 <h4 id="mod-de-msg-6-revoke-vs-operator-authorization"><a class="toc-anchor" href="#mod-de-msg-6-revoke-vs-operator-authorization" >§</a> [MOD-DE-MSG-6] Revoke VS Operator Authorization</h4>
-<p>This method can only be called by the following methods with no signer check:</p>
+<p>This method can only be called directly by the following Permission module methods, with no signer check:</p>
 <ul>
-<li>Revoke Permission</li>
-<li>Slash Permission Trust Deposit</li>
+<li><a href="#mod-perm-msg-6-cancel-permission-vp-last-request" >Cancel Permission VP Last Request</a> (only when the cancellation terminates the permission)</li>
+<li><a href="#mod-perm-msg-9-revoke-permission" >Revoke Permission</a></li>
+<li><a href="#mod-perm-msg-12-slash-permission-trust-deposit" >Slash Permission Trust Deposit</a></li>
 </ul>
+<p>It removes the unique <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> identified by <code>perm_id</code> and recomputes the on-chain <code>FeeGrant</code> of its containing VSOA. No-op if no such record exists.</p>
+<p>This method does NOT read <code>Permission</code> state.</p>
 <h5 id="mod-de-msg-6-1-revoke-vs-operator-authorization-method-parameters"><a class="toc-anchor" href="#mod-de-msg-6-1-revoke-vs-operator-authorization-method-parameters" >§</a> [MOD-DE-MSG-6-1] Revoke VS Operator Authorization method parameters</h5>
 <ul>
-<li><code>perm_id</code> (uint64) (<em>mandatory</em>): the permission this authorization is referring to.</li>
+<li><code>perm_id</code> (uint64) (<em>mandatory</em>): id of the permission whose authorization record must be removed.</li>
 </ul>
 <h5 id="mod-de-msg-6-2-revoke-vs-operator-authorization-basic-checks"><a class="toc-anchor" href="#mod-de-msg-6-2-revoke-vs-operator-authorization-basic-checks" >§</a> [MOD-DE-MSG-6-2] Revoke VS Operator Authorization basic checks</h5>
-<p>MUST abort if one of these conditions fails:</p>
 <ul>
-<li><code>perm_id</code> (uint64) (<em>mandatory</em>): Permission MUST exist.</li>
-<li>load Permission <code>perm</code> with <code>perm_id</code>. <code>perm.authority</code> and <code>perm.vs_operator</code> MUST NOT be null.</li>
+<li><code>perm_id</code> MUST be a valid uint64.</li>
 </ul>
+<blockquote>
+<p>Note: absence of a record for <code>perm_id</code> is NOT an error. The method is a no-op in that case (the permission was never VS-operator-authorized, or was already revoked).</p>
+</blockquote>
 <h5 id="mod-de-msg-6-3-revoke-vs-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-6-3-revoke-vs-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-6-3] Revoke VS Operator Authorization fee checks</h5>
 <ul>
-<li>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>;</li>
+<li>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>.</li>
 </ul>
 <h5 id="mod-de-msg-6-4-revoke-vs-operator-authorization-execution-of-the-method"><a class="toc-anchor" href="#mod-de-msg-6-4-revoke-vs-operator-authorization-execution-of-the-method" >§</a> [MOD-DE-MSG-6-4] Revoke VS Operator Authorization execution of the method</h5>
 <ul>
-<li>load Permission <code>perm</code> with <code>perm_id</code>.</li>
-<li>load VSOperatorAuthorization <code>vs_operator_authz</code> with <code>perm.authority</code> and <code>perm.vs_operator</code>.</li>
-<li>If <code>vs_operator_authz</code> is not null:
+<li>Locate the unique <code>PermissionAuthorizationRecord</code> <code>record</code> with <code>record.perm_id = perm_id</code>. If none exists, EXIT (no-op).</li>
+<li>Let <code>vsoa</code> = the <code>VSOperatorAuthorization</code> that contains <code>record</code>.</li>
+<li>Remove <code>record</code> from <code>vsoa.records</code>.</li>
+<li>Call <strong><a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >Recompute VS Operator Fee Allowance</a></strong> for <code>vsoa</code>.</li>
+<li>If <code>vsoa.records</code> is now empty, delete <code>vsoa</code>.</li>
+</ul>
+<h4 id="mod-de-msg-9-update-vs-operator-authorization-expiration"><a class="toc-anchor" href="#mod-de-msg-9-update-vs-operator-authorization-expiration" >§</a> [MOD-DE-MSG-9] Update VS Operator Authorization Expiration</h4>
+<p>This method can only be called directly by the following Permission module methods, with no signer check:</p>
 <ul>
-<li>remove <code>perm_id</code> from <code>vs_operator_authz.permissions</code> if present.</li>
-<li>if <code>perm.vs_operator_authz_with_feegrant</code> is true:
+<li><a href="#mod-perm-msg-3-set-permission-vp-to-validated" >Set Permission VP to Validated</a></li>
+<li><a href="#mod-perm-msg-8-adjust-permission" >Adjust Permission</a></li>
+</ul>
+<p>It updates the <code>expiration</code> of the unique record identified by <code>perm_id</code> and recomputes the on-chain <code>FeeGrant</code> of its containing VSOA. No-op if no record exists for <code>perm_id</code>.</p>
+<p>This method does NOT read <code>Permission</code> state; the caller supplies the new expiration value directly.</p>
+<h5 id="mod-de-msg-9-1-update-vs-operator-authorization-expiration-method-parameters"><a class="toc-anchor" href="#mod-de-msg-9-1-update-vs-operator-authorization-expiration-method-parameters" >§</a> [MOD-DE-MSG-9-1] Update VS Operator Authorization Expiration method parameters</h5>
 <ul>
-<li>if size(vs_operator_authz.permissions) == 0 =&gt; call Revoke Fee Allowance (<code>perm.authority</code>, <code>perm.vs_operator</code>).</li>
-<li>else define <code>max_expire</code> = null</li>
-<li>foreach <code>current_perm_id</code> of <code>vs_operator_authz.permissions</code>
+<li><code>perm_id</code> (uint64) (<em>mandatory</em>): id of the permission whose authorization record’s <code>expiration</code> must be updated.</li>
+<li><code>new_expiration</code> (timestamp) (<em>mandatory</em>): the new value of <code>record.expiration</code>.</li>
+</ul>
+<h5 id="mod-de-msg-9-2-update-vs-operator-authorization-expiration-basic-checks"><a class="toc-anchor" href="#mod-de-msg-9-2-update-vs-operator-authorization-expiration-basic-checks" >§</a> [MOD-DE-MSG-9-2] Update VS Operator Authorization Expiration basic checks</h5>
 <ul>
-<li>load Permission <code>current_perm</code> from <code>current_perm_id</code></li>
-<li>if <code>current_perm.vs_operator_authz_with_feegrant</code> is true:
+<li><code>perm_id</code> MUST be a valid uint64.</li>
+<li><code>new_expiration</code> MUST be a valid timestamp.</li>
+</ul>
+<blockquote>
+<p>Note: absence of a record for <code>perm_id</code> is NOT an error. The method is a no-op in that case (the permission does not enable VS operator authorization).</p>
+</blockquote>
+<h5 id="mod-de-msg-9-3-update-vs-operator-authorization-expiration-fee-checks"><a class="toc-anchor" href="#mod-de-msg-9-3-update-vs-operator-authorization-expiration-fee-checks" >§</a> [MOD-DE-MSG-9-3] Update VS Operator Authorization Expiration fee checks</h5>
 <ul>
-<li>if <code>current_perm.effective_until</code> == null set <code>max_expire</code> = null</li>
-<li>else if <code>max_expire</code> == null set <code>max_expire</code> = <code>current_perm.effective_until</code></li>
-<li>else <code>max_expire</code> = max (<code>max_expire</code>, <code>current_perm.effective_until</code>)</li>
+<li>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>.</li>
 </ul>
-</li>
+<h5 id="mod-de-msg-9-4-update-vs-operator-authorization-expiration-execution-of-the-method"><a class="toc-anchor" href="#mod-de-msg-9-4-update-vs-operator-authorization-expiration-execution-of-the-method" >§</a> [MOD-DE-MSG-9-4] Update VS Operator Authorization Expiration execution of the method</h5>
+<ul>
+<li>Locate the unique <code>PermissionAuthorizationRecord</code> <code>record</code> with <code>record.perm_id = perm_id</code>. If none exists, EXIT (no-op).</li>
+<li>Set <code>record.expiration = new_expiration</code>.</li>
+<li>Call <strong><a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >Recompute VS Operator Fee Allowance</a></strong> for the VSOA containing <code>record</code>.</li>
 </ul>
-</li>
-<li>if <code>max_expire</code> &gt; now, call Grant Fee Allowance (<code>authority</code>, <code>grantee</code>, <code>CreateOrUpdatePermissionSession</code>, <code>max_expire</code>, null, null).</li>
+<h4 id="mod-de-qry-1-list-operator-authorizations"><a class="toc-anchor" href="#mod-de-qry-1-list-operator-authorizations" >§</a> [MOD-DE-QRY-1] List Operator Authorizations</h4>
+<p>Anyone CAN execute this method.</p>
+<h5 id="mod-de-qry-1-1-list-operator-authorizations-parameters"><a class="toc-anchor" href="#mod-de-qry-1-1-list-operator-authorizations-parameters" >§</a> [MOD-DE-QRY-1-1] List Operator Authorizations parameters</h5>
+<ul>
+<li><code>corporation</code> (group) (<em>optional</em>): filter by the corporation group that granted the authorization.</li>
+<li><code>operator</code> (account) (<em>optional</em>): filter by the operator account that received the authorization.</li>
+<li><code>response_max_size</code> (small number) (<em>optional</em>): limit to <code>response_max_size</code> results. Must be min 1, max 1,024. Default to 64.</li>
 </ul>
-</li>
+<h5 id="mod-de-qry-1-2-list-operator-authorizations-checks"><a class="toc-anchor" href="#mod-de-qry-1-2-list-operator-authorizations-checks" >§</a> [MOD-DE-QRY-1-2] List Operator Authorizations checks</h5>
+<p>Basic type check arg SHOULD be applied.</p>
+<p>If any of these checks fail, <a class="term-reference" href="#term:query">query</a> MUST fail.</p>
+<ul>
+<li><code>response_max_size</code> must be between 1 and 1,024. Default to 64 if unspecified.</li>
 </ul>
-</li>
+<h5 id="mod-de-qry-1-3-list-operator-authorizations-execution"><a class="toc-anchor" href="#mod-de-qry-1-3-list-operator-authorizations-execution" >§</a> [MOD-DE-QRY-1-3] List Operator Authorizations execution</h5>
+<p>Return a list of <code>OperatorAuthorization</code> entries matching the filter criteria, or an empty list if nothing found.</p>
+<h4 id="mod-de-qry-2-list-vs-operator-authorizations"><a class="toc-anchor" href="#mod-de-qry-2-list-vs-operator-authorizations" >§</a> [MOD-DE-QRY-2] List VS Operator Authorizations</h4>
+<p>Anyone CAN execute this method.</p>
+<h5 id="mod-de-qry-2-1-list-vs-operator-authorizations-parameters"><a class="toc-anchor" href="#mod-de-qry-2-1-list-vs-operator-authorizations-parameters" >§</a> [MOD-DE-QRY-2-1] List VS Operator Authorizations parameters</h5>
+<ul>
+<li><code>corporation</code> (group) (<em>optional</em>): filter by the corporation group that granted the authorization.</li>
+<li><code>vs_operator</code> (account) (<em>optional</em>): filter by the VS operator account that received the authorization.</li>
+<li><code>response_max_size</code> (small number) (<em>optional</em>): limit to <code>response_max_size</code> results. Must be min 1, max 1,024. Default to 64.</li>
 </ul>
-<div id="note-17" class="notice note"><a class="notice-link" href="#note-17">NOTE</a><p>When a permission is removed from authorization, and the removed permission had a feegrant, new expire of the feegrant is the biggest effective_until of all associated permissions that have feegrant enabled.</p>
-</div>
-<div id="note-18" class="notice note"><a class="notice-link" href="#note-18">NOTE</a><p>In the case of VS Operator Authorizations, spending limit are managed by the Permission module.</p>
-</div>
+<h5 id="mod-de-qry-2-2-list-vs-operator-authorizations-checks"><a class="toc-anchor" href="#mod-de-qry-2-2-list-vs-operator-authorizations-checks" >§</a> [MOD-DE-QRY-2-2] List VS Operator Authorizations checks</h5>
+<p>Basic type check arg SHOULD be applied.</p>
+<p>If any of these checks fail, <a class="term-reference" href="#term:query">query</a> MUST fail.</p>
+<ul>
+<li><code>response_max_size</code> must be between 1 and 1,024. Default to 64 if unspecified.</li>
+</ul>
+<h5 id="mod-de-qry-2-3-list-vs-operator-authorizations-execution"><a class="toc-anchor" href="#mod-de-qry-2-3-list-vs-operator-authorizations-execution" >§</a> [MOD-DE-QRY-2-3] List VS Operator Authorizations execution</h5>
+<p>Return a list of <code>VSOperatorAuthorization</code> entries matching the filter criteria, or an empty list if nothing found.</p>
 <h4 id="mod-di-msg-1-store-digest"><a class="toc-anchor" href="#mod-di-msg-1-store-digest" >§</a> [MOD-DI-MSG-1] Store Digest</h4>
 <ul>
-<li>Any authorized <code>operator</code> CAN execute this method on behalf of an <code>authority</code>.</li>
+<li>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</li>
 <li>This method can be called directly by <a href="#mod-perm-msg-10-create-or-update-permission-session" >Create or Update Permission Session</a> module with no checks.</li>
 </ul>
 <h5 id="mod-di-msg-1-1-store-digest-method-parameters"><a class="toc-anchor" href="#mod-di-msg-1-1-store-digest-method-parameters" >§</a> [MOD-DI-MSG-1-1] Store Digest method parameters</h5>
 <ul>
-<li><code>authority</code> (group) (<em>mandatory</em>): (Signer) the signing authority on whose behalf this message is executed.</li>
-<li><code>operator</code> (account) (<em>mandatory</em>): (Signer) the account authorized by the <code>authority</code> to run this Msg.</li>
-<li><code>digest_sri</code> (string) (<em>mandatory</em>): digest_sri to store.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account) (<em>mandatory</em>): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
+<li><code>digest</code> (string) (<em>mandatory</em>): digest to store.</li>
 </ul>
 <h5 id="mod-di-msg-1-2-store-digest-precondition-checks"><a class="toc-anchor" href="#mod-di-msg-1-2-store-digest-precondition-checks" >§</a> [MOD-DI-MSG-1-2] Store Digest precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <h6 id="mod-di-msg-1-2-1-store-digest-basic-checks"><a class="toc-anchor" href="#mod-di-msg-1-2-1-store-digest-basic-checks" >§</a> [MOD-DI-MSG-1-2-1] Store Digest basic checks</h6>
 <p>if any of these conditions is not satisfied, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><code>authority</code> (group): (Signer) signature must be verified.</li>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
-<li>if <code>digest_sri</code> is not present or <code>digest_sri</code> is not a valid digestSRI, abort.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
+<li>if <code>digest</code> is not present, abort.</li>
 </ul>
 <h6 id="mod-di-msg-1-2-2-store-digest-fee-checks"><a class="toc-anchor" href="#mod-di-msg-1-2-2-store-digest-fee-checks" >§</a> [MOD-DI-MSG-1-2-2] Store Digest fee checks</h6>
 <ul>
@@ -4726,27 +5133,27 @@ The decision between this method and specifying the amount directly is left to i
 </ul>
 <p>Create Digest <code>digest</code>:</p>
 <ul>
-<li>set <code>digest.digest_sri</code> to digest_sri</li>
+<li>set <code>digest.digest</code> to digest</li>
 <li>set <code>digest.created</code> to now.</li>
 </ul>
 <h4 id="mod-di-qry-1-get-digest"><a class="toc-anchor" href="#mod-di-qry-1-get-digest" >§</a> [MOD-DI-QRY-1] Get Digest</h4>
 <p>Anyone CAN execute this method.</p>
 <h5 id="mod-di-qry-1-1-get-digest-parameters"><a class="toc-anchor" href="#mod-di-qry-1-1-get-digest-parameters" >§</a> [MOD-DI-QRY-1-1] Get Digest parameters</h5>
 <ul>
-<li><code>digest_sri</code> (string) (<em>mandatory</em>): the digestSRI to look up.</li>
+<li><code>digest</code> (string) (<em>mandatory</em>): the digest to look up.</li>
 </ul>
 <h5 id="mod-di-qry-1-2-get-digest-checks"><a class="toc-anchor" href="#mod-di-qry-1-2-get-digest-checks" >§</a> [MOD-DI-QRY-1-2] Get Digest checks</h5>
 <p>If any of these checks fail, <a class="term-reference" href="#term:query">query</a> MUST fail.</p>
 <ul>
-<li><code>digest_sri</code> MUST be a valid digestSRI as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>.</li>
+<li><code>digest</code> MUST not be empty.</li>
 </ul>
 <h5 id="mod-di-qry-1-3-get-digest-execution"><a class="toc-anchor" href="#mod-di-qry-1-3-get-digest-execution" >§</a> [MOD-DI-QRY-1-3] Get Digest execution</h5>
 <p>If all checks passed, <a class="term-reference" href="#term:query">query</a> is executed.</p>
-<p>Return found <code>Digest</code> entry (if any) matching <code>digest_sri</code>.</p>
+<p>Return found <code>Digest</code> entry (if any) matching <code>digest</code>.</p>
 <h5 id="mod-di-qry-1-4-get-digest-api-result-example"><a class="toc-anchor" href="#mod-di-qry-1-4-get-digest-api-result-example" >§</a> [MOD-DI-QRY-1-4] Get Digest API result example</h5>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span>
   <span class="token property">"digest"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
-    <span class="token property">"digest_sri"</span><span class="token operator">:</span> <span class="token string">"sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26"</span><span class="token punctuation">,</span>
+    <span class="token property">"digest"</span><span class="token operator">:</span> <span class="token string">"sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26"</span><span class="token punctuation">,</span>
     <span class="token property">"created"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span>
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span>
@@ -5018,7 +5425,7 @@ rate_scale       = S</p>
 </ul>
 </li>
 </ul>
-<div id="warning-9" class="notice warning"><a class="notice-link" href="#warning-9">WARNING</a><ul>
+<div id="warning-54" class="notice warning"><a class="notice-link" href="#warning-54">WARNING</a><ul>
 <li>Conversions use base units only.</li>
 <li>Integer arithmetic MUST be used.</li>
 <li><code>quote_amount = floor(base_amount × rate / 10^rate_scale)</code>.</li>
@@ -5153,7 +5560,9 @@ rate_scale       = S</p>
 <li><a href="#denomamount" >DenomAmount</a></li>
 <li><a href="#digest" >Digest</a></li>
 <li><a href="#operatorauthorization" >OperatorAuthorization</a></li>
+<li><a href="#feegrant" >FeeGrant</a></li>
 <li><a href="#vsoperatorauthorization" >VSOperatorAuthorization</a></li>
+<li><a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a></li>
 <li><a href="#exchangerate" >ExchangeRate</a></li>
 <li><a href="#globalvariables" >GlobalVariables</a></li>
 </ul>
@@ -5166,6 +5575,7 @@ rate_scale       = S</p>
 <li><a href="#not-delegable-module-messages" >Not Delegable Module Messages</a></li>
 <li><a href="#governance-signed-module-messages" >Governance-Signed Module Messages</a></li>
 <li><a href="#fee-grants" >Fee Grants</a></li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK] Common Authorization and Fee Grant Precondition Checks</a></li>
 <li><a href="#example" >Example</a></li>
 </ul>
 </li>
@@ -5218,6 +5628,7 @@ rate_scale       = S</p>
 <li><a href="#mod-perm-msg-12-slash-permission-trust-deposit" >[MOD-PERM-MSG-12] Slash Permission Trust Deposit</a></li>
 <li><a href="#mod-perm-msg-13-repay-permission-slashed-trust-deposit" >[MOD-PERM-MSG-13] Repay Permission Slashed Trust Deposit</a></li>
 <li><a href="#mod-perm-msg-14-self-create-permission" >[MOD-PERM-MSG-14] Self Create Permission</a></li>
+<li><a href="#mod-perm-msg-15-trigger-resolver" >[MOD-PERM-MSG-15] Trigger Resolver</a></li>
 <li><a href="#mod-perm-qry-1-list-permissions" >[MOD-PERM-QRY-1] List Permissions</a></li>
 <li><a href="#mod-perm-qry-2-get-permission" >[MOD-PERM-QRY-2] Get Permission</a></li>
 <li><a href="#mod-perm-qry-3-void" >[MOD-PERM-QRY-3] Void</a></li>
@@ -5245,6 +5656,9 @@ rate_scale       = S</p>
 <li><a href="#mod-de-msg-4-revoke-operator-authorization" >[MOD-DE-MSG-4] Revoke Operator Authorization</a></li>
 <li><a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5] Grant VS Operator Authorization</a></li>
 <li><a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6] Revoke VS Operator Authorization</a></li>
+<li><a href="#mod-de-msg-9-update-vs-operator-authorization-expiration" >[MOD-DE-MSG-9] Update VS Operator Authorization Expiration</a></li>
+<li><a href="#mod-de-qry-1-list-operator-authorizations" >[MOD-DE-QRY-1] List Operator Authorizations</a></li>
+<li><a href="#mod-de-qry-2-list-vs-operator-authorizations" >[MOD-DE-QRY-2] List VS Operator Authorizations</a></li>
 <li><a href="#mod-di-msg-1-store-digest" >[MOD-DI-MSG-1] Store Digest</a></li>
 <li><a href="#mod-di-qry-1-get-digest" >[MOD-DI-QRY-1] Get Digest</a></li>
 <li><a href="#mod-xr-msg-1-create-exchange-rate" >[MOD-XR-MSG-1] Create Exchange Rate</a></li>

--- a/spec.md
+++ b/spec.md
@@ -1165,6 +1165,7 @@ entity "TrustDeposit" as td {
 group --o fg: grantor
 account --o fg: grantee
 fg "1" --- "0..n" da: spend_limit
+fg "1" --- "0..n" da: remaining_spend
 
 xrauthz o-- xr
 xrauthz o-- account: operator
@@ -1200,6 +1201,8 @@ cspsr  o-- "0..1" csp: agent_perm_id
 
 oauthz "1" --- "0..n" da: fee_spend_limit
 oauthz "1" --- "0..n" da: spend_limit
+oauthz "1" --- "0..n" da: remaining_spend
+oauthz "1" --- "0..n" da: remaining_fee_spend
 
 csp "1" --- "0..n" da: vs_operator_spend_limit
 csp "1" --- "0..n" da: vs_operator_fee_spend_limit
@@ -1385,9 +1388,11 @@ group  --o td: corporation
 - `msg_types` (msg_type[]) (*mandatory*): list of module message types this authorization applies to.
 - `spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds that the grantee is allowed to spend
   as a direct consequence of executing authorized messages.
+- `remaining_spend` (DenomAmount[]) (*conditional*): runtime balance for `spend_limit`. Present iff `spend_limit` is set. Initialized to `spend_limit` at create time. Decremented per matching `denom` after each authorized operation. Reset to `spend_limit` when the current cycle ends (see `expiration` and `period` below).
 - `fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of fees that can be paid using this authorization.
-- `expiration` (timestamp) (*optional*): timestamp after which the authorization is no longer valid.
-- `period` (duration) (*optional*): reset period for spend_limit and fee_spend_limit.
+- `remaining_fee_spend` (DenomAmount[]) (*conditional*): runtime balance for `fee_spend_limit`. Present iff `fee_spend_limit` is set. Initialized, decremented and reset following the same rules as `remaining_spend`.
+- `expiration` (timestamp) (*optional*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the authorization is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the authorization auto-renews until the corporation revokes it).
+- `period` (duration) (*optional*): reset period for `spend_limit` and `fee_spend_limit`. If set, `expiration` MUST also be set.
 
 ### FeeGrant
 
@@ -1397,8 +1402,9 @@ group  --o td: corporation
 - `grantee` (account) (*mandatory*): the account that receives the fee grant from `grantor`.
 - `msg_types` (msg_type[]) (*mandatory*): list of VPR delegable message types for which the fee allowance applies.
 - `spend_limit` (DenomAmount[]) (*optional*): maximum amount of fees that can be spent using this grant.
-- `expiration` (timestamp) (*optional*): timestamp after which the fee grant is no longer valid.
-- `period` (duration) (*optional*): reset period for spend_limit.
+- `remaining_spend` (DenomAmount[]) (*conditional*): runtime balance for `spend_limit`. Present iff `spend_limit` is set. Initialized to `spend_limit` at create time. Decremented per matching `denom` after each authorized operation. Reset to `spend_limit` when the current cycle ends (see `expiration` and `period` below).
+- `expiration` (timestamp) (*optional*): grant window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the grant is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, `remaining_spend` is reset to `spend_limit` and `expiration` is advanced to `now() + period` (the grant auto-renews until the grantor revokes it).
+- `period` (duration) (*optional*): reset period for `spend_limit`. If set, `expiration` MUST also be set.
 
 ### VSOperatorAuthorization
 
@@ -1415,9 +1421,11 @@ A `PermissionAuthorizationRecord` carries the per-permission authorization confi
 - `perm_id` (uint64) (*mandatory*): id of the `Permission` this authorization record applies to. Globally unique across all `PermissionAuthorizationRecord` entries.
 - `msg_types` (msg_type[]) (*mandatory*): list of delegable message types for which the `vs_operator` is authorized on behalf of `corporation` when acting in the context of `perm_id`. Declared by the applicant at record creation time (see [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp) and [[MOD-PERM-MSG-14]](#mod-perm-msg-14-self-create-permission)). Frozen after creation.
 - `spend_limit` (DenomAmount[]) (*optional*): maximum amount the `vs_operator` is allowed to spend, in the context of this permission, as a direct consequence of executing authorized messages.
+- `remaining_spend` (DenomAmount[]) (*conditional*): runtime balance for `spend_limit`. Present iff `spend_limit` is set. Initialized to `spend_limit` at create time. Decremented per matching `denom` after each authorized operation. Reset to `spend_limit` when the current cycle ends (see `expiration` and `period` below).
 - `fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
+- `remaining_fee_spend` (DenomAmount[]) (*conditional*): runtime balance for `fee_spend_limit`. Present iff `fee_spend_limit` is set. Initialized, decremented and reset following the same rules as `remaining_spend`.
 - `with_feegrant` (bool) (*mandatory*): if true, `corporation` pays the transaction fees for `vs_operator` when executing authorized messages in the context of this permission, through an on-chain `FeeGrant`.
-- `expiration` (timestamp) (*mandatory*): timestamp after which this authorization is no longer valid. Written to `now` at [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp) (disabled until validation) and to `Permission.effective_until` at [[MOD-PERM-MSG-3]](#mod-perm-msg-3-set-permission-vp-to-validated) / [[MOD-PERM-MSG-8]](#mod-perm-msg-8-adjust-permission) / [[MOD-PERM-MSG-14]](#mod-perm-msg-14-self-create-permission).
+- `expiration` (timestamp) (*mandatory*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the record is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the record auto-renews until removed via [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)). Initially written to `now` at [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp) (disabled until validation) and to `Permission.effective_until` at [[MOD-PERM-MSG-3]](#mod-perm-msg-3-set-permission-vp-to-validated) / [[MOD-PERM-MSG-8]](#mod-perm-msg-8-adjust-permission) / [[MOD-PERM-MSG-14]](#mod-perm-msg-14-self-create-permission).
 - `period` (duration) (*optional*): reset period for `spend_limit` and `fee_spend_limit` in the context of this permission.
 
 ### ExchangeRate
@@ -1651,18 +1659,25 @@ For any **delegable message** executed by an `operator` on behalf of a `corporat
 ##### [AUTHZ-CHECK-1] Operator Authorization checks
 
 1. An `OperatorAuthorization` `oauthz` MUST exist where `oauthz.corporation` = `corporation`, `oauthz.operator` = `operator`, and `oauthz.msg_types` includes the current message type.
-2. If `oauthz.expiration` is set, it MUST be in the future.
-3. If `oauthz.spend_limit` is set, the remaining balance MUST be sufficient for the operation. After successful execution, the consumed amount MUST be deducted from the remaining balance.
-4. If `oauthz.period` is set and the current period has elapsed since the last reset, the remaining balance MUST be reset to `oauthz.spend_limit` before evaluating the check above.
+2. If `oauthz.expiration` is set:
+   - if `oauthz.period` is set and `now() >= oauthz.expiration`:
+     - if `oauthz.spend_limit` is set, set `oauthz.remaining_spend := oauthz.spend_limit`.
+     - if `oauthz.fee_spend_limit` is set, set `oauthz.remaining_fee_spend := oauthz.fee_spend_limit`.
+     - set `oauthz.expiration := now() + oauthz.period`.
+   - else, `oauthz.expiration` MUST be strictly greater than `now()`. Abort otherwise.
+3. If `oauthz.spend_limit` is set, `oauthz.remaining_spend` MUST be sufficient for the operation. After successful execution, the consumed amount MUST be deducted from `oauthz.remaining_spend` (per matching `denom` entry).
 
 ##### [AUTHZ-CHECK-2] Fee Grant checks
 
 If the transaction fees are paid by the `corporation` account (via fee grant) instead of the `operator` account:
 
 1. A `FeeGrant` `fg` MUST exist where `fg.grantor` = `corporation`, `fg.grantee` = `operator`, and `fg.msg_types` includes the current message type.
-2. If `fg.expiration` is set, it MUST be in the future.
-3. If `fg.spend_limit` is set, the remaining balance MUST be sufficient for the [[ref: estimated transaction fees]]. After successful execution, the consumed fee amount MUST be deducted from the remaining balance.
-4. If `fg.period` is set and the current period has elapsed since the last reset, the remaining balance MUST be reset to `fg.spend_limit` before evaluating the check above.
+2. If `fg.expiration` is set:
+   - if `fg.period` is set and `now() >= fg.expiration`:
+     - if `fg.spend_limit` is set, set `fg.remaining_spend := fg.spend_limit`.
+     - set `fg.expiration := now() + fg.period`.
+   - else, `fg.expiration` MUST be strictly greater than `now()`. Abort otherwise.
+3. If `fg.spend_limit` is set, `fg.remaining_spend` MUST be sufficient for the [[ref: estimated transaction fees]]. After successful execution, the consumed fee amount MUST be deducted from `fg.remaining_spend` (per matching `denom` entry).
 
 ##### [AUTHZ-CHECK-3] VS Operator Authorization checks
 
@@ -1675,17 +1690,21 @@ Given a `corporation`, an `operator` (the `vs_operator`), a **primary permission
 1. A `PermissionAuthorizationRecord` `record` MUST exist for `perm_id`. Abort if not found.
 2. `record` MUST belong to `VSOperatorAuthorization[corporation, operator]`, that is: the containing `VSOperatorAuthorization` MUST have `corporation` as its `corporation` and `operator` as its `vs_operator`. Abort otherwise.
 3. `msg_type` MUST be in `record.msg_types`. Abort otherwise.
-4. `record.expiration` MUST be strictly greater than now(). Abort otherwise.
-5. If `record.period` is set and the current period has elapsed since the last reset, the remaining balances for `record.spend_limit` and `record.fee_spend_limit` MUST be reset to their original values before evaluating the check below.
-6. If `record.spend_limit` is set, the remaining balance MUST be sufficient for the operation. After successful execution, the consumed amount MUST be deducted from the remaining balance.
+4. Cycle / expiration check:
+   - if `record.period` is set and `now() >= record.expiration`:
+     - if `record.spend_limit` is set, set `record.remaining_spend := record.spend_limit`.
+     - if `record.fee_spend_limit` is set, set `record.remaining_fee_spend := record.fee_spend_limit`.
+     - set `record.expiration := now() + record.period`.
+   - else, `record.expiration` MUST be strictly greater than `now()`. Abort otherwise.
+5. If `record.spend_limit` is set, `record.remaining_spend` MUST be sufficient for the operation. After successful execution, the consumed amount MUST be deducted from `record.remaining_spend` (per matching `denom` entry).
 
 ##### [AUTHZ-CHECK-4] VS Operator Fee Grant checks
 
 If the [[ref: transaction]] fees are paid by the `corporation` account (via fee grant) instead of the `operator` account, using the same `PermissionAuthorizationRecord` `record` looked up in [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks):
 
 1. `record.with_feegrant` MUST be true, else abort.
-2. If `record.period` is set and the current period has elapsed since the last reset, the remaining balance for `record.fee_spend_limit` MUST be reset to its original value before evaluating the check below.
-3. If `record.fee_spend_limit` is set, the remaining balance MUST be sufficient for the [[ref: estimated transaction fees]]. After successful execution, the consumed fee amount MUST be deducted from the remaining balance.
+2. The cycle / expiration check from [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) step 4 has already been performed against the same `record`; `record.remaining_fee_spend` is therefore current.
+3. If `record.fee_spend_limit` is set, `record.remaining_fee_spend` MUST be sufficient for the [[ref: estimated transaction fees]]. After successful execution, the consumed fee amount MUST be deducted from `record.remaining_fee_spend` (per matching `denom` entry).
 
 #### Example
 
@@ -4428,10 +4447,10 @@ At least one of the two authorization paths below MUST pass, else [[ref: transac
 The target `perm` itself is excluded from this walk; only its ancestors (from the direct parent up to the root) are considered. Walk the tree:
 
 - set `v` = `perm`.
-- while `v.validator_perm_id` is defined:
+- while `v.validator_perm_id` is defined and != `perm.id` :
   - load `v` from `v.validator_perm_id`.
   - if `v` is not an [[ref: active permission]], continue with the next iteration.
-  - `corporation` MUST be equal to `v.corporation`.
+  - if corporation != v.corporation, continue with the next iteration.
   - if [AUTHZ-CHECK-1](#authz-check-1-operator-authorization-checks) pass for this (`corporation`, `operator`) tuple and message `TriggerResolver` AND [AUTHZ-CHECK-2](#authz-check-2-fee-grant-checks) pass for this (`corporation`, `operator`) tuple and message `TriggerResolver`, then authorization is granted => match.
 
 If the walk terminates without a match, Path 2 fails.
@@ -5188,6 +5207,7 @@ if any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 - `expiration` (timestamp): if specified, MUST be in the future
 - `spend_limit` (DenomAmount[]) if specified, MUST be a list of valid DenomAmounts
 - `period` (duration): if specified MUST be a valid period.
+- if `period` is specified, `expiration` MUST also be specified.
 
 ##### [MOD-DE-MSG-1-3] Grant Fee Allowance fee checks
 
@@ -5204,7 +5224,8 @@ Create (or update if it already exist) FeeGrant `feegrant`:
 - set `feegrant.msg_types` to `msg_types`
 - set `feegrant.expiration` to `expiration`
 - set `feegrant.spend_limit` to `spend_limit`
-- set `feegrant.period` to `period``
+- if `spend_limit` is set, set `feegrant.remaining_spend` to `spend_limit`
+- set `feegrant.period` to `period`
 
 #### [MOD-DE-MSG-2] Revoke Fee Allowance
 
@@ -5265,6 +5286,7 @@ if any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 - `authz_spend_limit_period` (duration): if specified MUST be a valid period. Ignored if `authz_spend_limit` is not set.
 - `feegrant_spend_limit` (DenomAmount[]) if specified, MUST be a list of valid DenomAmounts. Ignored if `with_feegrant` is false.
 - `feegrant_spend_limit_period` (duration): if specified MUST be a valid period. Ignored if `feegrant_spend_limit` is not set or if `with_feegrant` is false.
+- if `authz_spend_limit_period` or `feegrant_spend_limit_period` is specified, `expiration` MUST also be specified.
 
 - Check if a **VS Operator Authorization** exists for `corporation` and `grantee`. If this is the case, MUST abort.
 
@@ -5287,6 +5309,7 @@ Create (or update if it already exist) Authorization `authz`:
 - set `authz.msg_types` to `msg_types`
 - set `authz.expiration` to `expiration`
 - set `authz.spend_limit` to `authz_spend_limit`
+- if `authz_spend_limit` is set, set `authz.remaining_spend` to `authz_spend_limit`
 - set `authz.period` to `authz_spend_limit_period`
 
 if `with_feegrant` is false:
@@ -5365,6 +5388,9 @@ A **VS Operator Authorization** record CAN be granted ONLY IF no **OperatorAutho
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
+- Initialize the runtime balances on `record`:
+  - if `record.spend_limit` is set, set `record.remaining_spend := record.spend_limit`.
+  - if `record.fee_spend_limit` is set, set `record.remaining_fee_spend := record.fee_spend_limit`.
 - Load `VSOperatorAuthorization` `vsoa` with `(corporation, vs_operator)`. If it does not exist, create a new `vsoa` with `vsoa.corporation = corporation`, `vsoa.vs_operator = vs_operator`, `vsoa.records = []`.
 - Append `record` to `vsoa.records`.
 - Call **[Recompute VS Operator Fee Allowance](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance)** for `vsoa`.

--- a/spec.md
+++ b/spec.md
@@ -5351,6 +5351,7 @@ If any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 - `record.perm_id` MUST NOT match an existing `PermissionAuthorizationRecord` anywhere in the store (each record is globally unique by `perm_id`).
 - `record.msg_types` MUST be non-empty and MUST contain only VPR delegable message types.
 - No `OperatorAuthorization` `oauthz` where `oauthz.corporation` = `corporation` and `oauthz.operator` = `vs_operator` MUST exist.
+- Another `VsOperatorAuthorization` `vsoauthz` where `vsoauthz.operator` = `vs_operator` and `vsoauthz.corporation` != `corporation` MUST NOT exist. In other words, a vs-agent Vpr account cannot be controlled by multiples corporations.
 
 ::: warning
 A **VS Operator Authorization** record CAN be granted ONLY IF no **OperatorAuthorization** exists for the same `(corporation, vs_operator)` pair. **VS Operator Authorization** and **Operator Authorization** are mutually exclusive for a given grantee.

--- a/spec.md
+++ b/spec.md
@@ -4219,12 +4219,14 @@ Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else
 - `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this Perm is effective, null if it doesn't expire. If not null, MUST be greater than `effective_from`.
 - `verification_fees` (number) (*optional*): price to pay by the verifier of a credential of this schema to the grantee of this ISSUER perm when a credential is verified, in the denom specified in the credential schema. Default to 0.
 - `validation_fees` (number) (*optional*): price to pay by the holder of a credential of this schema to the issuer when executing a validation process to obtain a credential, in the denom specified in the credential schema. Default to 0.
-- `vs_operator_authz_enabled`: boolean (*mandatory*): if set to true authorize this vs_operator to execute CreateOrUpdatePermissionSession *on behalf* of `corporation` account (trust fees will be paid by corporation account)
-- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds that the vs_operator is allowed to spend in the context of this permission.
-  as a direct consequence of executing authorized messages.
-- `vs_operator_authz_with_feegrant`: boolean (*mandatory*): if set to true, enable feegrant for this permission so vs_operator can pay the fees for CreateOrUpdatePermissionSession with `corporation` account.
-- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of fees that can be spent by vs_operator in the context of this permission.
-- `vs_operator_authz_spend_period`: (period) (*optional*): reset period for vs_operator_authz_spend_limit and vs_operator_authz_fee_spend_limit in the context of this permission.
+
+The following VS Operator Authorization parameters are **optional** and collectively define the initial [PermissionAuthorizationRecord](#permissionauthorizationrecord) for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
+
+- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `PermissionAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified.
+- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.
+- `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this permission.
+- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
+- `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
 
 ##### [MOD-PERM-MSG-14-2] Self Create Permission precondition checks
 
@@ -4251,12 +4253,7 @@ Load `Permission` `validator_perm` from `validator_perm_id`.
   - else if not null, must be greater than `effective_from` AND if `validator_perm.effective_until` is not null, MUST be lower or equal to `validator_perm.effective_until`
 - `verification_fees` (number) (*optional*): If specified, MUST be >= 0 and MUST be a ISSUER permission.
 - `validation_fees` (number) (*optional*): If specified, MUST be >= 0 and MUST be a ISSUER permission.
-- `vs_operator_authz_enabled`: boolean (*mandatory*): if set to true, `vs_operator` MUST NOT be null, else abort.
-- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds that the vs_operator is allowed to spend in the context of this permission.
-  as a direct consequence of executing authorized messages.
-- `vs_operator_authz_with_feegrant`: boolean (*mandatory*): if set to true, `vs_operator` MUST NOT be null, else abort.
-- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of fees that can be spent by vs_operator in the context of this permission.
-- `vs_operator_authz_spend_period`: (period) (*optional*): if not null, `vs_operator` MUST NOT be null, else abort. Reset period for vs_operator_authz_spend_limit and vs_operator_authz_fee_spend_limit in the context of this permission.
+- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types.
 
 ###### [MOD-PERM-MSG-14-2-2] Self Create Permission permission checks
 
@@ -4312,15 +4309,21 @@ A new entry `Permission` `perm` MUST be created:
 - `perm.issuance_fees`: 0
 - `perm.verification_fees`: `verification_fees` if specified and `type` is ISSUER, else 0.
 - `perm.deposit`: 0
-- `perm.vs_operator_authz_enabled`: `vs_operator_authz_enabled`
-- `perm.vs_operator_authz_spend_limit`: `vs_operator_authz_spend_limit`
-- `perm.vs_operator_authz_with_feegrant`: `vs_operator_authz_with_feegrant`
-- `perm.vs_operator_authz_fee_spend_limit`: `vs_operator_authz_fee_spend_limit`
-- `perm.vs_operator_authz_spend_period`: `vs_operator_authz_spend_period`
-  
-Create authorization for `vs_operator` so that the Verifiable Service will be able to call CreateOrUpdatePermissionSession when issuing or verifying credentials:
 
-- if `perm.vs_operator_authz_enabled` == true: call **Grant VS Operator Authorization(`perm.id`)**.
+If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizationRecord](#permissionauthorizationrecord) in **active** state by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
+
+- `corporation`: `corporation`
+- `vs_operator`: `vs_operator`
+- `record`:
+  - `record.perm_id`: `perm.id`
+  - `record.msg_types`: `vs_operator_authz_msg_types`
+  - `record.spend_limit`: `vs_operator_authz_spend_limit`
+  - `record.fee_spend_limit`: `vs_operator_authz_fee_spend_limit`
+  - `record.with_feegrant`: `vs_operator_authz_with_feegrant` (default: false)
+  - `record.expiration`: `perm.effective_until`
+  - `record.period`: `vs_operator_authz_period`
+
+> Note: unlike [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp), the record is created with `expiration = perm.effective_until` and is therefore immediately active. If `with_feegrant` is true and `perm.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
 
 #### [MOD-PERM-MSG-15] Trigger Resolver
 

--- a/spec.md
+++ b/spec.md
@@ -5351,7 +5351,7 @@ If any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 - `record.perm_id` MUST NOT match an existing `PermissionAuthorizationRecord` anywhere in the store (each record is globally unique by `perm_id`).
 - `record.msg_types` MUST be non-empty and MUST contain only VPR delegable message types.
 - No `OperatorAuthorization` `oauthz` where `oauthz.corporation` = `corporation` and `oauthz.operator` = `vs_operator` MUST exist.
-- Another `VsOperatorAuthorization` `vsoauthz` where `vsoauthz.operator` = `vs_operator` and `vsoauthz.corporation` != `corporation` MUST NOT exist. In other words, a vs-agent Vpr account cannot be controlled by multiples corporations.
+- Another `VsOperatorAuthorization` `vsoauthz.vs_operator` = `vs_operator` and `vsoauthz.corporation` != `corporation` MUST NOT exist. In other words, a vs-agent Vpr account cannot be controlled by multiples corporations.
 
 ::: warning
 A **VS Operator Authorization** record CAN be granted ONLY IF no **OperatorAuthorization** exists for the same `(corporation, vs_operator)` pair. **VS Operator Authorization** and **Operator Authorization** are mutually exclusive for a given grantee.

--- a/spec.md
+++ b/spec.md
@@ -1338,7 +1338,6 @@ group  --o td: corporation
 - `id` (uuid) (*mandatory*): session uuid.
 - `corporation` (group) (*mandatory*): corporation that controls the entry.
 - `vs_operator` (account) (*mandatory*): verifiable service agent account that controls the entry (agent crypto account).
-- `agent_perm_id` (uint64) (*mandatory*): permission id of the agent.
 - `created` (timestamp) (*mandatory*): timestamp this PermissionSession has been created.
 - `modified` (timestamp) (*mandatory*): timestamp this PermissionSession has been modified.
 - `session_records` (PermissionSessionRecord[]) (*mandatory*): session records, for this session.
@@ -1351,6 +1350,7 @@ group  --o td: corporation
 - `issuer_perm_id` (uint64) (*optional*): related issuer `Permission` id (if applicable).
 - `verifier_perm_id` (uint64) (*optional*): related verifier `Permission` id (if applicable).
 - `wallet_agent_perm_id` (uint64) (*optional*): related wallet agent `Permission` id (if applicable).
+- `agent_perm_id` (uint64) (*optional*): permission id of the agent `Permission` id (if applicable).
 
 ### TrustDeposit
 

--- a/spec.md
+++ b/spec.md
@@ -1092,9 +1092,6 @@ entity "Permission" as csp {
   +vp_summary_digest: string
   +issuance_fee_discount: number
   +verification_fee_discount: number
-  +vs_operator_authz_enabled: boolean
-  +vs_operator_authz_spend_period: duration
-  +vs_operator_authz_with_feegrant: boolean
 }
 
 
@@ -1325,11 +1322,8 @@ group  --o td: corporation
 - `vp_summary_digest` (string) (*optional*): an optional digest SRI, set by [[ref: validator]], of a summary of the information, proofs... provided by the [[ref: applicant]].
 - `issuance_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_VALIDATION_PROCESS mode) or an ISSUER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 - `verification_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_VALIDATION_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
-- `vs_operator_authz_enabled`: boolean (*mandatory*): if set to true, authorize this vs_operator to execute CreateOrUpdatePermissionSession *on behalf* of `corporation` account (trust fees will be paid by corporation account)
-- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds that the vs_operator is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.
-- `vs_operator_authz_with_feegrant`: boolean (*mandatory*): if set to true, enable feegrant for this permission so vs_operator can pay the fees for CreateOrUpdatePermissionSession with `corporation` account.
-- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of fees that can be spent by vs_operator in the context of this permission.
-- `vs_operator_authz_spend_period`: (period) (*optional*): reset period for vs_operator_authz_spend_limit and vs_operator_authz_fee_spend_limit in the context of this permission.
+
+> Note: VS operator authorization settings (spend limits, feegrant, expiration, authorized message types) are no longer stored on `Permission`. They live in `PermissionAuthorizationRecord` entries inside [VSOperatorAuthorization](#vsoperatorauthorization), keyed by `Permission.id`. See [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) and [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks).
 
 ### PermissionSession
 

--- a/spec.md
+++ b/spec.md
@@ -2765,12 +2765,14 @@ An Applicant that would like to start a permission validation process MUST execu
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
 - `verification_fees` (number) (*optional*): Requested verification_fees for this permission (can be modified by validator).
 - `did` (string) (*required*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- `vs_operator_authz_enabled`: boolean (*mandatory*): if set to true authorize this vs_operator to execute CreateOrUpdatePermissionSession *on behalf* of `corporation` account (trust fees will be paid by corporation account)
-- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds that the vs_operator is allowed to spend in the context of this permission.
-  as a direct consequence of executing authorized messages.
-- `vs_operator_authz_with_feegrant`: boolean (*mandatory*): if set to true, enable feegrant for this permission so vs_operator can pay the fees for CreateOrUpdatePermissionSession with `corporation` account.
-- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of fees that can be spent by vs_operator in the context of this permission.
-- `vs_operator_authz_spend_period`: (period) (*optional*): reset period for vs_operator_authz_spend_limit and vs_operator_authz_fee_spend_limit in the context of this permission.
+
+The following VS Operator Authorization parameters are **optional** and collectively define the initial [PermissionAuthorizationRecord](#permissionauthorizationrecord) that will be created for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode (the corporation signs and pays for its own permission-related transactions directly). VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
+
+- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `PermissionAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified.
+- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.
+- `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this permission.
+- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
+- `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
 
 Available compatible perms can be found by using an indexer and presented in a front-end so applicant can choose its validator.
 
@@ -2791,12 +2793,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
 - `verification_fees` (number) (*optional*): Requested verification_fees for this permission (can be modified by validator).
 - `did`, if specified, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- `vs_operator_authz_enabled`: boolean (*mandatory*): if set to true, `vs_operator` MUST NOT be null, else abort.
-- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds that the vs_operator is allowed to spend in the context of this permission.
-  as a direct consequence of executing authorized messages.
-- `vs_operator_authz_with_feegrant`: boolean (*mandatory*): if set to true, `vs_operator` MUST NOT be null, else abort.
-- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of fees that can be spent by vs_operator in the context of this permission.
-- `vs_operator_authz_spend_period`: (period) (*optional*): if not null, `vs_operator` MUST NOT be null, else abort. Reset period for vs_operator_authz_spend_limit and vs_operator_authz_fee_spend_limit in the context of this permission.
+- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types.
 
 :::note
 A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It's up to the issuer to decide if running the validation process is REQUIRED or not.
@@ -2926,12 +2923,21 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - `applicant_perm.vp_current_deposit` (number): `validation_trust_deposit_in_native_denom`.
   - `applicant_perm.vp_summary_digest`: null.
   - `applicant_perm.vp_validator_deposit`: 0.
-  - `applicant_perm.vs_operator_authz_enabled`: `vs_operator_authz_enabled`
-  - `applicant_perm.vs_operator_authz_spend_limit`: `vs_operator_authz_spend_limit`
-  - `applicant_perm.vs_operator_authz_with_feegrant`: `vs_operator_authz_with_feegrant`
-  - `applicant_perm.vs_operator_authz_fee_spend_limit`: `vs_operator_authz_fee_spend_limit`
-  - `applicant_perm.vs_operator_authz_spend_period`: `vs_operator_authz_spend_period`
-  
+
+If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizationRecord](#permissionauthorizationrecord) in **disabled** state (`expiration = now`) by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
+
+- `corporation`: `corporation`
+- `vs_operator`: `vs_operator`
+- `record`:
+  - `record.perm_id`: `applicant_perm.id`
+  - `record.msg_types`: `vs_operator_authz_msg_types`
+  - `record.spend_limit`: `vs_operator_authz_spend_limit`
+  - `record.fee_spend_limit`: `vs_operator_authz_fee_spend_limit`
+  - `record.with_feegrant`: `vs_operator_authz_with_feegrant` (default: false)
+  - `record.expiration`: `now`
+  - `record.period`: `vs_operator_authz_period`
+
+> Note: the record is created with `expiration = now` so authorization is **not yet active**. [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) will reject any attempt to use it until [[MOD-PERM-MSG-3]](#mod-perm-msg-3-set-permission-vp-to-validated) updates `expiration` to `applicant_perm.effective_until`. No on-chain `FeeGrant` object is created at this stage even if `with_feegrant` is true (the recompute subroutine in [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) requires `expiration > now`).
 
 #### Connecting to the VS of the Validator
 

--- a/spec.md
+++ b/spec.md
@@ -1371,9 +1371,9 @@ group  --o td: corporation
 - `deposit` (number) (*mandatory*): amount of deposit in `denom`.
 - `refunded` (number) (*mandatory*): amount of refunded trust deposit, in `denom`. Refunded trust deposit is reused as funding for the next trust deposit spending before drawing additional funds from the corporation account.
 - `slashed_deposit` (number) (*optional*): amount of slashed deposit in `denom`.
-- `repaid_deposit` (number) (*optional*): amount of slashed deposit in `denom`.
+- `repaid_deposit` (number) (*optional*): part of the slashed trust deposit, in `denom`, that has been repaid.
 - `last_slashed` (timestamp) (*optional*): last time this trust deposit has been slashed.
-- `last_repaid` (timestamp) (*optional*): last time this trust deposit has been slashed.
+- `last_repaid` (timestamp) (*optional*): last time this trust deposit has been repaid.
 - `slash_count` (number) (*optional*): number of times this account has been slashed.
 
 ### DenomAmount
@@ -5379,7 +5379,7 @@ If any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 - `record.perm_id` MUST NOT match an existing `PermissionAuthorizationRecord` anywhere in the store (each record is globally unique by `perm_id`).
 - `record.msg_types` MUST be non-empty and MUST contain only VPR delegable message types.
 - No `OperatorAuthorization` `oauthz` where `oauthz.corporation` = `corporation` and `oauthz.operator` = `vs_operator` MUST exist.
-- Another `VsOperatorAuthorization` `vsoauthz.vs_operator` = `vs_operator` and `vsoauthz.corporation` != `corporation` MUST NOT exist. In other words, a vs-agent Vpr account cannot be controlled by multiples corporations.
+- No other `VSOperatorAuthorization` `vsoauthz'` where `vsoauthz'.vs_operator` = `vs_operator` AND `vsoauthz'.corporation` != `corporation` MUST exist. In other words, a vs-agent VPR account cannot be controlled by multiple corporations.
 
 ::: warning
 A **VS Operator Authorization** record CAN be granted ONLY IF no **OperatorAuthorization** exists for the same `(corporation, vs_operator)` pair. **VS Operator Authorization** and **Operator Authorization** are mutually exclusive for a given grantee.

--- a/spec.md
+++ b/spec.md
@@ -3293,6 +3293,8 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - call [MOD-TD-MSG-1] to reduce trust deposit of `applicant_perm.corporation` by `applicant_perm.vp_current_deposit`
   - set `applicant_perm.vp_current_deposit` to 0.
 
+If `applicant_perm.vp_state` was set to TERMINATED (i.e. `applicant_perm.vp_exp` was null so validation never completed), call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `perm_id = applicant_perm.id` to remove any disabled authorization record created at [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp). The call is a no-op if no record exists. If `applicant_perm.vp_state` was set back to VALIDATED, no VSOA changes are needed (the existing record's `expiration` remains at the value set by the previous successful validation).
+
 #### [MOD-PERM-MSG-7] Create Root Permission
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
@@ -3602,9 +3604,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - set `applicant_perm.revoked` to `now`
 - set `applicant_perm.modified` to `now`
 
-If `applicant_perm.type` is ISSUER or VERIFIER: Delete authorization for `applicant_perm.vs_operator`:
-
-- call **Revoke VS Operator Authorization(`applicant_perm.id`)**.
+Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `perm_id = applicant_perm.id` to remove any authorization record for this permission. The call is a no-op if no record exists.
 
 #### [MOD-PERM-MSG-10] Create or Update Permission Session
 
@@ -4146,9 +4146,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 use [MOD-TD-MSG-7](#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit) to burn the slashed `amount` from the trust deposit of `applicant_perm.corporation`.
 
-If `applicant_perm.type` is ISSUER or VERIFIER: Delete authorization for `applicant_perm.vs_operator`:
-
-- call **Revoke VS Operator Authorization(`applicant_perm.id`)** with the following parameters:
+Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `perm_id = applicant_perm.id` to remove any authorization record for this permission. The call is a no-op if no record exists.
 
 #### [MOD-PERM-MSG-13] Repay Permission Slashed Trust Deposit
 

--- a/spec.md
+++ b/spec.md
@@ -1034,6 +1034,14 @@ entity "OperatorAuthorization" as oauthz {
 entity "VSOperatorAuthorization" as vsoauthz {
 }
 
+entity "PermissionAuthorizationRecord" as par {
+   *perm_id: uint64
+   +msg_types: msg_type[]
+   +with_feegrant: boolean
+   +expiration: timestamp
+   +period: duration
+}
+
 entity "DenomAmount" as da {
   denom: string
   amount: number
@@ -1394,9 +1402,23 @@ group  --o td: corporation
 
 ### VSOperatorAuthorization
 
+A `VSOperatorAuthorization` groups all `PermissionAuthorizationRecord` entries delegated by one `corporation` to one `vs_operator`. It is keyed by the `(corporation, vs_operator)` pair. The entry exists if, and only if, it has at least one record.
+
 - `corporation` (group) (*mandatory*): the corporation group granting the authorization.
 - `vs_operator` (account) (*mandatory*): the operator account receiving the authorization.
-- `permissions[]` (uint64[]) (*mandatory*): permission ids for which we grant this authorization.
+- `records` (PermissionAuthorizationRecord[]) (*mandatory*): per-permission authorization records granted to `vs_operator` by `corporation`.
+
+### PermissionAuthorizationRecord
+
+A `PermissionAuthorizationRecord` carries the per-permission authorization configuration that was previously stored on `Permission.vs_operator_authz_*` fields. Each record is globally unique by `perm_id`: for any `Permission.id`, at most one record exists system-wide, so `(corporation, vs_operator)` can be derived from `perm_id` via a direct lookup.
+
+- `perm_id` (uint64) (*mandatory*): id of the `Permission` this authorization record applies to. Globally unique across all `PermissionAuthorizationRecord` entries.
+- `msg_types` (msg_type[]) (*mandatory*): list of delegable message types for which the `vs_operator` is authorized on behalf of `corporation` when acting in the context of `perm_id`. Declared by the applicant at record creation time (see [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp) and [[MOD-PERM-MSG-14]](#mod-perm-msg-14-self-create-permission)). Frozen after creation.
+- `spend_limit` (DenomAmount[]) (*optional*): maximum amount the `vs_operator` is allowed to spend, in the context of this permission, as a direct consequence of executing authorized messages.
+- `fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
+- `with_feegrant` (bool) (*mandatory*): if true, `corporation` pays the transaction fees for `vs_operator` when executing authorized messages in the context of this permission, through an on-chain `FeeGrant`.
+- `expiration` (timestamp) (*mandatory*): timestamp after which this authorization is no longer valid. Written to `now` at [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp) (disabled until validation) and to `Permission.effective_until` at [[MOD-PERM-MSG-3]](#mod-perm-msg-3-set-permission-vp-to-validated) / [[MOD-PERM-MSG-8]](#mod-perm-msg-8-adjust-permission) / [[MOD-PERM-MSG-14]](#mod-perm-msg-14-self-create-permission).
+- `period` (duration) (*optional*): reset period for `spend_limit` and `fee_spend_limit` in the context of this permission.
 
 ### ExchangeRate
 

--- a/spec.md
+++ b/spec.md
@@ -4921,9 +4921,9 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
     - else
       - use bank? to transfer `augend` - `td.refunded` from corporation account to corporation `TrustDeposit` account.
       - set `td.deposit` to `td.deposit` + `augend` - `td.refunded`
-      - set `td.refunded` to 0
       - calculate `missing_augend_share` from missing tokens :  `missing_augend_share` = (`augend` - `td.refunded`) / `GlobalVariables.trust_deposit_share_value`.
       - set `td.share` to `td.share` + `missing_augend_share`
+      - set `td.refunded` to 0
   
   - else
     - use bank? to transfer `augend` from `account` to `TrustDeposit` account.

--- a/spec.md
+++ b/spec.md
@@ -3229,9 +3229,12 @@ Update `Permission` `applicant_perm`:
   - set `applicant_perm.issuance_fee_discount` to `issuance_fee_discount`.
   - set `applicant_perm.verification_fee_discount` to `verification_fee_discount`.
 
-If `applicant_perm.type` is ISSUER or VERIFIER: Create authorization for `applicant_perm.vs_operator` so that the Verifiable Service will be able to call CreateOrUpdatePermissionSession when issuing or verifying credentials:
+Activate VS Operator Authorization, if any. Call [[MOD-DE-MSG-7]](#mod-de-msg-7-update-vs-operator-authorization-expiration) Update VS Operator Authorization Expiration with:
 
-- if `applicant_perm.vs_operator_authz_enabled` == true: call **Grant VS Operator Authorization(`applicant_perm.id`)**.
+- `perm_id`: `applicant_perm.id`
+- `new_expiration`: `applicant_perm.effective_until`
+
+This call is a no-op if no record was created at [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp) (i.e., the applicant did not declare `vs_operator_authz_msg_types`). If a record exists, its `expiration` is updated from `now` (disabled) to `applicant_perm.effective_until`, and the on-chain `FeeGrant` for the containing VSOA is granted for the first time (or refreshed) via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance).
 
 #### [MOD-PERM-MSG-4] Void
 

--- a/spec.md
+++ b/spec.md
@@ -1154,7 +1154,7 @@ entity "GlobalVariables" as gv {
 entity "TrustDeposit" as td {
   share: number
   deposit: number
-  claimable: number
+  refunded: number
   slashed_deposit: number
   repaid_deposit: number
   last_slashed: timestamp
@@ -1364,7 +1364,7 @@ group  --o td: corporation
 - `share` (number) (*mandatory*): share of the module total deposit.
 - `corporation` (group) (*mandatory*) (key): the [[ref: group]]
 - `deposit` (number) (*mandatory*): amount of deposit in `denom`.
-- `claimable` (number) (*mandatory*): amount of claimable deposit in `denom`.
+- `refunded` (number) (*mandatory*): amount of refunded trust deposit, in `denom`. Refunded trust deposit is reused as funding for the next trust deposit spending before drawing additional funds from the corporation account.
 - `slashed_deposit` (number) (*optional*): amount of slashed deposit in `denom`.
 - `repaid_deposit` (number) (*optional*): amount of slashed deposit in `denom`.
 - `last_slashed` (timestamp) (*optional*): last time this trust deposit has been slashed.
@@ -4870,7 +4870,7 @@ Value checks:
   - if `td` does not exist:
     - if `augend` is negative, [[ref: transaction]] MUST abort.
   - else
-    - if `augend` is negative and `td.claimable` - `augend` is greater than `td.deposit` transaction MUST abort. (`td.claimable` trust deposit cannot be greater than `td.deposit`).
+    - if `augend` is negative and `td.refunded` - `augend` is greater than `td.deposit` transaction MUST abort. (`td.refunded` trust deposit cannot be greater than `td.deposit`).
 
 ###### [MOD-TD-MSG-1-2-2] Adjust Trust Deposit fee checks
 
@@ -4881,7 +4881,7 @@ Additionally:
 - load `TrustDeposit` entry `td` for `corporation`.
 - if `td` exists:
   - if `augend` is positive:
-    - calculate `needed_deposit` = `augend` - `td.claimable`. 
+    - calculate `needed_deposit` = `augend` - `td.refunded`. 
     - if `needed_deposit` < 0: `needed_deposit` = 0.
   - else `needed_deposit` = 0.
 - else `needed_deposit` = `augend`.
@@ -4901,7 +4901,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - set `td.corporation` to `corporation`;
   - set `td.deposit` to `augend`;
   - set `td.share` to `augend_share`;
-  - set `td.claimable` to 0.
+  - set `td.refunded` to 0.
   - set `td.slashed_deposit` to 0.
   - set `td.repaid_deposit` to 0.
   - set `td.slash_count` to 0.
@@ -4910,14 +4910,14 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - else if `augend` > 0:
   
-  - if `td.claimable` > 0:
-    - if `td.claimable` >= `augend` :
-      - set `td.claimable` to `td.claimable` - `augend`
+  - if `td.refunded` > 0:
+    - if `td.refunded` >= `augend` :
+      - set `td.refunded` to `td.refunded` - `augend`
     - else
-      - use bank? to transfer `augend` - `td.claimable` from corporation account to corporation `TrustDeposit` account.
-      - set `td.deposit` to `td.deposit` + `augend` - `td.claimable`
-      - set `td.claimable` to 0
-      - calculate `missing_augend_share` from missing tokens :  `missing_augend_share` = (`augend` - `td.claimable`) / `GlobalVariables.trust_deposit_share_value`.
+      - use bank? to transfer `augend` - `td.refunded` from corporation account to corporation `TrustDeposit` account.
+      - set `td.deposit` to `td.deposit` + `augend` - `td.refunded`
+      - set `td.refunded` to 0
+      - calculate `missing_augend_share` from missing tokens :  `missing_augend_share` = (`augend` - `td.refunded`) / `GlobalVariables.trust_deposit_share_value`.
       - set `td.share` to `td.share` + `missing_augend_share`
   
   - else
@@ -4927,9 +4927,9 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
     - set `td.share` to `td.share` + `augend_share`
 
 - else if `augend` < 0:
-  - set `td.claimable` to `td.claimable` - `augend`
+  - set `td.refunded` to `td.refunded` - `augend`
 
-The last case, `augend` < 0, is to free trust deposit (ej when canceling a validation process).
+The last case, `augend` < 0, is to refund trust deposit (e.g. when canceling a validation process). The refunded amount is added to `td.refunded` and is reused for the next trust deposit spending.
 
 #### [MOD-TD-MSG-2] Reclaim Trust Deposit Yield
 

--- a/spec.md
+++ b/spec.md
@@ -3468,10 +3468,12 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - set `applicant_perm.modified` to `now`
 
 
-If `applicant_perm.type` is ISSUER or VERIFIER: Update authorization for `applicant_perm.vs_operator` so that the Verifiable Service will be able to call CreateOrUpdatePermissionSession when issuing or verifying credentials:
+Synchronise VS Operator Authorization expiration, if any. Call [[MOD-DE-MSG-7]](#mod-de-msg-7-update-vs-operator-authorization-expiration) Update VS Operator Authorization Expiration with:
 
-- if `applicant_perm.vs_operator_authz_enabled` == true: call **Grant VS Operator Authorization(`applicant_perm.id`)**.
+- `perm_id`: `applicant_perm.id`
+- `new_expiration`: `applicant_perm.effective_until`
 
+This call is a no-op if no record exists for `applicant_perm.id`. If a record exists, its `expiration` is updated and the on-chain `FeeGrant` for the containing VSOA is refreshed via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance). Adjust Permission does **not** accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp) and [[MOD-PERM-MSG-14]](#mod-perm-msg-14-self-create-permission)). Adjust also cannot create a record that does not already exist.
 
 #### [MOD-PERM-MSG-9] Revoke Permission
 

--- a/spec.md
+++ b/spec.md
@@ -1204,6 +1204,11 @@ oauthz "1" --- "0..n" da: spend_limit
 oauthz "1" --- "0..n" da: remaining_spend
 oauthz "1" --- "0..n" da: remaining_fee_spend
 
+par "1" --- "0..n" da: spend_limit
+par "1" --- "0..n" da: fee_spend_limit
+par "1" --- "0..n" da: remaining_spend
+par "1" --- "0..n" da: remaining_fee_spend
+
 csp "1" --- "0..n" da: vs_operator_spend_limit
 csp "1" --- "0..n" da: vs_operator_fee_spend_limit
 

--- a/spec.md
+++ b/spec.md
@@ -5103,9 +5103,8 @@ Return the list of the existing parameters and their values.
 
 This method can only be called directly by the following methods:
 
-- Grant Operator Authorization
-- Grant VS Operator Authorization
-- Revoke VS Operator Authorization
+- [Grant Operator Authorization](#mod-de-msg-3-grant-operator-authorization)
+- the VS Operator Authorization feegrant subroutine [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) (invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization), [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) and [[MOD-DE-MSG-7]](#mod-de-msg-7-update-vs-operator-authorization-expiration))
 
 ##### [MOD-DE-MSG-1-1] Grant Fee Allowance method parameters
 
@@ -5146,9 +5145,9 @@ Create (or update if it already exist) FeeGrant `feegrant`:
 
 This method can only be called directly by the following methods:
 
-- Grant Operator Authorization
-- Revoke Operator Authorization
-- Revoke VS Operator Authorization
+- [Grant Operator Authorization](#mod-de-msg-3-grant-operator-authorization)
+- [Revoke Operator Authorization](#mod-de-msg-4-revoke-operator-authorization)
+- the VS Operator Authorization feegrant subroutine [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) (invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization), [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) and [[MOD-DE-MSG-7]](#mod-de-msg-7-update-vs-operator-authorization-expiration))
 
 ##### [MOD-DE-MSG-2-1] Revoke Allowance method parameters
 
@@ -5264,111 +5263,127 @@ MUST abort if one of these conditions fails:
 
 #### [MOD-DE-MSG-5] Grant VS Operator Authorization
 
-This method can only be called directly by the following methods with no signer check:
+This method can only be called directly by the following Permission module methods, with no signer check:
 
-- Self Create Permission
-- Adjust Permission
-- Set Permission VP to Validated
+- [Start Permission VP](#mod-perm-msg-1-start-permission-vp)
+- [Self Create Permission](#mod-perm-msg-14-self-create-permission)
 
-> Note: This method can only grant authorization for the `CreateOrUpdatePermissionSession`, `SetPermissionVPtoValidated` and `TriggerResolver` Msgs.
+It creates a new [PermissionAuthorizationRecord](#permissionauthorizationrecord) inside `VSOperatorAuthorization[corporation, vs_operator]` and, if the record enables a fee grant and its `expiration` is in the future, synchronises the on-chain `FeeGrant` for the containing VSOA.
+
+This method does NOT read `Permission` state. All authorization configuration is provided by the caller.
 
 ##### [MOD-DE-MSG-5-1] Grant VS Operator Authorization method parameters
 
-- `perm_id` (uint64) (*mandatory*): the permission this authorization is referring to.
+- `corporation` (group) (*mandatory*): the corporation delegating the authorization.
+- `vs_operator` (account) (*mandatory*): the account receiving the authorization.
+- `record` ([PermissionAuthorizationRecord](#permissionauthorizationrecord)) (*mandatory*): the full record to store.
 
 ##### [MOD-DE-MSG-5-2] Grant VS Operator Authorization basic checks
 
-if any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
+If any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 
-- `perm_id` (uint64) (*mandatory*): Permission MUST exist.
-- load Permission `perm` with `perm_id`. `perm.corporation` and `perm.vs_operator` MUST NOT be null.
-- Check if a **Operator Authorization** exists for `perm.corporation` and `perm.vs_operator`. If this is the case, MUST abort.
+- `corporation` and `vs_operator` MUST NOT be null.
+- `record.perm_id` MUST NOT match an existing `PermissionAuthorizationRecord` anywhere in the store (each record is globally unique by `perm_id`).
+- `record.msg_types` MUST be non-empty and MUST contain only VPR delegable message types.
+- No `OperatorAuthorization` `oauthz` where `oauthz.corporation` = `corporation` and `oauthz.operator` = `vs_operator` MUST exist.
 
 ::: warning
-A **VS Operator Authorization** CAN be granted ONLY IF no **Operator Authorization** exists for `perm.corporation` and `perm.vs_operator`. **VS Operator Authorization** and **Operator Authorization** are mutually exclusive for a given grantee.
+A **VS Operator Authorization** record CAN be granted ONLY IF no **OperatorAuthorization** exists for the same `(corporation, vs_operator)` pair. **VS Operator Authorization** and **Operator Authorization** are mutually exclusive for a given grantee.
 :::
 
 ##### [MOD-DE-MSG-5-3] Grant VS Operator Authorization fee checks
 
-- Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]];
+- Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]].
 
 ##### [MOD-DE-MSG-5-4] Grant VS Operator Authorization execution of the method
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-Load Permission `perm` with `perm_id`.
+- Load `VSOperatorAuthorization` `vsoa` with `(corporation, vs_operator)`. If it does not exist, create a new `vsoa` with `vsoa.corporation = corporation`, `vsoa.vs_operator = vs_operator`, `vsoa.records = []`.
+- Append `record` to `vsoa.records`.
+- Call **[Recompute VS Operator Fee Allowance](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance)** for `vsoa`.
 
-Create VSOperatorAuthorization `vs_operator_authz` if it doesn't exist yet:
+##### [MOD-DE-MSG-5-5] Recompute VS Operator Fee Allowance
 
-- set `vs_operator_authz.grantor` to `perm.corporation`
-- set `vs_operator_authz.grantee` to `perm.vs_operator`
+This is a shared subroutine invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization), [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) and [[MOD-DE-MSG-7]](#mod-de-msg-7-update-vs-operator-authorization-expiration) after they mutate `vsoa.records`.
 
-then, add the perm_id to the list of authorized permissions:
+- define `max_expire` = null.
+- define `feegrant_msg_types` = empty set.
+- for each `r` in `vsoa.records`:
+  - if `r.with_feegrant` is true AND `r.expiration` > now():
+    - if `max_expire` is null OR `r.expiration` > `max_expire`, set `max_expire` = `r.expiration`.
+    - add all entries of `r.msg_types` to `feegrant_msg_types`.
+- if `max_expire` is null (no active feegrant-enabled record remains): call [Revoke Fee Allowance](#mod-de-msg-2-revoke-fee-allowance)(`vsoa.corporation`, `vsoa.vs_operator`).
+- else: call [Grant Fee Allowance](#mod-de-msg-1-grant-fee-allowance)(`vsoa.corporation`, `vsoa.vs_operator`, `feegrant_msg_types`, `max_expire`, null, null).
 
-- Add `perm_id` to `vs_operator_authz.permissions`
-
-Then check for feegrant:
-
-- if `perm.vs_operator_authz_with_feegrant` is true:
-  - set `max_expire` = `perm.effective_until`
-  - if `max_expire` == null: call Grant Fee Allowance (`corporation`, `grantee`, [`CreateOrUpdatePermissionSession`, `SetPermissionVPtoValidated`, `TriggerResolver`], null, null, null) and EXIT.
-  - else foreach `current_perm_id` of `vs_operator_authz.permissions`
-    - load Permission `current_perm` from `current_perm_id`
-    - if `current_perm.vs_operator_authz_with_feegrant` is true:
-      - if `current_perm.effective_until` == null: call Grant Fee Allowance (`corporation`, `grantee`, [`CreateOrUpdatePermissionSession`, `SetPermissionVPtoValidated`, `TriggerResolver`], null, null, null) and EXIT.
-      - else if `current_perm.effective_until` > `max_expire` => set `max_expire` = `current_perm.effective_until`
-  - if `max_expire` > now, call Grant Fee Allowance (`corporation`, `grantee`, [`CreateOrUpdatePermissionSession`, `SetPermissionVPtoValidated`, `TriggerResolver`], `max_expire`, null, null).
-
-::: note
-We MUST align to the farthest effective_until for the feegrant, for the permissions that have `current_perm.effective_until` set.
-:::
+> Note: `max_expire` is bounded by the farthest `record.expiration` among feegrant-enabled records. The chain-level `FeeGrant` `msg_types` is the union of all such records' `msg_types`. Per-record spend limits are enforced at [[AUTHZ-CHECK-4]](#authz-check-4-vs-operator-fee-grant-checks) time; they are not replicated on the `FeeGrant` object.
 
 #### [MOD-DE-MSG-6] Revoke VS Operator Authorization
 
-This method can only be called by the following methods with no signer check:
+This method can only be called directly by the following Permission module methods, with no signer check:
 
-- Revoke Permission
-- Slash Permission Trust Deposit
+- [Cancel Permission VP Last Request](#mod-perm-msg-6-cancel-permission-vp-last-request) (only when the cancellation terminates the permission)
+- [Revoke Permission](#mod-perm-msg-9-revoke-permission)
+- [Slash Permission Trust Deposit](#mod-perm-msg-12-slash-permission-trust-deposit)
+
+It removes the unique [PermissionAuthorizationRecord](#permissionauthorizationrecord) identified by `perm_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no such record exists.
+
+This method does NOT read `Permission` state.
 
 ##### [MOD-DE-MSG-6-1] Revoke VS Operator Authorization method parameters
 
-- `perm_id` (uint64) (*mandatory*): the permission this authorization is referring to.
+- `perm_id` (uint64) (*mandatory*): id of the permission whose authorization record must be removed.
 
 ##### [MOD-DE-MSG-6-2] Revoke VS Operator Authorization basic checks
 
-MUST abort if one of these conditions fails:
+- `perm_id` MUST be a valid uint64.
 
-- `perm_id` (uint64) (*mandatory*): Permission MUST exist.
-- load Permission `perm` with `perm_id`. `perm.corporation` and `perm.vs_operator` MUST NOT be null.
+> Note: absence of a record for `perm_id` is NOT an error. The method is a no-op in that case (the permission was never VS-operator-authorized, or was already revoked).
 
 ##### [MOD-DE-MSG-6-3] Revoke VS Operator Authorization fee checks
 
-- Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]];
+- Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]].
 
 ##### [MOD-DE-MSG-6-4] Revoke VS Operator Authorization execution of the method
 
-- load Permission `perm` with `perm_id`.
-- load VSOperatorAuthorization `vs_operator_authz` with `perm.corporation` and `perm.vs_operator`.
-- If `vs_operator_authz` is not null:
-  - remove `perm_id` from `vs_operator_authz.permissions` if present.
-  - if `perm.vs_operator_authz_with_feegrant` is true:
-    - if size(vs_operator_authz.permissions) == 0 => call Revoke Fee Allowance (`perm.corporation`, `perm.vs_operator`).
-    - else define `max_expire` = null
-    - foreach `current_perm_id` of `vs_operator_authz.permissions`
-      - load Permission `current_perm` from `current_perm_id`
-      - if `current_perm.vs_operator_authz_with_feegrant` is true:
-        - if `current_perm.effective_until` == null set `max_expire` = null
-        - else if `max_expire` == null set `max_expire` = `current_perm.effective_until`
-        - else `max_expire` = max (`max_expire`, `current_perm.effective_until`)
-    - if `max_expire` > now, call Grant Fee Allowance (`corporation`, `grantee`, [`CreateOrUpdatePermissionSession`, `SetPermissionVPtoValidated`, `TriggerResolver`] , `max_expire`, null, null).
+- Locate the unique `PermissionAuthorizationRecord` `record` with `record.perm_id = perm_id`. If none exists, EXIT (no-op).
+- Let `vsoa` = the `VSOperatorAuthorization` that contains `record`.
+- Remove `record` from `vsoa.records`.
+- Call **[Recompute VS Operator Fee Allowance](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance)** for `vsoa`.
+- If `vsoa.records` is now empty, delete `vsoa`.
 
-::: note
-When a permission is removed from authorization, and the removed permission had a feegrant, new expire of the feegrant is the biggest effective_until of all associated permissions that have feegrant enabled.
-:::
+#### [MOD-DE-MSG-7] Update VS Operator Authorization Expiration
 
-::: note
-In the case of VS Operator Authorizations, spending limit are managed by the Permission module.
-:::
+This method can only be called directly by the following Permission module methods, with no signer check:
+
+- [Set Permission VP to Validated](#mod-perm-msg-3-set-permission-vp-to-validated)
+- [Adjust Permission](#mod-perm-msg-8-adjust-permission)
+
+It updates the `expiration` of the unique record identified by `perm_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no record exists for `perm_id`.
+
+This method does NOT read `Permission` state; the caller supplies the new expiration value directly.
+
+##### [MOD-DE-MSG-7-1] Update VS Operator Authorization Expiration method parameters
+
+- `perm_id` (uint64) (*mandatory*): id of the permission whose authorization record's `expiration` must be updated.
+- `new_expiration` (timestamp) (*mandatory*): the new value of `record.expiration`.
+
+##### [MOD-DE-MSG-7-2] Update VS Operator Authorization Expiration basic checks
+
+- `perm_id` MUST be a valid uint64.
+- `new_expiration` MUST be a valid timestamp.
+
+> Note: absence of a record for `perm_id` is NOT an error. The method is a no-op in that case (the permission does not enable VS operator authorization).
+
+##### [MOD-DE-MSG-7-3] Update VS Operator Authorization Expiration fee checks
+
+- Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]].
+
+##### [MOD-DE-MSG-7-4] Update VS Operator Authorization Expiration execution of the method
+
+- Locate the unique `PermissionAuthorizationRecord` `record` with `record.perm_id = perm_id`. If none exists, EXIT (no-op).
+- Set `record.expiration = new_expiration`.
+- Call **[Recompute VS Operator Fee Allowance](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance)** for the VSOA containing `record`.
 
 #### [MOD-DE-QRY-1] List Operator Authorizations
 

--- a/spec.md
+++ b/spec.md
@@ -1,6 +1,6 @@
 # Verifiable Public Registry v4 Specification
 
-**Latest draft:** [spec v4-draft17](https://verana-labs.github.io/verifiable-trust-vpr-spec/)
+**Latest draft:** [spec v4-draft18](https://verana-labs.github.io/verifiable-trust-vpr-spec/)
 
 **Latest stable:** [spec v3](https://verana-labs.github.io/verifiable-trust-vpr-spec/index-v3.html)
 
@@ -1769,6 +1769,7 @@ As a result, `accountABC` is authorized to:
 |             | Revoke VS Operator Authorization        |     N/A (Tx) | Msg  | [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)   |module call|
 |             | Grant Exchange Rate Authorization         |     N/A (Tx)| Msg  | [[MOD-DE-MSG-7]](#mod-de-msg-7-grant-exchange-rate-authorization)   |governance proposal|
 |             | Revoke Exchange Rate Authorization        |     N/A (Tx) | Msg  | [[MOD-DE-MSG-8]](#mod-de-msg-8-revoke-exchange-rate-authorization)   |governance proposal|
+|             | Update VS Operator Authorization Expiration |     N/A (Tx) | Msg  | [[MOD-DE-MSG-9]](#mod-de-msg-9-update-vs-operator-authorization-expiration)   |module call|
 |             | List Operator Authorizations              | /de/v1/authz/list | Query  | [[MOD-DE-QRY-1]](#mod-de-qry-1-list-operator-authorizations)   |N/A |
 |             | List VS Operator Authorizations           | /de/v1/vs-authz/list | Query  | [[MOD-DE-QRY-2]](#mod-de-qry-2-list-vs-operator-authorizations)   |N/A |
 | Digests  | Store Digest         |   N/A (Tx) | Msg  | [[MOD-DI-MSG-1]](#mod-di-msg-1-store-digest)   |corporation + operator OR module call|
@@ -3229,7 +3230,7 @@ Update `Permission` `applicant_perm`:
   - set `applicant_perm.issuance_fee_discount` to `issuance_fee_discount`.
   - set `applicant_perm.verification_fee_discount` to `verification_fee_discount`.
 
-Activate VS Operator Authorization, if any. Call [[MOD-DE-MSG-7]](#mod-de-msg-7-update-vs-operator-authorization-expiration) Update VS Operator Authorization Expiration with:
+Activate VS Operator Authorization, if any. Call [[MOD-DE-MSG-9]](#mod-de-msg-9-update-vs-operator-authorization-expiration) Update VS Operator Authorization Expiration with:
 
 - `perm_id`: `applicant_perm.id`
 - `new_expiration`: `applicant_perm.effective_until`
@@ -3470,7 +3471,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - set `applicant_perm.modified` to `now`
 
 
-Synchronise VS Operator Authorization expiration, if any. Call [[MOD-DE-MSG-7]](#mod-de-msg-7-update-vs-operator-authorization-expiration) Update VS Operator Authorization Expiration with:
+Synchronise VS Operator Authorization expiration, if any. Call [[MOD-DE-MSG-9]](#mod-de-msg-9-update-vs-operator-authorization-expiration) Update VS Operator Authorization Expiration with:
 
 - `perm_id`: `applicant_perm.id`
 - `new_expiration`: `applicant_perm.effective_until`
@@ -5116,7 +5117,7 @@ Return the list of the existing parameters and their values.
 This method can only be called directly by the following methods:
 
 - [Grant Operator Authorization](#mod-de-msg-3-grant-operator-authorization)
-- the VS Operator Authorization feegrant subroutine [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) (invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization), [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) and [[MOD-DE-MSG-7]](#mod-de-msg-7-update-vs-operator-authorization-expiration))
+- the VS Operator Authorization feegrant subroutine [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) (invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization), [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) and [[MOD-DE-MSG-9]](#mod-de-msg-9-update-vs-operator-authorization-expiration))
 
 ##### [MOD-DE-MSG-1-1] Grant Fee Allowance method parameters
 
@@ -5159,7 +5160,7 @@ This method can only be called directly by the following methods:
 
 - [Grant Operator Authorization](#mod-de-msg-3-grant-operator-authorization)
 - [Revoke Operator Authorization](#mod-de-msg-4-revoke-operator-authorization)
-- the VS Operator Authorization feegrant subroutine [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) (invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization), [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) and [[MOD-DE-MSG-7]](#mod-de-msg-7-update-vs-operator-authorization-expiration))
+- the VS Operator Authorization feegrant subroutine [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) (invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization), [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) and [[MOD-DE-MSG-9]](#mod-de-msg-9-update-vs-operator-authorization-expiration))
 
 ##### [MOD-DE-MSG-2-1] Revoke Allowance method parameters
 
@@ -5317,7 +5318,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 ##### [MOD-DE-MSG-5-5] Recompute VS Operator Fee Allowance
 
-This is a shared subroutine invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization), [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) and [[MOD-DE-MSG-7]](#mod-de-msg-7-update-vs-operator-authorization-expiration) after they mutate `vsoa.records`.
+This is a shared subroutine invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization), [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) and [[MOD-DE-MSG-9]](#mod-de-msg-9-update-vs-operator-authorization-expiration) after they mutate `vsoa.records`.
 
 - define `max_expire` = null.
 - define `feegrant_msg_types` = empty set.
@@ -5364,7 +5365,7 @@ This method does NOT read `Permission` state.
 - Call **[Recompute VS Operator Fee Allowance](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance)** for `vsoa`.
 - If `vsoa.records` is now empty, delete `vsoa`.
 
-#### [MOD-DE-MSG-7] Update VS Operator Authorization Expiration
+#### [MOD-DE-MSG-9] Update VS Operator Authorization Expiration
 
 This method can only be called directly by the following Permission module methods, with no signer check:
 
@@ -5375,23 +5376,23 @@ It updates the `expiration` of the unique record identified by `perm_id` and rec
 
 This method does NOT read `Permission` state; the caller supplies the new expiration value directly.
 
-##### [MOD-DE-MSG-7-1] Update VS Operator Authorization Expiration method parameters
+##### [MOD-DE-MSG-9-1] Update VS Operator Authorization Expiration method parameters
 
 - `perm_id` (uint64) (*mandatory*): id of the permission whose authorization record's `expiration` must be updated.
 - `new_expiration` (timestamp) (*mandatory*): the new value of `record.expiration`.
 
-##### [MOD-DE-MSG-7-2] Update VS Operator Authorization Expiration basic checks
+##### [MOD-DE-MSG-9-2] Update VS Operator Authorization Expiration basic checks
 
 - `perm_id` MUST be a valid uint64.
 - `new_expiration` MUST be a valid timestamp.
 
 > Note: absence of a record for `perm_id` is NOT an error. The method is a no-op in that case (the permission does not enable VS operator authorization).
 
-##### [MOD-DE-MSG-7-3] Update VS Operator Authorization Expiration fee checks
+##### [MOD-DE-MSG-9-3] Update VS Operator Authorization Expiration fee checks
 
 - Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]].
 
-##### [MOD-DE-MSG-7-4] Update VS Operator Authorization Expiration execution of the method
+##### [MOD-DE-MSG-9-4] Update VS Operator Authorization Expiration execution of the method
 
 - Locate the unique `PermissionAuthorizationRecord` `record` with `record.perm_id = perm_id`. If none exists, EXIT (no-op).
 - Set `record.expiration = new_expiration`.

--- a/spec.md
+++ b/spec.md
@@ -1181,6 +1181,8 @@ account --o oauthz: operator
 
 group --o vsoauthz: corporation
 account --o vsoauthz: vs_operator
+vsoauthz "1" --- "1..n" par: records
+par o-- csp: perm_id
 
 csp o-- cspt: type
 csp o-- cs: schema_id

--- a/spec.md
+++ b/spec.md
@@ -1666,26 +1666,26 @@ If the transaction fees are paid by the `corporation` account (via fee grant) in
 
 ##### [AUTHZ-CHECK-3] VS Operator Authorization checks
 
-A second authorization grant mode exists for vs-agents.
-It is used to grant access to `CreateOrUpdatePermissionSession`, `SetPermissionVPtoValidated` and `TriggerResolver` for specific permission manipulation only. The authorization model differs from other delegable messages: it relies on `VSOperatorAuthorization` and per-permission settings instead of `OperatorAuthorization`.
+A second authorization grant mode exists for vs-agents. It is used when a corporation delegates a specific permission (and a specific set of message types, scoped to that permission) to a `vs_operator` account. The authorization model differs from other delegable messages: it relies on [VSOperatorAuthorization](#vsoperatorauthorization) / [PermissionAuthorizationRecord](#permissionauthorizationrecord) instead of `OperatorAuthorization`.
 
-> Note: when a vs-agent account is granted a `VSOperatorAuthorization` for a given permission, the permission is automatically granted for all tree messages `CreateOrUpdatePermissionSession`, `SetPermissionVPtoValidated` and `TriggerResolver`. It is not possible to limit specific messages per permission.
+> Note: the set of messages a `vs_operator` is authorized to execute in the context of a permission is declared by the applicant at permission creation time (see [[MOD-PERM-MSG-1-1]](#mod-perm-msg-1-1-start-permission-vp-parameters) and [[MOD-PERM-MSG-14-1]](#mod-perm-msg-14-1-self-create-permission-parameters)) and stored in `record.msg_types`. It is frozen for the lifetime of the record and can only be changed by revoking the permission and starting a new one.
 
-Given a `corporation`, an `operator` (the `vs_operator`), and a **primary permission** `perm` (determined by the calling method):
+Given a `corporation`, an `operator` (the `vs_operator`), a **primary permission id** `perm_id` (determined by the calling method), and the current message type `msg_type`:
 
-1. A `VSOperatorAuthorization` `vso` MUST exist where `vso.corporation` = `corporation` and `vso.vs_operator` = `operator`.
-2. `vso.permissions` MUST include `perm.id`.
-3. `perm.vs_operator_authz_enabled` MUST be true.
-4. If `perm.vs_operator_authz_spend_period` is set and the current period has elapsed since the last reset, the remaining balances for `perm.vs_operator_authz_spend_limit` and `perm.vs_operator_authz_fee_spend_limit` MUST be reset to their original values before evaluating the checks below.
-5. If `perm.vs_operator_authz_spend_limit` is set, the remaining balance MUST be sufficient for the operation. After successful execution, the consumed amount MUST be deducted from the remaining balance.
+1. A `PermissionAuthorizationRecord` `record` MUST exist for `perm_id`. Abort if not found.
+2. `record` MUST belong to `VSOperatorAuthorization[corporation, operator]`, that is: the containing `VSOperatorAuthorization` MUST have `corporation` as its `corporation` and `operator` as its `vs_operator`. Abort otherwise.
+3. `msg_type` MUST be in `record.msg_types`. Abort otherwise.
+4. `record.expiration` MUST be strictly greater than now(). Abort otherwise.
+5. If `record.period` is set and the current period has elapsed since the last reset, the remaining balances for `record.spend_limit` and `record.fee_spend_limit` MUST be reset to their original values before evaluating the check below.
+6. If `record.spend_limit` is set, the remaining balance MUST be sufficient for the operation. After successful execution, the consumed amount MUST be deducted from the remaining balance.
 
 ##### [AUTHZ-CHECK-4] VS Operator Fee Grant checks
 
-If the [[ref: transaction]] fees are paid by the `corporation` account (via fee grant) instead of the `operator` account, using the same **primary permission** `perm`:
+If the [[ref: transaction]] fees are paid by the `corporation` account (via fee grant) instead of the `operator` account, using the same `PermissionAuthorizationRecord` `record` looked up in [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks):
 
-1. `perm.vs_operator_authz_with_feegrant` MUST be true, else abort.
-2. If `perm.vs_operator_authz_spend_period` is set and the current period has elapsed since the last reset, the remaining balance for `perm.vs_operator_authz_fee_spend_limit` MUST be reset to its original value before evaluating the check below.
-3. If `perm.vs_operator_authz_fee_spend_limit` is set, the remaining balance MUST be sufficient for the [[ref: estimated transaction fees]]. After successful execution, the consumed fee amount MUST be deducted from the remaining balance.
+1. `record.with_feegrant` MUST be true, else abort.
+2. If `record.period` is set and the current period has elapsed since the last reset, the remaining balance for `record.fee_spend_limit` MUST be reset to its original value before evaluating the check below.
+3. If `record.fee_spend_limit` is set, the remaining balance MUST be sufficient for the [[ref: estimated transaction fees]]. After successful execution, the consumed fee amount MUST be deducted from the remaining balance.
 
 #### Example
 

--- a/spec.md
+++ b/spec.md
@@ -1204,8 +1204,6 @@ oauthz "1" --- "0..n" da: spend_limit
 csp "1" --- "0..n" da: vs_operator_spend_limit
 csp "1" --- "0..n" da: vs_operator_fee_spend_limit
 
-vsoauthz --- "0..n" csp: permissions 
-
 
 tr "1" --- "1..n" gfv: versions 
 gfv "1" --- "1..n" gfd: documents 
@@ -2771,11 +2769,23 @@ An Applicant that would like to start a permission validation process MUST execu
 
 The following VS Operator Authorization parameters are **optional** and collectively define the initial [PermissionAuthorizationRecord](#permissionauthorizationrecord) that will be created for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode (the corporation signs and pays for its own permission-related transactions directly). VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
 
-- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `PermissionAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified.
+- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `PermissionAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified. The permitted list of message types is provided below.
 - `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.
 - `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this permission.
 - `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
 - `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
+
+Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`.
+
+|Permission type|Permitted Messages|
+|-|-|
+| HOLDER | TriggerResolver |
+| ISSUER | CreateOrUpdatePermissionSession, SetPermissionVPtoValidated |
+| VERIFIER | CreateOrUpdatePermissionSession |
+| ISSUER_GRANTOR | SetPermissionVPtoValidated |
+| VERIFIER_GRANTOR | SetPermissionVPtoValidated |
+| ECOSYSTEM | SetPermissionVPtoValidated |
+ 
 
 Available compatible perms can be found by using an indexer and presented in a front-end so applicant can choose its validator.
 
@@ -2796,7 +2806,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
 - `verification_fees` (number) (*optional*): Requested verification_fees for this permission (can be modified by validator).
 - `did`, if specified, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types.
+- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PERM-MSG-1-1](#mod-perm-msg-1-1-start-permission-vp-parameters).
 
 :::note
 A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It's up to the issuer to decide if running the validation process is REQUIRED or not.
@@ -3311,12 +3321,27 @@ An [[ref: account]] that would like to create a `Permission` entry MUST call thi
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `schema_id` (uint64) (*mandatory*)
+- `vs_operator` (account) (*optional*): the account we want to authorize to act on behalf of `corporation` in the context of this permission. **Required** for payment delegation.
 - `did` (string) (*mandatory*): [[ref: DID]] of the VS.
 - `effective_from` (timestamp) (*mandatory*): timestamp from when (exclusive) this Perm is effective. MUST be in the future.
 - `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this Perm is effective, null if it doesn't expire. If not null, MUST be greater than `effective_from`.
 - `validation_fees` (number) (*mandatory*): price to pay by applicant to validator for running a validation process that uses this perm as validator, for a given validation period, in the denom specified in the credential schema. Default to 0. Note that setting validation fees for OPEN schemas has no effect and does not mean a validation process must take place. For enabling validation processes, at least one of the two issuer, verifier mode must be different than OPEN.
 - `issuance_fees` (number) (*mandatory*): price to pay by the issuer of a credential of this schema to the grantee of this perm when a credential is issued, in the denom specified in the credential schema. Default to 0.
 - `verification_fees` (number) (*mandatory*): price to pay by the verifier of a credential of this schema to the grantee of this perm when a credential is verified, in the denom specified in the credential schema. Default to 0.
+
+The following VS Operator Authorization parameters are **optional** and collectively define the initial [PermissionAuthorizationRecord](#permissionauthorizationrecord) for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
+
+- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `PermissionAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified. The permitted list of message types is provided below.
+- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.
+- `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this permission.
+- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
+- `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
+
+Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`. Since [Create Root Permission](#mod-perm-msg-7-create-root-permission) always creates an ECOSYSTEM permission, only the following is allowed:
+
+|Permission type|Permitted Messages|
+|-|-|
+| ECOSYSTEM | SetPermissionVPtoValidated |
 
 ##### [MOD-PERM-MSG-7-2] Create Root Permission precondition checks
 
@@ -3336,6 +3361,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `validation_fees` (number) (*mandatory*): MUST be >= 0.
 - `issuance_fees` (number) (*mandatory*): MUST be >= 0.
 - `verification_fees` (number) (*mandatory*): MUST be >= 0.
+- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PERM-MSG-7-1](#mod-perm-msg-7-1-create-root-permission-parameters).
 
 ###### [MOD-PERM-MSG-7-2-2] Create Root Permission permission checks
 
@@ -3382,6 +3408,7 @@ A new entry `Permission` `perm` MUST be created:
 - `perm.type`: ECOSYSTEM.
 - `perm.did`: `did`.
 - `perm.corporation`: `corporation`.
+- `perm.vs_operator`: `vs_operator`.
 - `perm.created`: `now`
 - `perm.effective_from`: `effective_from`
 - `perm.effective_until`: `effective_until`
@@ -3389,6 +3416,21 @@ A new entry `Permission` `perm` MUST be created:
 - `perm.issuance_fees`: `issuance_fees`
 - `perm.verification_fees`: `verification_fees`
 - `perm.deposit`: 0
+
+If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizationRecord](#permissionauthorizationrecord) in **active** state by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
+
+- `corporation`: `corporation`
+- `vs_operator`: `vs_operator`
+- `record`:
+  - `record.perm_id`: `perm.id`
+  - `record.msg_types`: `vs_operator_authz_msg_types`
+  - `record.spend_limit`: `vs_operator_authz_spend_limit`
+  - `record.fee_spend_limit`: `vs_operator_authz_fee_spend_limit`
+  - `record.with_feegrant`: `vs_operator_authz_with_feegrant` (default: false)
+  - `record.expiration`: `perm.effective_until`
+  - `record.period`: `vs_operator_authz_period`
+
+> Note: like [[MOD-PERM-MSG-14]](#mod-perm-msg-14-self-create-permission), the record is created with `expiration = perm.effective_until` and is therefore immediately active. If `with_feegrant` is true and `perm.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
 
 #### [MOD-PERM-MSG-8] Adjust Permission
 
@@ -4229,6 +4271,17 @@ The following VS Operator Authorization parameters are **optional** and collecti
 - `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
 - `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
 
+Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`.
+
+|Permission type|Permitted Messages|
+|-|-|
+| HOLDER | TriggerResolver |
+| ISSUER | CreateOrUpdatePermissionSession, SetPermissionVPtoValidated |
+| VERIFIER | CreateOrUpdatePermissionSession |
+| ISSUER_GRANTOR | SetPermissionVPtoValidated |
+| VERIFIER_GRANTOR | SetPermissionVPtoValidated |
+| ECOSYSTEM | SetPermissionVPtoValidated |
+ 
 ##### [MOD-PERM-MSG-14-2] Self Create Permission precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
@@ -4254,7 +4307,7 @@ Load `Permission` `validator_perm` from `validator_perm_id`.
   - else if not null, must be greater than `effective_from` AND if `validator_perm.effective_until` is not null, MUST be lower or equal to `validator_perm.effective_until`
 - `verification_fees` (number) (*optional*): If specified, MUST be >= 0 and MUST be a ISSUER permission.
 - `validation_fees` (number) (*optional*): If specified, MUST be >= 0 and MUST be a ISSUER permission.
-- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types.
+- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PERM-MSG-14-1](#mod-perm-msg-14-1-self-create-permission-parameters).
 
 ###### [MOD-PERM-MSG-14-2-2] Self Create Permission permission checks
 

--- a/spec.md
+++ b/spec.md
@@ -4278,9 +4278,6 @@ Permitted message types to be set in `vs_operator_authz_msg_types` depends on `t
 | HOLDER | TriggerResolver |
 | ISSUER | CreateOrUpdatePermissionSession, SetPermissionVPtoValidated |
 | VERIFIER | CreateOrUpdatePermissionSession |
-| ISSUER_GRANTOR | SetPermissionVPtoValidated |
-| VERIFIER_GRANTOR | SetPermissionVPtoValidated |
-| ECOSYSTEM | SetPermissionVPtoValidated |
  
 ##### [MOD-PERM-MSG-14-2] Self Create Permission precondition checks
 
@@ -4337,7 +4334,7 @@ for each `Permission` entry `p` from `perms[]`:
 
 > note: this check was not present in v3.
 
-##### [MOD-PERM-MSG-14-3] Create Permission execution
+##### [MOD-PERM-MSG-14-3] Self Create Permission execution
 
 If all precondition checks passed, method is executed.
 


### PR DESCRIPTION
## Summary

Refactor VS Operator Authorization so that authorization configuration lives inside the Delegation Engine module (on `VSOperatorAuthorization.records[]` → `PermissionAuthorizationRecord`) instead of being stored on `Permission.vs_operator_authz_*` fields.

This breaks the TR → DE → Perm → TR dependency cycle: the DE module no longer needs to read `Permission` state to evaluate a VS Operator authorization; all data required for `AUTHZ-CHECK-3` and `AUTHZ-CHECK-4` is now carried by the record itself.

Bumps spec version to **v4-draft18**.

## Motivation

Before this change, `VSOperatorAuthorization` held only a flat list of permission ids (`permissions[]`), and the per-permission authorization configuration (spend limits, feegrant, spend period, enabled flag) was read from `Permission.vs_operator_authz_*` fields. This coupling forced the Delegation Engine to load `Permission` at authorization check time, which:

- Introduced a cyclic module dependency (TR → DE → Perm → TR) that complicates module boundaries and bootstrap ordering.
- Hardcoded the authorized message set for VS operators (always `CreateOrUpdatePermissionSession`, `SetPermissionVPtoValidated`, `TriggerResolver`), leaving no way for an applicant to delegate a different message subset on a per-permission basis (e.g. `TriggerResolver` only on a HOLDER permission, or `SetPermissionVPtoValidated` only on a GRANTOR permission).
- Produced an `O(n)` iteration over every permission in the VSOA on every authorization check.

## Design

### New data layout

- `VSOperatorAuthorization` now exposes `records: PermissionAuthorizationRecord[]` instead of `permissions: uint64[]`. Same primary key `(corporation, vs_operator)`.
- `PermissionAuthorizationRecord` carries everything previously on `Permission.vs_operator_authz_*`: `perm_id`, `msg_types`, `spend_limit`, `fee_spend_limit`, `with_feegrant`, `expiration`, `period`.
- **Global uniqueness invariant**: each `perm_id` appears in at most one `PermissionAuthorizationRecord` system-wide, so `(corporation, vs_operator)` can be derived from `perm_id` via a direct O(1) lookup.
- Entity diagram updated: `vsoauthz "1" --- "1..n" par: records` and `par o-- csp: perm_id` replace the old `vsoauthz --- "0..n" csp: permissions` edge.

### Per-permission-type `msg_types` constraint

`record.msg_types` is **applicant-declared at creation time** (frozen afterward) but constrained by the `Permission.type` and the creation entry point. Each of the three VSOA-creating methods now publishes its own permitted-messages table:

| Entry point | Permission types allowed | Permitted `msg_types` per type |
|---|---|---|
| `MSG-1 Start Permission VP` | all 6 types | HOLDER → `TriggerResolver`; ISSUER → `CreateOrUpdatePermissionSession, SetPermissionVPtoValidated`; VERIFIER → `CreateOrUpdatePermissionSession`; ISSUER_GRANTOR → `SetPermissionVPtoValidated`; VERIFIER_GRANTOR → `SetPermissionVPtoValidated`; ECOSYSTEM → `SetPermissionVPtoValidated` |
| `MSG-7 Create Root Permission` | ECOSYSTEM (only) | ECOSYSTEM → `SetPermissionVPtoValidated` |
| `MSG-14 Self Create Permission` | HOLDER / ISSUER / VERIFIER | HOLDER → `TriggerResolver`; ISSUER → `CreateOrUpdatePermissionSession, SetPermissionVPtoValidated`; VERIFIER → `CreateOrUpdatePermissionSession` |

Precondition checks on `MSG-1 / MSG-7 / MSG-14` enforce that the submitted `vs_operator_authz_msg_types` is a non-empty list and matches the permitted set for the `type`.

### Lifecycle

| Permission event | DE call | `record.expiration` |
|---|---|---|
| `MSG-1 Start Permission VP` (`msg_types` provided) | `MSG-5 Grant` | `now` (disabled until `MSG-3` runs) |
| `MSG-3 Set Permission VP to Validated` | `MSG-9 Update` | `applicant_perm.effective_until` |
| `MSG-7 Create Root Permission` (`msg_types` provided) | `MSG-5 Grant` | `perm.effective_until` (active immediately) |
| `MSG-8 Adjust Permission` | `MSG-9 Update` | `applicant_perm.effective_until` |
| `MSG-14 Self Create Permission` (`msg_types` provided) | `MSG-5 Grant` | `perm.effective_until` (active immediately) |
| `MSG-6 Cancel VP Last Request` (only TERMINATED path) | `MSG-6 Revoke` | — |
| `MSG-9 Revoke Permission` | `MSG-6 Revoke` | — |
| `MSG-12 Slash Permission Trust Deposit` | `MSG-6 Revoke` | — |
| `MSG-2 Renew Permission VP` | (none) | unchanged (same `effective_until` persists) |

The on-chain `FeeGrant` for a VSOA is a **derived** object: after any mutation of `vsoa.records`, the subroutine `MOD-DE-MSG-5-5 Recompute VS Operator Fee Allowance` re-derives `max_expire = max(r.expiration for r in vsoa.records where r.with_feegrant)` and either grants (with msg_types = union) or revokes the chain-level `FeeGrant`. Per-record spend limits are enforced at `AUTHZ-CHECK-4` time.

**VSOA configuration is frozen at record creation time** — only `record.expiration` can change afterward (via `MSG-9 Update`). To change any other field (including `msg_types`, `spend_limit`, `with_feegrant`, `period`), the permission MUST be revoked and re-created.

### `AUTHZ-CHECK-3` / `AUTHZ-CHECK-4`

Both checks now operate entirely off the record:

1. Look up `PermissionAuthorizationRecord` by `perm_id` (O(1), globally unique). Abort if absent.
2. Verify `(corporation, operator)` match the containing VSOA.
3. Verify current `msg_type` ∈ `record.msg_types` (data-driven; no more hardcoded list).
4. Verify `record.expiration > now()`.
5. Reset / decrement `spend_limit` and `fee_spend_limit` against `period`.

## Commits

Staged as 14 self-contained, atomic commits:

1. `refactor(perm): move agent_perm_id from PermissionSession to PermissionSessionRecord` — unrelated prep, fixes a field placement that was already in the working tree.
2. `refactor(perm): remove vs_operator_authz_* fields from Permission entity`
3. `refactor(de): replace VSOA.permissions[] with VSOA.records[] of PermissionAuthorizationRecord`
4. `refactor(authz): AUTHZ-CHECK-3 looks up record by perm_id; verifies (corp, operator) match`
5. `refactor(de): rewrite MOD-DE-MSG-5/6 and add MOD-DE-MSG-7 — O(1) by unique perm_id; no Permission reads` — the new "Update" method was introduced here as MSG-7 and renumbered to MSG-9 in commit 11 to avoid collision with the existing index-table placeholders for Grant/Revoke Exchange Rate Authorization.
6. `feat(perm): MSG-1 Start Permission VP adds optional VSOA params; creates record with expiration=now`
7. `feat(perm): MSG-3 Set Permission VP to Validated updates record.expiration; grants FeeGrant`
8. `feat(perm): MSG-8 Adjust Permission updates record.expiration only (no VSOA params)`
9. `feat(perm): MSG-14 Self Create Permission adds optional VSOA params; creates active record`
10. `feat(perm): MSG-6/9/12 remove record on permission termination; recompute/revoke FeeGrant`
11. `docs(spec): renumber Update VS Operator Authorization Expiration to MSG-9; bump to v4-draft18`
12. `docs(spec): add VSOA/PermissionAuthorizationRecord/Permission relationships to entity diagram`
13. `feat(perm): MSG-7 Create Root Permission adds optional VSOA params; creates active record`
14. `fix: small fixes and improvements. Added list of permitted message types for VSOperatorAuthorization` — per-permission-type permitted-message-types tables on MSG-1 / MSG-7 / MSG-14 and associated precondition checks.

## Breaking changes

### Schema / entities

- `Permission` no longer carries `vs_operator_authz_enabled`, `vs_operator_authz_spend_limit`, `vs_operator_authz_with_feegrant`, `vs_operator_authz_fee_spend_limit`, `vs_operator_authz_spend_period`. Implementations migrating from a prior draft must translate these fields into `PermissionAuthorizationRecord` entries.
- `VSOperatorAuthorization.permissions[]` replaced by `VSOperatorAuthorization.records[]` (`PermissionAuthorizationRecord[]`).
- New entity `PermissionAuthorizationRecord` with global uniqueness invariant on `perm_id`.

### Permission module messages

- `MSG-1` / `MSG-14` parameter `vs_operator_authz_enabled` **removed**; presence of `vs_operator_authz_msg_types` is now the trigger that creates a record. `vs_operator_authz_spend_period` **renamed** to `vs_operator_authz_period` for consistency with `record.period`.
- `MSG-7 Create Root Permission` **now accepts** `vs_operator` and the full `vs_operator_authz_*` parameter set (previously had no way to declare a `vs_operator` even though `Permission.vs_operator` already existed as a field). It also now assigns `perm.vs_operator` on creation.
- `vs_operator_authz_msg_types` is a **non-empty, type-constrained list**: each of `MSG-1 / MSG-7 / MSG-14` defines its own permitted `(permission_type, msg_types)` mapping in its parameters section.
- `MSG-8 Adjust Permission` **no longer accepts** VSOA parameters and can only update `record.expiration` (which it synchronises with `applicant_perm.effective_until`).
- The hardcoded `[CreateOrUpdatePermissionSession, SetPermissionVPtoValidated, TriggerResolver]` message set is gone: `record.msg_types` is applicant-declared at `MSG-1 / MSG-7 / MSG-14` and frozen.
- The ISSUER/VERIFIER type guard around VSOA grant/revoke on `MSG-3`, `MSG-8`, `MSG-9 Revoke`, `MSG-12 Slash` is removed — any permission type can have a record (since `msg_types` is applicant-declared), and the DE methods are silent no-ops when no record exists.

### Delegation Engine module messages

- `MOD-DE-MSG-5 Grant VS Operator Authorization` signature changes from `(perm_id)` to `(corporation, vs_operator, record)`; no longer reads `Permission`.
- `MOD-DE-MSG-6 Revoke VS Operator Authorization` keeps its `(perm_id)` parameter but no longer reads `Permission`; global uniqueness of `perm_id` suffices. Returning from an empty VSOA now deletes the VSOA itself.
- New `MOD-DE-MSG-9 Update VS Operator Authorization Expiration` (module-call only, invoked by `MSG-3` and `MSG-8`). No-op if no record exists.
- New shared subroutine `MOD-DE-MSG-5-5 Recompute VS Operator Fee Allowance` re-derives the chain-level `FeeGrant` after every mutation of `vsoa.records`.

## Related

- Closes #124
- Follows-on from #127 (`SetPermissionVPtoValidated` addition to VSOA msg_types)
