### PR TITLE
refactor: Participants, Onboarding Process, Corporation...

### DIFF
--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ customElements.define("slide-panels",class extends HTMLElement{static get observ
 <p>This specification defines the data model, API, and normative requirements for implementing and interacting with a Verifiable Public Registry.</p>
 <h2 id="about-this-document"><a class="toc-anchor" href="#about-this-document" >§</a> About this Document</h2>
 <p>In order to fully understand the concepts developed in this document, you should have some basic knowledge of <a class="term-reference" href="#term:did">DID</a>, <a class="term-reference" href="#term:didcomm">DIDComm</a>, <a class="term-reference" href="#term:vs">VS</a>, <a class="term-reference" href="#term:ecosystem">ecosystem</a>, ledger-based applications, and more generally, all terms present in the <a href="#terminology" >Terminology</a> section.</p>
-<div id="note-121" class="notice note"><a class="notice-link" href="#note-121">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
+<div id="note-136" class="notice note"><a class="notice-link" href="#note-136">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
 </div>
 <h2 id="introduction"><a class="toc-anchor" href="#introduction" >§</a> Introduction</h2>
 <h3 id="what-is-an-ecosystem"><a class="toc-anchor" href="#what-is-an-ecosystem" >§</a> What is an Ecosystem?</h3>
@@ -553,7 +553,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <li>A portion defined by <code>trust_deposit_rate</code> is allocated to the <strong>participant’s trust deposit</strong>.</li>
 <li>The remaining portion is <strong>transferred directly to the participant’s wallet</strong>.</li>
 </ul>
-<div id="note-122" class="notice note"><a class="notice-link" href="#note-122">NOTE</a><p>Agents that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
+<div id="note-137" class="notice note"><a class="notice-link" href="#note-137">NOTE</a><p>Agents that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
 If not, they <strong>must reject</strong> the issuance or verification request.</p>
 <p>Note: The <strong>User Agent</strong> and <strong>Wallet User Agent</strong> may refer to the same implementation.</p>
 </div>
@@ -565,7 +565,7 @@ If not, they <strong>must reject</strong> the issuance or verification request.<
 <p><em>This section is non-normative.</em></p>
 <p>A <a class="term-reference" href="#term:governance-framework">governance framework</a> must define the governance rules that apply to a <a class="term-reference" href="#term:vpr">VPR</a>.</p>
 <p>A designated <a class="term-reference" href="#term:governance-authority">governance authority</a> (aka a council) is responsible for <strong>enforcing these rules</strong> and, when necessary, <strong>applying financial sanctions</strong> to participants who violate the rules.</p>
-<div id="note-123" class="notice note"><a class="notice-link" href="#note-123">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
+<div id="note-138" class="notice note"><a class="notice-link" href="#note-138">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
 <p>While the <strong>VPR governance framework</strong> defines the global rules for operating the Verifiable Public Registry (e.g., trust deposits, fee distribution, slashing conditions), each <strong>ecosystem</strong> must define its own <strong>EGF</strong> to govern roles, permissions, credential policies, and compliance within its specific domain.</p>
 <p>This separation ensures that ecosystems remain autonomous and can tailor governance to their unique needs, without being constrained by the global rules of the VPR.</p>
 </div>
@@ -578,7 +578,7 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 <p>A <code>Corporation</code> is the VPR-level entity that extends a Cosmos SDK <a class="term-reference" href="#term:group">group</a> with a DID, a governance framework, and lifecycle attributes. A Corporation may control <a class="term-reference" href="#term:participants">participants</a> in zero or more <a class="term-reference" href="#term:ecosystems">ecosystems</a> and may itself be the controller of zero or more <a class="term-reference" href="#term:ecosystems">ecosystems</a>.</p>
 <p><code>Corporation</code>:</p>
 <ul>
-<li><code>did</code> (string) (<em>mandatory</em>): the DID of the Corporation.</li>
+<li><code>did</code> (string) (<em>mandatory</em>): the DID of the Corporation. MUST be <strong>globally unique</strong> across all <code>Corporation</code> entries (per-Corporation <code>did</code> uniqueness invariant): at any block height, no two <code>Corporation</code> entries MAY share the same <code>did</code> value. Enforced at create time by <a href="#mod-co-msg-1-2-1-create-new-corporation-basic-checks" >[MOD-CO-MSG-1-2-1]</a> and at rotation time by <a href="#mod-co-msg-2-2-1-update-corporation-basic-checks" >[MOD-CO-MSG-2-2-1]</a>.</li>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this Corporation has been created.</li>
 <li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this Corporation has been modified.</li>
 <li><code>archived</code> (timestamp) (<em>optional</em>): timestamp this Corporation has been archived.</li>
@@ -592,8 +592,8 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 <p><code>Ecosystem</code>:</p>
 <ul>
 <li><code>id</code> (uint64) (<em>mandatory</em>): the id of the ecosystem.</li>
-<li><code>did</code> (string) (<em>mandatory</em>): the did of the ecosystem.</li>
-<li><code>corporation</code> (group) (<em>mandatory</em>): <a class="term-reference" href="#term:corporation">corporation</a> that controls this entry.</li>
+<li><code>did</code> (string) (<em>mandatory</em>): the did of the ecosystem. MAY be shared with other <code>Ecosystem</code> entries (a single DID MAY be the <code>did</code> of several ecosystems); per-Ecosystem DID uniqueness is NOT enforced because the <code>Ecosystem</code> identity is its <code>id</code>. However, per-Ecosystem <code>(did, corporation)</code> consistency IS enforced: at any block height, all <code>Ecosystem</code> entries with equal <code>did</code> MUST share the same <code>corporation</code>. Enforced at create time by <a href="#mod-es-msg-1-2-1-create-new-ecosystem-basic-checks" >[MOD-ES-MSG-1-2-1]</a> and at rotation time by <a href="#mod-es-msg-2-2-1-update-ecosystem-basic-checks" >[MOD-ES-MSG-2-2-1]</a>.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): <a class="term-reference" href="#term:corporation">corporation</a> that controls this entry. Constrained by the per-Ecosystem <code>(did, corporation)</code> consistency invariant above.</li>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this Ecosystem has been created.</li>
 <li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this Ecosystem has been modified.</li>
 <li><code>archived</code> (timestamp) (<em>mandatory</em>): timestamp this Ecosystem has been archived.</li>
@@ -665,8 +665,8 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 <li><code>id</code> (uint64) (<em>mandatory</em>): the id of the participant.</li>
 <li><code>schema_id</code> (uint64) (<em>mandatory</em>): the id of the related <code>CredentialSchema</code> entry.</li>
 <li><code>role</code> (ParticipantRole): ISSUER, VERIFIER, ISSUER_GRANTOR, VERIFIER_GRANTOR, ECOSYSTEM, HOLDER</li>
-<li><code>did</code> (string) (<em>optional</em>): <a class="term-reference" href="#term:did">DID</a> this permission refers to. MUST conform to [<a class="spec-reference" href="#ref:RFC3986">RFC3986</a>].</li>
-<li><code>corporation</code> (group) (<em>mandatory</em>): <a class="term-reference" href="#term:corporation">corporation</a> that owns this permission.</li>
+<li><code>did</code> (string) (<em>optional</em>): <a class="term-reference" href="#term:did">DID</a> this permission refers to. MUST conform to [<a class="spec-reference" href="#ref:RFC3986">RFC3986</a>]. MAY be shared with other <code>Participant</code> entries (a single DID MAY be the <code>did</code> of several participants); per-Participant DID uniqueness is NOT enforced because the <code>Participant</code> identity is its <code>id</code>. However, per-Participant <code>(did, corporation)</code> consistency IS enforced: at any block height, all <code>Participant</code> entries with non-null equal <code>did</code> MUST share the same <code>corporation</code>. Enforced by the create-time basic checks of <a href="#mod-pp-msg-1-2-1-start-participant-op-basic-checks" >[MOD-PP-MSG-1-2-1]</a>, <a href="#mod-pp-msg-7-2-1-create-root-participant-basic-checks" >[MOD-PP-MSG-7-2-1]</a>, and <a href="#mod-pp-msg-14-2-1-self-create-participant-basic-checks" >[MOD-PP-MSG-14-2-1]</a>. <code>Participant.did</code> is set at create time and is not rotated thereafter.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): <a class="term-reference" href="#term:corporation">corporation</a> that owns this permission. Constrained by the per-Participant <code>(did, corporation)</code> consistency invariant above (when <code>did</code> is non-null).</li>
 <li><code>vs_operator</code> (account) (<em>mandatory</em>): verifiable service agent account. This is the account that will have the right to create or update permission sessions.</li>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this <code>Participant</code> has been created.</li>
 <li><code>adjusted</code> (timestamp) (<em>mandatory</em>): timestamp this <code>Participant</code> has been adjusted.</li>
@@ -935,10 +935,10 @@ as a direct consequence of executing authorized messages.</li>
   <span class="token punctuation">}</span>
 <span class="token punctuation">]</span>
 </code></pre>
-<div id="warning-73" class="notice warning"><a class="notice-link" href="#warning-73">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
+<div id="warning-82" class="notice warning"><a class="notice-link" href="#warning-82">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
 </div>
 <p>A VPR implementation MUST implement all the following requirements.</p>
-<div id="note-124" class="notice note"><a class="notice-link" href="#note-124">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="ec"path-3="v1"path-4="get"href="https://example/verana/ec/v1/get" ><span>https://example/verana/ec/v1/get</span></a>.</p>
+<div id="note-139" class="notice note"><a class="notice-link" href="#note-139">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="ec"path-3="v1"path-4="get"href="https://example/verana/ec/v1/get" ><span>https://example/verana/ec/v1/get</span></a>.</p>
 </div>
 <h3 id="authorization-and-fee-grants"><a class="toc-anchor" href="#authorization-and-fee-grants" >§</a> Authorization and Fee Grants</h3>
 <h4 id="delegable-module-messages"><a class="toc-anchor" href="#delegable-module-messages" >§</a> Delegable Module Messages</h4>
@@ -1695,7 +1695,7 @@ messages.</p>
 </tr>
 </tbody>
 </table>
-<div id="note-125" class="notice note"><a class="notice-link" href="#note-125">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
+<div id="note-140" class="notice note"><a class="notice-link" href="#note-140">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
 </div>
 <h3 id="corporation-module"><a class="toc-anchor" href="#corporation-module" >§</a> Corporation Module</h3>
 <p>This module manages <a class="term-reference" href="#term:corporation">corporation</a> entries — the VPR-level entity that extends a Cosmos SDK <a class="term-reference" href="#term:group">group</a> with a DID, a governance framework, and lifecycle attributes. A <code>Corporation</code> entry MUST exist before its underlying group can be referenced as the <code>corporation</code> (group) in any other VPR Create-* method (see <a href="#mod-co-msg-1-create-new-corporation" >[MOD-CO-MSG-1]</a>).</p>
@@ -1733,6 +1733,9 @@ messages.</p>
 </li>
 <li>
 <p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
+</li>
+<li>
+<p><code>did</code> MUST NOT already be the <code>did</code> of any existing <code>Corporation</code> entry; if some <code>Corporation</code> entry already holds this <code>did</code>, method MUST abort (per-Corporation <code>did</code> uniqueness invariant: a DID is the <code>did</code> of at most one <code>Corporation</code>).</p>
 </li>
 <li>
 <p><code>language</code> (string(17)) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>).</p>
@@ -1849,6 +1852,9 @@ messages.</p>
 </li>
 <li>
 <p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
+</li>
+<li>
+<p><code>did</code> MUST NOT already be the <code>did</code> of any <strong>other</strong> <code>Corporation</code> entry (i.e., any <code>Corporation</code> entry whose underlying group differs from the signing <code>corporation</code>); if some other <code>Corporation</code> entry already holds this <code>did</code>, method MUST abort (per-Corporation <code>did</code> uniqueness invariant). Rotating to the same value <code>co.did</code> already holds is a no-op and MUST be allowed.</p>
 </li>
 </ul>
 <h6 id="mod-co-msg-2-2-2-update-corporation-fee-checks"><a class="toc-anchor" href="#mod-co-msg-2-2-2-update-corporation-fee-checks" >§</a> [MOD-CO-MSG-2-2-2] Update Corporation fee checks</h6>
@@ -2013,6 +2019,9 @@ messages.</p>
 <p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
 </li>
 <li>
+<p>if any existing <code>Ecosystem</code> entry has <code>did</code> equal to the provided <code>did</code>, its <code>corporation</code> MUST equal the signing <code>corporation</code>; else method MUST abort (per-Ecosystem <code>(did, corporation)</code> consistency invariant: at any block height, all <code>Ecosystem</code> entries sharing a <code>did</code> are controlled by the same <code>Corporation</code>).</p>
+</li>
+<li>
 <p><code>language</code> (string(17)) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>).</p>
 </li>
 <li>
@@ -2022,7 +2031,7 @@ messages.</p>
 <p><code>doc_digest_sri</code> (string) (<em>mandatory</em>): MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</p>
 </li>
 </ul>
-<div id="note-126" class="notice note"><a class="notice-link" href="#note-126">NOTE</a><p>It is not a problem if several ecosystems are created with the same ecosystem DID. Identifier of a <code>Ecosystem</code> is its id, and the Verifiable Trust Spec includes the id of the <code>Ecosystem</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
+<div id="note-141" class="notice note"><a class="notice-link" href="#note-141">NOTE</a><p>Several <code>Ecosystem</code> entries MAY share the same ecosystem DID. The identifier of an <code>Ecosystem</code> is its <code>id</code>, and the Verifiable Trust Spec includes the <code>id</code> of the <code>Ecosystem</code> in the DID Document. Per-Ecosystem DID uniqueness is therefore NOT required: proof of control of the DID is verified by resolving the DID outside of the context of the VPR. However, <strong>all <code>Ecosystem</code> entries sharing the same <code>did</code> MUST be controlled by the same <code>corporation</code></strong> — see the basic-check bullet above. Proof of control of the shared DID is, by construction, held by that single controlling <code>Corporation</code>, and the corresponding <code>Corporation</code> entry (if any whose own <code>did</code> equals this value) is unique by the per-Corporation <code>did</code> uniqueness invariant (although the Corporation that <em>owns</em> the DID per Corp.did and the Corporation that <em>controls</em> the Ecosystems claiming it need not coincide).</p>
 </div>
 <h6 id="mod-es-msg-1-2-2-create-new-ecosystem-fee-checks"><a class="toc-anchor" href="#mod-es-msg-1-2-2-create-new-ecosystem-fee-checks" >§</a> [MOD-ES-MSG-1-2-2] Create New Ecosystem fee checks</h6>
 <p>Fee payer MUST have an available balance to cover the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</p>
@@ -2130,6 +2139,9 @@ messages.</p>
 </li>
 <li>
 <p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
+</li>
+<li>
+<p>if any <strong>other</strong> <code>Ecosystem</code> entry (i.e., any <code>Ecosystem</code> entry whose <code>id</code> differs from the supplied <code>id</code>) has <code>did</code> equal to the provided <code>did</code>, its <code>corporation</code> MUST equal the signing <code>corporation</code>; else method MUST abort (per-Ecosystem <code>(did, corporation)</code> consistency invariant). Rotating <code>ecosystem.did</code> to a value already held by another <code>Ecosystem</code> controlled by a different <code>corporation</code> is forbidden.</p>
 </li>
 </ul>
 <h6 id="mod-es-msg-2-2-2-update-ecosystem-fee-checks"><a class="toc-anchor" href="#mod-es-msg-2-2-2-update-ecosystem-fee-checks" >§</a> [MOD-ES-MSG-2-2-2] Update Ecosystem fee checks</h6>
@@ -2494,7 +2506,7 @@ messages.</p>
 <p><code>pricing_asset</code> (string) (<em>mandatory</em>): <code>&quot;tu&quot;</code> if <code>pricing_asset_type</code> is set to TU, else examples: COIN: <code>denom</code> <code>&quot;uvna&quot;</code>, <code>&quot;ufoo&quot;</code>, <code>&quot;ibc/3A0F9C2E4E2A9B7D6F...&quot;</code>, <code>&quot;factory/verana1.../ueurv&quot;</code>, FIAT: <code>&quot;EUR&quot;</code>, <code>&quot;GBP&quot;</code>,…</p>
 </li>
 </ul>
-<div id="note-127" class="notice note"><a class="notice-link" href="#note-127">NOTE</a><p>When pricing_currency is set to FIAT, pricing_asset MUST be an ISO-4217 currency code.
+<div id="note-142" class="notice note"><a class="notice-link" href="#note-142">NOTE</a><p>When pricing_currency is set to FIAT, pricing_asset MUST be an ISO-4217 currency code.
 The number of decimals and minor unit semantics MUST follow the ISO-4217 standard for that currency.
 FIAT amounts MUST be expressed in minor units and MUST NOT be represented as on-chain coins.
 FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on chain.</p>
@@ -2527,7 +2539,7 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 </ul>
 </li>
 </ul>
-<div id="note-128" class="notice note"><a class="notice-link" href="#note-128">NOTE</a><p>If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM <code>Participant</code> so that onboarding processes can be run.</p>
+<div id="note-143" class="notice note"><a class="notice-link" href="#note-143">NOTE</a><p>If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM <code>Participant</code> so that onboarding processes can be run.</p>
 </div>
 <h4 id="mod-cs-msg-2-update-credential-schema"><a class="toc-anchor" href="#mod-cs-msg-2-update-credential-schema" >§</a> [MOD-CS-MSG-2] Update Credential Schema</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
@@ -2953,7 +2965,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li>If the <a class="term-reference" href="#term:applicant">applicant</a> qualifies, the <a class="term-reference" href="#term:validator">validator</a> runs <a href="#mod-pp-msg-3-set-participant-op-to-validated" >[MOD-PP-MSG-3]</a> to update the Participant entry; the <a class="term-reference" href="#term:applicant">applicant</a> is then granted the new <code>Participant</code> entries and/or issued a credential.</li>
 </ol>
 <p>Once in the <code>VALIDATED</code> state, a Participant entry remains valid for a specific period (e.g., 365 days), configured in the <a class="term-reference" href="#term:credential-schema">credential schema</a> for credential-schema-related onboarding, or set by the <a class="term-reference" href="#term:ecosystem">ecosystem</a> for user-agent onboarding.</p>
-<div id="note-129" class="notice note"><a class="notice-link" href="#note-129">NOTE</a><p>Even when the Participant entry remains in the <code>VALIDATED</code> state for the configured period, the resulting <code>Participant</code> entry or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the <a class="term-reference" href="#term:applicant">applicant</a> MUST provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration in order to be issued an updated <code>Participant</code> entry and/or credential.</p>
+<div id="note-144" class="notice note"><a class="notice-link" href="#note-144">NOTE</a><p>Even when the Participant entry remains in the <code>VALIDATED</code> state for the configured period, the resulting <code>Participant</code> entry or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the <a class="term-reference" href="#term:applicant">applicant</a> MUST provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration in order to be issued an updated <code>Participant</code> entry and/or credential.</p>
 </div>
 <p>If the <code>VALIDATED</code> state is set to expire, an <a class="term-reference" href="#term:applicant">applicant</a> that wishes to extend the expiration timestamp MUST renew its <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-2-renew-participant-op" >[MOD-PP-MSG-2]</a>).</p>
 <p>At any time, the <a class="term-reference" href="#term:applicant">applicant</a> CAN cancel the <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-6-cancel-participant-op-last-request" >[MOD-PP-MSG-6]</a>).</p>
@@ -3035,9 +3047,10 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li><code>issuance_fees</code> (number) (<em>optional</em>): Requested issuance_fees for this <code>Participant</code> entry (can be modified by validator).</li>
 <li><code>verification_fees</code> (number) (<em>optional</em>): Requested verification_fees for this <code>Participant</code> entry (can be modified by validator).</li>
 <li><code>did</code>, if specified, MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
+<li>if <code>did</code> is specified and any existing <code>Participant</code> entry has non-null <code>did</code> equal to the provided <code>did</code>, its <code>corporation</code> MUST equal the signing <code>corporation</code>; else method MUST abort (per-Participant <code>(did, corporation)</code> consistency invariant: at any block height, all <code>Participant</code> entries sharing a non-null <code>did</code> are owned by the same <code>Corporation</code>).</li>
 <li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-pp-msg-1-1-start-participant-op-parameters" >MOD-PP-MSG-1-1</a>.</li>
 </ul>
-<div id="note-130" class="notice note"><a class="notice-link" href="#note-130">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the onboarding process is REQUIRED or not.</p>
+<div id="note-145" class="notice note"><a class="notice-link" href="#note-145">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the onboarding process is REQUIRED or not.</p>
 </div>
 <h6 id="mod-pp-msg-1-2-2-start-participant-op-permission-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-2-start-participant-op-permission-checks" >§</a> [MOD-PP-MSG-1-2-2] Start Participant OP permission checks</h6>
 <ul>
@@ -3164,7 +3177,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 </ul>
-<div id="note-131" class="notice note"><a class="notice-link" href="#note-131">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
+<div id="note-146" class="notice note"><a class="notice-link" href="#note-146">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
 <h6 id="mod-pp-msg-1-2-4-start-participant-op-overlap-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-4-start-participant-op-overlap-checks" >§</a> [MOD-PP-MSG-1-2-4] Start Participant OP overlap checks</h6>
 <p>We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a <code>corporation</code> from running different OP with differents validators for the same <code>schema_id</code>, <code>role</code>.</p>
@@ -3339,7 +3352,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 </ul>
-<div id="note-132" class="notice note"><a class="notice-link" href="#note-132">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
+<div id="note-147" class="notice note"><a class="notice-link" href="#note-147">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
 <h6 id="mod-pp-msg-2-3-renew-participant-op-execution"><a class="toc-anchor" href="#mod-pp-msg-2-3-renew-participant-op-execution" >§</a> [MOD-PP-MSG-2-3] Renew Participant OP execution</h6>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
@@ -3709,6 +3722,7 @@ else MUST abort.</p>
 <li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>schema_id</code> MUST be a valid uint64 and a <a class="term-reference" href="#term:credential-schema">credential schema</a> entry with this id MUST exist.</li>
 <li><code>did</code>, if specified, MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
+<li>if <code>did</code> is specified and any existing <code>Participant</code> entry has non-null <code>did</code> equal to the provided <code>did</code>, its <code>corporation</code> MUST equal the signing <code>corporation</code>; else method MUST abort (per-Participant <code>(did, corporation)</code> consistency invariant).</li>
 <li><code>effective_from</code> must be in the future.</li>
 <li><code>effective_until</code>, if not null, must be greater than <code>effective_from</code></li>
 <li><code>validation_fees</code> (number) (<em>mandatory</em>): MUST be &gt;= 0.</li>
@@ -4029,7 +4043,7 @@ else MUST abort.</p>
 <li>if <code>wallet_agent_participant.role</code> is not ISSUER, abort.</li>
 <li>if <code>wallet_agent_participant</code> is not a <a class="term-reference" href="#term:active-participant">active participant</a>, abort.</li>
 </ul>
-<div id="warning-74" class="notice warning"><a class="notice-link" href="#warning-74">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a <code>Participant</code> entry that is not controlled by its owner.</p>
+<div id="warning-83" class="notice warning"><a class="notice-link" href="#warning-83">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a <code>Participant</code> entry that is not controlled by its owner.</p>
 </div>
 <h6 id="mod-pp-msg-10-3-create-or-update-participant-session-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-10-3-create-or-update-participant-session-fee-checks" >§</a> [MOD-PP-MSG-10-3] Create or Update Participant Session fee checks</h6>
 <ul>
@@ -4205,7 +4219,7 @@ else MUST abort.</p>
 <li><code>corporation</code> MUST have available balance ≥ <code>total_payer_trust_deposit</code> + <code>total_payees_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 <hr>
-<div id="warning-75" class="notice warning"><a class="notice-link" href="#warning-75">WARNING</a><ul>
+<div id="warning-84" class="notice warning"><a class="notice-link" href="#warning-84">WARNING</a><ul>
 <li>Trust deposits MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 <li>When paying with COIN ≠ <a class="term-reference" href="#term:native-denom">native denom</a> or with FIAT, payer pays trust deposits on behalf of payees (since payees receive non-native assets that cannot be directly staked).</li>
 </ul>
@@ -4367,7 +4381,7 @@ else MUST abort.</p>
 </ul>
 <p>then, add the <code>cspsr</code> to <code>session.session_records</code></p>
 <p>if current transaction if for issuance of a credential, persist the digest SRI by calling <a href="#mod-di-msg-1-store-digest" >[MOD-DI-MSG-1]</a>.</p>
-<div id="warning-76" class="notice warning"><a class="notice-link" href="#warning-76">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_participant_id</code> OR <code>verifier_participant_id</code></p>
+<div id="warning-85" class="notice warning"><a class="notice-link" href="#warning-85">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_participant_id</code> OR <code>verifier_participant_id</code></p>
 </div>
 <h4 id="mod-pp-msg-11-update-participant-module-parameters"><a class="toc-anchor" href="#mod-pp-msg-11-update-participant-module-parameters" >§</a> [MOD-PP-MSG-11] Update Participant Module Parameters</h4>
 <p>Update Participant Module Parameters.</p>
@@ -4416,7 +4430,7 @@ else MUST abort.</p>
 <li>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>. If no entry found, abort.</li>
 <li><code>amount</code> MUST be lower or equal to <code>applicant_participant.deposit</code> else MUST abort.</li>
 </ul>
-<div id="note-133" class="notice note"><a class="notice-link" href="#note-133">NOTE</a><p>Even if the <code>Participant</code> entry has expired or is revoked, it is still possible to slash it.</p>
+<div id="note-148" class="notice note"><a class="notice-link" href="#note-148">NOTE</a><p>Even if the <code>Participant</code> entry has expired or is revoked, it is still possible to slash it.</p>
 </div>
 <h6 id="mod-pp-msg-12-2-2-slash-participant-trust-deposit-validator-perms"><a class="toc-anchor" href="#mod-pp-msg-12-2-2-slash-participant-trust-deposit-validator-perms" >§</a> [MOD-PP-MSG-12-2-2] Slash Participant Trust Deposit validator perms</h6>
 <p>Either Option #1, or #2 MUST return true, else abort.</p>
@@ -4509,7 +4523,7 @@ else MUST abort.</p>
 <h4 id="mod-pp-msg-14-self-create-participant"><a class="toc-anchor" href="#mod-pp-msg-14-self-create-participant" >§</a> [MOD-PP-MSG-14] Self Create Participant</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This simple <code>Participant</code>-creation method can be used to self-create an ISSUER (resp. VERIFIER) <code>Participant</code> entry if issuance mode (resp. verification mode) is set to <code>OPEN</code> for a given schema. As <code>Participant</code> entries are the anchor of ecosystem trust deposit operations, it is required for an issuer/verifier candidate to self-create a <code>Participant</code> entry for being issuer or verifier of a given schema.</p>
-<div id="note-134" class="notice note"><a class="notice-link" href="#note-134">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their <code>Participant</code> entry may be revoked by ecosystem governance authority and their deposit slashed.</p>
+<div id="note-149" class="notice note"><a class="notice-link" href="#note-149">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their <code>Participant</code> entry may be revoked by ecosystem governance authority and their deposit slashed.</p>
 </div>
 <h5 id="mod-pp-msg-14-1-self-create-participant-parameters"><a class="toc-anchor" href="#mod-pp-msg-14-1-self-create-participant-parameters" >§</a> [MOD-PP-MSG-14-1] Self Create Participant parameters</h5>
 <ul>
@@ -4568,6 +4582,7 @@ else MUST abort.</p>
 <li><code>validator_participant_id</code> (uint64) (<em>mandatory</em>): <code>validator_participant</code> MUST be an ECOSYSTEM <a class="term-reference" href="#term:active-participant">active participant</a> or <a class="term-reference" href="#term:future-participant">future participant</a>.</li>
 <li><code>vs_operator</code> (account) (<em>optional</em>): no check required.</li>
 <li><code>did</code>, MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
+<li>if any existing <code>Participant</code> entry has non-null <code>did</code> equal to the provided <code>did</code>, its <code>corporation</code> MUST equal the signing <code>corporation</code>; else method MUST abort (per-Participant <code>(did, corporation)</code> consistency invariant: at any block height, all <code>Participant</code> entries sharing a non-null <code>did</code> are owned by the same <code>Corporation</code>).</li>
 <li><code>effective_from</code> MUST be in the future AND
 <ul>
 <li>MUST be greater or equal to <code>validator_participant.effective_from</code> AND</li>
@@ -4819,7 +4834,7 @@ else MUST abort.</p>
 </li>
 </ul>
 <p>return <code>found_perms</code>.</p>
-<div id="note-135" class="notice note"><a class="notice-link" href="#note-135">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
+<div id="note-150" class="notice note"><a class="notice-link" href="#note-150">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
 </div>
 <h4 id="mod-pp-qry-5-get-participantsession"><a class="toc-anchor" href="#mod-pp-qry-5-get-participantsession" >§</a> [MOD-PP-QRY-5] Get ParticipantSession</h4>
 <h5 id="mod-pp-qry-5-1-get-participantsession-parameters"><a class="toc-anchor" href="#mod-pp-qry-5-1-get-participantsession-parameters" >§</a> [MOD-PP-QRY-5-1] Get ParticipantSession parameters</h5>
@@ -5199,14 +5214,14 @@ else MUST abort.</p>
 </ul>
 <h4 id="mod-td-msg-7-burn-ecosystem-slashed-trust-deposit"><a class="toc-anchor" href="#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit" >§</a> [MOD-TD-MSG-7] Burn Ecosystem Slashed Trust Deposit</h4>
 <p>Burn the portion of the trust deposit of a given account. This method can only be called by the permission module when performing an ecosystem-related slash.</p>
-<div id="warning-77" class="notice warning"><a class="notice-link" href="#warning-77">WARNING</a><p>Make sure to <strong>properly protect access to the execution of this method</strong> else it may lead to very destructive actions.</p>
+<div id="warning-86" class="notice warning"><a class="notice-link" href="#warning-86">WARNING</a><p>Make sure to <strong>properly protect access to the execution of this method</strong> else it may lead to very destructive actions.</p>
 </div>
 <h5 id="mod-td-msg-7-1-burn-ecosystem-slashed-trust-deposit-method-parameters"><a class="toc-anchor" href="#mod-td-msg-7-1-burn-ecosystem-slashed-trust-deposit-method-parameters" >§</a> [MOD-TD-MSG-7-1] Burn Ecosystem Slashed Trust Deposit method parameters</h5>
 <ul>
 <li><code>corporation</code> (group) (<em>mandatory</em>): corporation of the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> we want to burn.</li>
 <li><code>amount</code> (number) (<em>mandatory</em>): value to burn, in <a class="term-reference" href="#term:denom">denom</a>.</li>
 </ul>
-<div id="warning-78" class="notice warning"><a class="notice-link" href="#warning-78">WARNING</a><p><strong>Alternative approach</strong>: For security and consistency, implementers MAY choose to reference the <strong>ID of the slashed permission</strong>, load it and use its defined <code>slashed_deposit</code> value as the slashing amount.
+<div id="warning-87" class="notice warning"><a class="notice-link" href="#warning-87">WARNING</a><p><strong>Alternative approach</strong>: For security and consistency, implementers MAY choose to reference the <strong>ID of the slashed permission</strong>, load it and use its defined <code>slashed_deposit</code> value as the slashing amount.
 The decision between this method and specifying the amount directly is left to implementers.</p>
 </div>
 <h5 id="mod-td-msg-7-2-burn-ecosystem-slashed-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-td-msg-7-2-burn-ecosystem-slashed-trust-deposit-precondition-checks" >§</a> [MOD-TD-MSG-7-2] Burn Ecosystem Slashed Trust Deposit precondition checks</h5>
@@ -5378,7 +5393,7 @@ The decision between this method and specifying the amount directly is left to i
 <p>Check if a <strong>VS Operator Authorization</strong> exists for <code>corporation</code> and <code>grantee</code>. If this is the case, MUST abort.</p>
 </li>
 </ul>
-<div id="warning-79" class="notice warning"><a class="notice-link" href="#warning-79">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>participant.corporation</code> and <code>participant.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-88" class="notice warning"><a class="notice-link" href="#warning-88">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>participant.corporation</code> and <code>participant.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-3-3-grant-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-3-3-grant-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-3-3] Grant Operator Authorization fee checks</h5>
 <ul>
@@ -5455,7 +5470,7 @@ The decision between this method and specifying the amount directly is left to i
 <li>No <code>OperatorAuthorization</code> <code>oauthz</code> where <code>oauthz.corporation</code> = <code>corporation</code> and <code>oauthz.operator</code> = <code>vs_operator</code> MUST exist.</li>
 <li>No other <code>VSOperatorAuthorization</code> <code>vsoauthz'</code> where <code>vsoauthz'.vs_operator</code> = <code>vs_operator</code> AND <code>vsoauthz'.corporation</code> != <code>corporation</code> MUST exist. In other words, a vs-agent VPR account cannot be controlled by multiple corporations.</li>
 </ul>
-<div id="warning-80" class="notice warning"><a class="notice-link" href="#warning-80">WARNING</a><p>A <strong>VS Operator Authorization</strong> record CAN be granted ONLY IF no <strong>OperatorAuthorization</strong> exists for the same <code>(corporation, vs_operator)</code> pair. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-89" class="notice warning"><a class="notice-link" href="#warning-89">WARNING</a><p>A <strong>VS Operator Authorization</strong> record CAN be granted ONLY IF no <strong>OperatorAuthorization</strong> exists for the same <code>(corporation, vs_operator)</code> pair. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-5-3-grant-vs-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-5-3-grant-vs-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-5-3] Grant VS Operator Authorization fee checks</h5>
 <ul>
@@ -5998,7 +6013,7 @@ rate_scale       = S</p>
 </ul>
 </li>
 </ul>
-<div id="warning-81" class="notice warning"><a class="notice-link" href="#warning-81">WARNING</a><ul>
+<div id="warning-90" class="notice warning"><a class="notice-link" href="#warning-90">WARNING</a><ul>
 <li>Conversions use base units only.</li>
 <li>Integer arithmetic MUST be used.</li>
 <li><code>quote_amount = floor(base_amount × rate / 10^rate_scale)</code>.</li>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ customElements.define("slide-panels",class extends HTMLElement{static get observ
 <p>This specification defines the data model, API, and normative requirements for implementing and interacting with a Verifiable Public Registry.</p>
 <h2 id="about-this-document"><a class="toc-anchor" href="#about-this-document" >§</a> About this Document</h2>
 <p>In order to fully understand the concepts developed in this document, you should have some basic knowledge of <a class="term-reference" href="#term:did">DID</a>, <a class="term-reference" href="#term:didcomm">DIDComm</a>, <a class="term-reference" href="#term:vs">VS</a>, <a class="term-reference" href="#term:ecosystem">ecosystem</a>, ledger-based applications, and more generally, all terms present in the <a href="#terminology" >Terminology</a> section.</p>
-<div id="note-46" class="notice note"><a class="notice-link" href="#note-46">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
+<div id="note-121" class="notice note"><a class="notice-link" href="#note-121">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
 </div>
 <h2 id="introduction"><a class="toc-anchor" href="#introduction" >§</a> Introduction</h2>
 <h3 id="what-is-an-ecosystem"><a class="toc-anchor" href="#what-is-an-ecosystem" >§</a> What is an Ecosystem?</h3>
@@ -390,10 +390,37 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <p>The same <code>Corporation</code> entry is the single entry point for the corporation’s governance (the CGF), authorization delegation (via <code>OperatorAuthorization</code> to one or more <code>operator</code> accounts), and trust-deposit accounting (<code>TrustDeposit</code>). See the <a href="#corporation-module" >Corporation Module</a> for the methods that manage <code>Corporation</code> entries.</p>
 <h3 id="did-indexing"><a class="toc-anchor" href="#did-indexing" >§</a> DID Indexing</h3>
 <p><em>This section is non-normative.</em></p>
-<p>The <code>Participant</code> registry CAN be used by crawlers to index the metadata associated with <a class="term-reference" href="#term:verifiable-services">verifiable services</a>.</p>
-<p>Search engines can iterate over <code>Participant</code> entries and index <a class="term-reference" href="#term:vss">VSs</a> by resolving the service identifier (currently a <a class="term-reference" href="#term:did">DID</a>, extensible in the future), verify whether the service is a <a class="term-reference" href="#term:verifiable-service">verifiable service</a>, and in that case extract its verifiable metadata, such as <a class="term-reference" href="#term:linked-vp">linked-vp</a> presented credentials.</p>
-<p>The index is particularly important for <a class="term-reference" href="#term:verifiable-user-agents">verifiable user agents</a>, such as social browsers, CDN enabled browser, or any service or AI agent that wants to search for a specific service and connect to it. However, it can also be leveraged by <strong>traditional, form-based search engines</strong>, which may return simple links for accessing <a class="term-reference" href="#term:vss">VSs</a>.</p>
-<img src="https://www.plantuml.com/plantuml/svg/bP8nQyCm48Lt_OeZNcEgk10NKufBisGhb7INhKkYLh5TwMmda1zVIx8D8LqwwKxVkzDxeDoICDIUDCldofP28vp46PuuXrv9EhAw-CAIOF4-Q5If6b4H63meI-Qo0651AYbdrPiHlKRZGHbgY1xtXIpMisPRIJnxXNBL7V_yW6WLLfDTGPIkqnJb3KucdDpZtQk7XQbxwrxdlE1xFlET7UsrGy6SUNY-nl7iDWD5Q0GXrDtG_XMRJTeulhu4aza0RQqxXCrsiuG34cXLVQECkyOknw1IaBYRJVunEsNoi_u-WvyMpIKqjxj7NXeSmZoqZNIPmZBcieVOqyeCxB7kdPDM4yknalvhXFCN" alt="uml diagram">
+<p>The <code>Participant</code> registry is the foundation for building <strong>searchable indexes of <a class="term-reference" href="#term:verifiable-services">verifiable services</a> and the verifiable metadata they expose</strong>. Crawlers iterate over <code>Participant</code> entries, resolve each service identifier (currently a <a class="term-reference" href="#term:did">DID</a>, extensible in the future), verify that the service is a <a class="term-reference" href="#term:verifiable-service">verifiable service</a>, and extract its verifiable metadata — most notably the credentials presented through <a class="term-reference" href="#term:linked-vp">linked-vp</a> — together with the <a class="term-reference" href="#term:ecosystem">ecosystem</a> memberships, <a class="term-reference" href="#term:credential-schema">credential schema</a> permissions, and <a class="term-reference" href="#term:trust-deposit">trust deposit</a> level associated with the controlling <a class="term-reference" href="#term:corporation">corporation</a>.</p>
+<p>Unlike a traditional web index, this index is <strong>trust-typed</strong>: every entry carries cryptographically verifiable claims about <em>what</em> the service is, <em>who</em> operates it, and <em>under which governance frameworks</em> it is accredited. This unlocks a class of discovery use cases that traditional search engines cannot serve.</p>
+<h4 id="ai-agent-discovery"><a class="toc-anchor" href="#ai-agent-discovery" >§</a> AI agent discovery</h4>
+<p>AI agents are first-class consumers of the index. Before delegating a task or accepting a connection, an agent needs to find counterparts whose <strong>presented credentials match the capabilities required for the interaction</strong>. Querying the index, an AI agent can:</p>
+<ul>
+<li>find <a class="term-reference" href="#term:verifiable-services">verifiable services</a> qualified for a specific task — for example, a payment processor accredited in a given jurisdiction, a KYC issuer recognized by a target <a class="term-reference" href="#term:ecosystem">ecosystem</a>, or an MCP-style service whose operator holds a recognized organization credential;</li>
+<li>discover other AI agents whose credentials prove the right scope, authority, or operator;</li>
+<li>restrict the search to a specific <a class="term-reference" href="#term:ecosystem">ecosystem</a> or to services that comply with a chosen <a class="term-reference" href="#term:credential-schema">credential schema</a>;</li>
+<li>rank candidates by <a class="term-reference" href="#term:trust-deposit">trust deposit</a> size, accreditations held, slashing history, or credential freshness, in order to bias selection toward parties with stronger economic accountability.</li>
+</ul>
+<p>Because every indexed claim is anchored in the <a class="term-reference" href="#term:vpr">VPR</a>, an AI agent can verify a counterpart end-to-end <em>before</em> initiating the interaction, avoiding spoofed services and unaccredited issuers.</p>
+<h4 id="verifiable-user-agent-content-discovery"><a class="toc-anchor" href="#verifiable-user-agent-content-discovery" >§</a> Verifiable User Agent content discovery</h4>
+<p><a class="term-reference" href="#term:verifiable-user-agents">Verifiable user agents</a> (VUAs) — such as social browsers, agentic browsers, or CDN-aware clients — use the index to <strong>find content and services that are compatible with the user’s context</strong>: the credentials the user holds, the <a class="term-reference" href="#term:ecosystems">ecosystems</a> the user trusts, the jurisdictions and languages that apply, and the schemas that the user’s wallet can satisfy.</p>
+<p>Typical VUA queries include:</p>
+<ul>
+<li><em>“Show only services accredited under ecosystem X”</em> — filter by <a class="term-reference" href="#term:ecosystem">ecosystem</a> membership.</li>
+<li><em>“Show services that accept the credentials currently in my wallet”</em> — match the holder’s credentials against each <a class="term-reference" href="#term:vs">VS</a>'s expected presentations.</li>
+<li><em>“Show issuers of schema Y operating in jurisdiction Z”</em> — combine <a class="term-reference" href="#term:credential-schema">credential schema</a> permissions with corporation metadata.</li>
+<li><em>“Show services my user has previously interacted with successfully”</em> — combine the index with the VUA’s local history.</li>
+</ul>
+<p>The result is a feed of <a class="term-reference" href="#term:vss">VSs</a> for which a proof of trust can be displayed to the user <em>before</em> connection, in line with the VUA enforcement obligations defined in this spec and in the <a class="term-reference" href="#term:vt-spec">VT Spec</a>.</p>
+<h4 id="other-consumers"><a class="toc-anchor" href="#other-consumers" >§</a> Other consumers</h4>
+<p>The same index serves additional consumers:</p>
+<ul>
+<li><strong>Trust-aware and traditional, form-based search engines</strong>, which can return ordinary links to <a class="term-reference" href="#term:vss">VSs</a> enriched with verifiable trust signals (issuer accreditations, <a class="term-reference" href="#term:ecosystem">ecosystem</a> memberships, <a class="term-reference" href="#term:trust-deposit">trust deposit</a> level).</li>
+<li><strong>Ecosystem operators and governance authorities</strong>, which use the index to monitor accredited issuers, verifiers, and grantors, observe schema adoption across <a class="term-reference" href="#term:ecosystems">ecosystems</a>, and detect rogue or expired participants.</li>
+<li><strong>Auditors, regulators, and compliance tools</strong>, which rely on the index to map the supply chain of trust behind a given service or credential, and to verify that participants are still in good standing.</li>
+<li><strong>Analytics and reputation services</strong>, which combine indexed metadata with on-chain history (trust-deposit movements, slashing events, session volumes) to produce reputational signals at the <a class="term-reference" href="#term:corporation">corporation</a> level.</li>
+</ul>
+<h4 id="indexing-pipeline"><a class="toc-anchor" href="#indexing-pipeline" >§</a> Indexing pipeline</h4>
+<img src="https://www.plantuml.com/plantuml/svg/hLHDYzim4BthLmoRImCRuYJj1a8f2LqekHMMxSaNsHedqpgIAutp0VlZEv8TxouDFHKVFDPxCtxpdl4wiFRS7cgr7gfGwXhXeCymox8CJcHuhvGhVcB9SFTTM5HIeos3nnq5zfSxq04C6JEmldfzgj4deEng62sgmXGF0sTh3PuJWs8ru0FXnnECPjri3ZCOBH-MIpJluFaLdW_mW6-se7TeEL4qfHf6LLKiFYvVXpnl4bvuTmfHP9OLMPKD-1DgN-u1xOui9cReJaPc4Q-1-CqTqLjjIuHfRZUj8OOfRAokB-9NIAqxTnG1dufbCNkL-Hnwdrefb8esmkUNoMJmRGN4w3KZtF9UNMcJoSkNpgYLWC7LHuJ7xUCzLCYYjoRx2ytas8Jxt7Q6Ys2gI1SnRMHjDEk_fit_txIEjfAzC2upXROniKZdIbqJUiVztQA_m8TAdg5qhHKZ6Z4XvBQun456EaZN0HeHAJMQiRf6-Oz1GhISsz8T6iqK9P-8zoc13ZtpMFL1tng3rbFlWaX9lUpRm11e9uc7iOfHt-eyE4liFEWogYUMrpiRJTJnYxc7egNQYEDDsq5ZfPAgz4LSDrj1sBkJH846N9NRDzOBVAGImvkkVe--gPEE9hVzkHZNrXpK6gr9FuBk_WS0" alt="uml diagram">
 <h3 id="business-models"><a class="toc-anchor" href="#business-models" >§</a> Business models</h3>
 <h4 id="trust-deposit"><a class="toc-anchor" href="#trust-deposit" >§</a> Trust Deposit</h4>
 <p><em>This section is non-normative.</em></p>
@@ -526,7 +553,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <li>A portion defined by <code>trust_deposit_rate</code> is allocated to the <strong>participant’s trust deposit</strong>.</li>
 <li>The remaining portion is <strong>transferred directly to the participant’s wallet</strong>.</li>
 </ul>
-<div id="note-47" class="notice note"><a class="notice-link" href="#note-47">NOTE</a><p>Agents that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
+<div id="note-122" class="notice note"><a class="notice-link" href="#note-122">NOTE</a><p>Agents that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
 If not, they <strong>must reject</strong> the issuance or verification request.</p>
 <p>Note: The <strong>User Agent</strong> and <strong>Wallet User Agent</strong> may refer to the same implementation.</p>
 </div>
@@ -538,7 +565,7 @@ If not, they <strong>must reject</strong> the issuance or verification request.<
 <p><em>This section is non-normative.</em></p>
 <p>A <a class="term-reference" href="#term:governance-framework">governance framework</a> must define the governance rules that apply to a <a class="term-reference" href="#term:vpr">VPR</a>.</p>
 <p>A designated <a class="term-reference" href="#term:governance-authority">governance authority</a> (aka a council) is responsible for <strong>enforcing these rules</strong> and, when necessary, <strong>applying financial sanctions</strong> to participants who violate the rules.</p>
-<div id="note-48" class="notice note"><a class="notice-link" href="#note-48">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
+<div id="note-123" class="notice note"><a class="notice-link" href="#note-123">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
 <p>While the <strong>VPR governance framework</strong> defines the global rules for operating the Verifiable Public Registry (e.g., trust deposits, fee distribution, slashing conditions), each <strong>ecosystem</strong> must define its own <strong>EGF</strong> to govern roles, permissions, credential policies, and compliance within its specific domain.</p>
 <p>This separation ensures that ecosystems remain autonomous and can tailor governance to their unique needs, without being constrained by the global rules of the VPR.</p>
 </div>
@@ -908,10 +935,10 @@ as a direct consequence of executing authorized messages.</li>
   <span class="token punctuation">}</span>
 <span class="token punctuation">]</span>
 </code></pre>
-<div id="warning-28" class="notice warning"><a class="notice-link" href="#warning-28">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
+<div id="warning-73" class="notice warning"><a class="notice-link" href="#warning-73">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
 </div>
 <p>A VPR implementation MUST implement all the following requirements.</p>
-<div id="note-49" class="notice note"><a class="notice-link" href="#note-49">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="ec"path-3="v1"path-4="get"href="https://example/verana/ec/v1/get" ><span>https://example/verana/ec/v1/get</span></a>.</p>
+<div id="note-124" class="notice note"><a class="notice-link" href="#note-124">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="ec"path-3="v1"path-4="get"href="https://example/verana/ec/v1/get" ><span>https://example/verana/ec/v1/get</span></a>.</p>
 </div>
 <h3 id="authorization-and-fee-grants"><a class="toc-anchor" href="#authorization-and-fee-grants" >§</a> Authorization and Fee Grants</h3>
 <h4 id="delegable-module-messages"><a class="toc-anchor" href="#delegable-module-messages" >§</a> Delegable Module Messages</h4>
@@ -1668,7 +1695,7 @@ messages.</p>
 </tr>
 </tbody>
 </table>
-<div id="note-50" class="notice note"><a class="notice-link" href="#note-50">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
+<div id="note-125" class="notice note"><a class="notice-link" href="#note-125">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
 </div>
 <h3 id="corporation-module"><a class="toc-anchor" href="#corporation-module" >§</a> Corporation Module</h3>
 <p>This module manages <a class="term-reference" href="#term:corporation">corporation</a> entries — the VPR-level entity that extends a Cosmos SDK <a class="term-reference" href="#term:group">group</a> with a DID, a governance framework, and lifecycle attributes. A <code>Corporation</code> entry MUST exist before its underlying group can be referenced as the <code>corporation</code> (group) in any other VPR Create-* method (see <a href="#mod-co-msg-1-create-new-corporation" >[MOD-CO-MSG-1]</a>).</p>
@@ -1995,7 +2022,7 @@ messages.</p>
 <p><code>doc_digest_sri</code> (string) (<em>mandatory</em>): MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</p>
 </li>
 </ul>
-<div id="note-51" class="notice note"><a class="notice-link" href="#note-51">NOTE</a><p>It is not a problem if several ecosystems are created with the same ecosystem DID. Identifier of a <code>Ecosystem</code> is its id, and the Verifiable Trust Spec includes the id of the <code>Ecosystem</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
+<div id="note-126" class="notice note"><a class="notice-link" href="#note-126">NOTE</a><p>It is not a problem if several ecosystems are created with the same ecosystem DID. Identifier of a <code>Ecosystem</code> is its id, and the Verifiable Trust Spec includes the id of the <code>Ecosystem</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
 </div>
 <h6 id="mod-es-msg-1-2-2-create-new-ecosystem-fee-checks"><a class="toc-anchor" href="#mod-es-msg-1-2-2-create-new-ecosystem-fee-checks" >§</a> [MOD-ES-MSG-1-2-2] Create New Ecosystem fee checks</h6>
 <p>Fee payer MUST have an available balance to cover the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</p>
@@ -2467,7 +2494,7 @@ messages.</p>
 <p><code>pricing_asset</code> (string) (<em>mandatory</em>): <code>&quot;tu&quot;</code> if <code>pricing_asset_type</code> is set to TU, else examples: COIN: <code>denom</code> <code>&quot;uvna&quot;</code>, <code>&quot;ufoo&quot;</code>, <code>&quot;ibc/3A0F9C2E4E2A9B7D6F...&quot;</code>, <code>&quot;factory/verana1.../ueurv&quot;</code>, FIAT: <code>&quot;EUR&quot;</code>, <code>&quot;GBP&quot;</code>,…</p>
 </li>
 </ul>
-<div id="note-52" class="notice note"><a class="notice-link" href="#note-52">NOTE</a><p>When pricing_currency is set to FIAT, pricing_asset MUST be an ISO-4217 currency code.
+<div id="note-127" class="notice note"><a class="notice-link" href="#note-127">NOTE</a><p>When pricing_currency is set to FIAT, pricing_asset MUST be an ISO-4217 currency code.
 The number of decimals and minor unit semantics MUST follow the ISO-4217 standard for that currency.
 FIAT amounts MUST be expressed in minor units and MUST NOT be represented as on-chain coins.
 FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on chain.</p>
@@ -2500,7 +2527,7 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 </ul>
 </li>
 </ul>
-<div id="note-53" class="notice note"><a class="notice-link" href="#note-53">NOTE</a><p>If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM <code>Participant</code> so that onboarding processes can be run.</p>
+<div id="note-128" class="notice note"><a class="notice-link" href="#note-128">NOTE</a><p>If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM <code>Participant</code> so that onboarding processes can be run.</p>
 </div>
 <h4 id="mod-cs-msg-2-update-credential-schema"><a class="toc-anchor" href="#mod-cs-msg-2-update-credential-schema" >§</a> [MOD-CS-MSG-2] Update Credential Schema</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
@@ -2926,7 +2953,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li>If the <a class="term-reference" href="#term:applicant">applicant</a> qualifies, the <a class="term-reference" href="#term:validator">validator</a> runs <a href="#mod-pp-msg-3-set-participant-op-to-validated" >[MOD-PP-MSG-3]</a> to update the Participant entry; the <a class="term-reference" href="#term:applicant">applicant</a> is then granted the new <code>Participant</code> entries and/or issued a credential.</li>
 </ol>
 <p>Once in the <code>VALIDATED</code> state, a Participant entry remains valid for a specific period (e.g., 365 days), configured in the <a class="term-reference" href="#term:credential-schema">credential schema</a> for credential-schema-related onboarding, or set by the <a class="term-reference" href="#term:ecosystem">ecosystem</a> for user-agent onboarding.</p>
-<div id="note-54" class="notice note"><a class="notice-link" href="#note-54">NOTE</a><p>Even when the Participant entry remains in the <code>VALIDATED</code> state for the configured period, the resulting <code>Participant</code> entry or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the <a class="term-reference" href="#term:applicant">applicant</a> MUST provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration in order to be issued an updated <code>Participant</code> entry and/or credential.</p>
+<div id="note-129" class="notice note"><a class="notice-link" href="#note-129">NOTE</a><p>Even when the Participant entry remains in the <code>VALIDATED</code> state for the configured period, the resulting <code>Participant</code> entry or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the <a class="term-reference" href="#term:applicant">applicant</a> MUST provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration in order to be issued an updated <code>Participant</code> entry and/or credential.</p>
 </div>
 <p>If the <code>VALIDATED</code> state is set to expire, an <a class="term-reference" href="#term:applicant">applicant</a> that wishes to extend the expiration timestamp MUST renew its <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-2-renew-participant-op" >[MOD-PP-MSG-2]</a>).</p>
 <p>At any time, the <a class="term-reference" href="#term:applicant">applicant</a> CAN cancel the <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-6-cancel-participant-op-last-request" >[MOD-PP-MSG-6]</a>).</p>
@@ -3010,7 +3037,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li><code>did</code>, if specified, MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
 <li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-pp-msg-1-1-start-participant-op-parameters" >MOD-PP-MSG-1-1</a>.</li>
 </ul>
-<div id="note-55" class="notice note"><a class="notice-link" href="#note-55">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the onboarding process is REQUIRED or not.</p>
+<div id="note-130" class="notice note"><a class="notice-link" href="#note-130">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the onboarding process is REQUIRED or not.</p>
 </div>
 <h6 id="mod-pp-msg-1-2-2-start-participant-op-permission-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-2-start-participant-op-permission-checks" >§</a> [MOD-PP-MSG-1-2-2] Start Participant OP permission checks</h6>
 <ul>
@@ -3137,7 +3164,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 </ul>
-<div id="note-56" class="notice note"><a class="notice-link" href="#note-56">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
+<div id="note-131" class="notice note"><a class="notice-link" href="#note-131">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
 <h6 id="mod-pp-msg-1-2-4-start-participant-op-overlap-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-4-start-participant-op-overlap-checks" >§</a> [MOD-PP-MSG-1-2-4] Start Participant OP overlap checks</h6>
 <p>We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a <code>corporation</code> from running different OP with differents validators for the same <code>schema_id</code>, <code>role</code>.</p>
@@ -3312,7 +3339,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 </ul>
-<div id="note-57" class="notice note"><a class="notice-link" href="#note-57">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
+<div id="note-132" class="notice note"><a class="notice-link" href="#note-132">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
 <h6 id="mod-pp-msg-2-3-renew-participant-op-execution"><a class="toc-anchor" href="#mod-pp-msg-2-3-renew-participant-op-execution" >§</a> [MOD-PP-MSG-2-3] Renew Participant OP execution</h6>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
@@ -4002,7 +4029,7 @@ else MUST abort.</p>
 <li>if <code>wallet_agent_participant.role</code> is not ISSUER, abort.</li>
 <li>if <code>wallet_agent_participant</code> is not a <a class="term-reference" href="#term:active-participant">active participant</a>, abort.</li>
 </ul>
-<div id="warning-29" class="notice warning"><a class="notice-link" href="#warning-29">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a <code>Participant</code> entry that is not controlled by its owner.</p>
+<div id="warning-74" class="notice warning"><a class="notice-link" href="#warning-74">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a <code>Participant</code> entry that is not controlled by its owner.</p>
 </div>
 <h6 id="mod-pp-msg-10-3-create-or-update-participant-session-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-10-3-create-or-update-participant-session-fee-checks" >§</a> [MOD-PP-MSG-10-3] Create or Update Participant Session fee checks</h6>
 <ul>
@@ -4178,7 +4205,7 @@ else MUST abort.</p>
 <li><code>corporation</code> MUST have available balance ≥ <code>total_payer_trust_deposit</code> + <code>total_payees_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 <hr>
-<div id="warning-30" class="notice warning"><a class="notice-link" href="#warning-30">WARNING</a><ul>
+<div id="warning-75" class="notice warning"><a class="notice-link" href="#warning-75">WARNING</a><ul>
 <li>Trust deposits MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 <li>When paying with COIN ≠ <a class="term-reference" href="#term:native-denom">native denom</a> or with FIAT, payer pays trust deposits on behalf of payees (since payees receive non-native assets that cannot be directly staked).</li>
 </ul>
@@ -4340,7 +4367,7 @@ else MUST abort.</p>
 </ul>
 <p>then, add the <code>cspsr</code> to <code>session.session_records</code></p>
 <p>if current transaction if for issuance of a credential, persist the digest SRI by calling <a href="#mod-di-msg-1-store-digest" >[MOD-DI-MSG-1]</a>.</p>
-<div id="warning-31" class="notice warning"><a class="notice-link" href="#warning-31">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_participant_id</code> OR <code>verifier_participant_id</code></p>
+<div id="warning-76" class="notice warning"><a class="notice-link" href="#warning-76">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_participant_id</code> OR <code>verifier_participant_id</code></p>
 </div>
 <h4 id="mod-pp-msg-11-update-participant-module-parameters"><a class="toc-anchor" href="#mod-pp-msg-11-update-participant-module-parameters" >§</a> [MOD-PP-MSG-11] Update Participant Module Parameters</h4>
 <p>Update Participant Module Parameters.</p>
@@ -4389,7 +4416,7 @@ else MUST abort.</p>
 <li>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>. If no entry found, abort.</li>
 <li><code>amount</code> MUST be lower or equal to <code>applicant_participant.deposit</code> else MUST abort.</li>
 </ul>
-<div id="note-58" class="notice note"><a class="notice-link" href="#note-58">NOTE</a><p>Even if the <code>Participant</code> entry has expired or is revoked, it is still possible to slash it.</p>
+<div id="note-133" class="notice note"><a class="notice-link" href="#note-133">NOTE</a><p>Even if the <code>Participant</code> entry has expired or is revoked, it is still possible to slash it.</p>
 </div>
 <h6 id="mod-pp-msg-12-2-2-slash-participant-trust-deposit-validator-perms"><a class="toc-anchor" href="#mod-pp-msg-12-2-2-slash-participant-trust-deposit-validator-perms" >§</a> [MOD-PP-MSG-12-2-2] Slash Participant Trust Deposit validator perms</h6>
 <p>Either Option #1, or #2 MUST return true, else abort.</p>
@@ -4482,7 +4509,7 @@ else MUST abort.</p>
 <h4 id="mod-pp-msg-14-self-create-participant"><a class="toc-anchor" href="#mod-pp-msg-14-self-create-participant" >§</a> [MOD-PP-MSG-14] Self Create Participant</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This simple <code>Participant</code>-creation method can be used to self-create an ISSUER (resp. VERIFIER) <code>Participant</code> entry if issuance mode (resp. verification mode) is set to <code>OPEN</code> for a given schema. As <code>Participant</code> entries are the anchor of ecosystem trust deposit operations, it is required for an issuer/verifier candidate to self-create a <code>Participant</code> entry for being issuer or verifier of a given schema.</p>
-<div id="note-59" class="notice note"><a class="notice-link" href="#note-59">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their <code>Participant</code> entry may be revoked by ecosystem governance authority and their deposit slashed.</p>
+<div id="note-134" class="notice note"><a class="notice-link" href="#note-134">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their <code>Participant</code> entry may be revoked by ecosystem governance authority and their deposit slashed.</p>
 </div>
 <h5 id="mod-pp-msg-14-1-self-create-participant-parameters"><a class="toc-anchor" href="#mod-pp-msg-14-1-self-create-participant-parameters" >§</a> [MOD-PP-MSG-14-1] Self Create Participant parameters</h5>
 <ul>
@@ -4792,7 +4819,7 @@ else MUST abort.</p>
 </li>
 </ul>
 <p>return <code>found_perms</code>.</p>
-<div id="note-60" class="notice note"><a class="notice-link" href="#note-60">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
+<div id="note-135" class="notice note"><a class="notice-link" href="#note-135">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
 </div>
 <h4 id="mod-pp-qry-5-get-participantsession"><a class="toc-anchor" href="#mod-pp-qry-5-get-participantsession" >§</a> [MOD-PP-QRY-5] Get ParticipantSession</h4>
 <h5 id="mod-pp-qry-5-1-get-participantsession-parameters"><a class="toc-anchor" href="#mod-pp-qry-5-1-get-participantsession-parameters" >§</a> [MOD-PP-QRY-5-1] Get ParticipantSession parameters</h5>
@@ -5172,14 +5199,14 @@ else MUST abort.</p>
 </ul>
 <h4 id="mod-td-msg-7-burn-ecosystem-slashed-trust-deposit"><a class="toc-anchor" href="#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit" >§</a> [MOD-TD-MSG-7] Burn Ecosystem Slashed Trust Deposit</h4>
 <p>Burn the portion of the trust deposit of a given account. This method can only be called by the permission module when performing an ecosystem-related slash.</p>
-<div id="warning-32" class="notice warning"><a class="notice-link" href="#warning-32">WARNING</a><p>Make sure to <strong>properly protect access to the execution of this method</strong> else it may lead to very destructive actions.</p>
+<div id="warning-77" class="notice warning"><a class="notice-link" href="#warning-77">WARNING</a><p>Make sure to <strong>properly protect access to the execution of this method</strong> else it may lead to very destructive actions.</p>
 </div>
 <h5 id="mod-td-msg-7-1-burn-ecosystem-slashed-trust-deposit-method-parameters"><a class="toc-anchor" href="#mod-td-msg-7-1-burn-ecosystem-slashed-trust-deposit-method-parameters" >§</a> [MOD-TD-MSG-7-1] Burn Ecosystem Slashed Trust Deposit method parameters</h5>
 <ul>
 <li><code>corporation</code> (group) (<em>mandatory</em>): corporation of the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> we want to burn.</li>
 <li><code>amount</code> (number) (<em>mandatory</em>): value to burn, in <a class="term-reference" href="#term:denom">denom</a>.</li>
 </ul>
-<div id="warning-33" class="notice warning"><a class="notice-link" href="#warning-33">WARNING</a><p><strong>Alternative approach</strong>: For security and consistency, implementers MAY choose to reference the <strong>ID of the slashed permission</strong>, load it and use its defined <code>slashed_deposit</code> value as the slashing amount.
+<div id="warning-78" class="notice warning"><a class="notice-link" href="#warning-78">WARNING</a><p><strong>Alternative approach</strong>: For security and consistency, implementers MAY choose to reference the <strong>ID of the slashed permission</strong>, load it and use its defined <code>slashed_deposit</code> value as the slashing amount.
 The decision between this method and specifying the amount directly is left to implementers.</p>
 </div>
 <h5 id="mod-td-msg-7-2-burn-ecosystem-slashed-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-td-msg-7-2-burn-ecosystem-slashed-trust-deposit-precondition-checks" >§</a> [MOD-TD-MSG-7-2] Burn Ecosystem Slashed Trust Deposit precondition checks</h5>
@@ -5351,7 +5378,7 @@ The decision between this method and specifying the amount directly is left to i
 <p>Check if a <strong>VS Operator Authorization</strong> exists for <code>corporation</code> and <code>grantee</code>. If this is the case, MUST abort.</p>
 </li>
 </ul>
-<div id="warning-34" class="notice warning"><a class="notice-link" href="#warning-34">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>participant.corporation</code> and <code>participant.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-79" class="notice warning"><a class="notice-link" href="#warning-79">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>participant.corporation</code> and <code>participant.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-3-3-grant-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-3-3-grant-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-3-3] Grant Operator Authorization fee checks</h5>
 <ul>
@@ -5428,7 +5455,7 @@ The decision between this method and specifying the amount directly is left to i
 <li>No <code>OperatorAuthorization</code> <code>oauthz</code> where <code>oauthz.corporation</code> = <code>corporation</code> and <code>oauthz.operator</code> = <code>vs_operator</code> MUST exist.</li>
 <li>No other <code>VSOperatorAuthorization</code> <code>vsoauthz'</code> where <code>vsoauthz'.vs_operator</code> = <code>vs_operator</code> AND <code>vsoauthz'.corporation</code> != <code>corporation</code> MUST exist. In other words, a vs-agent VPR account cannot be controlled by multiple corporations.</li>
 </ul>
-<div id="warning-35" class="notice warning"><a class="notice-link" href="#warning-35">WARNING</a><p>A <strong>VS Operator Authorization</strong> record CAN be granted ONLY IF no <strong>OperatorAuthorization</strong> exists for the same <code>(corporation, vs_operator)</code> pair. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-80" class="notice warning"><a class="notice-link" href="#warning-80">WARNING</a><p>A <strong>VS Operator Authorization</strong> record CAN be granted ONLY IF no <strong>OperatorAuthorization</strong> exists for the same <code>(corporation, vs_operator)</code> pair. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-5-3-grant-vs-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-5-3-grant-vs-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-5-3] Grant VS Operator Authorization fee checks</h5>
 <ul>
@@ -5971,7 +5998,7 @@ rate_scale       = S</p>
 </ul>
 </li>
 </ul>
-<div id="warning-36" class="notice warning"><a class="notice-link" href="#warning-36">WARNING</a><ul>
+<div id="warning-81" class="notice warning"><a class="notice-link" href="#warning-81">WARNING</a><ul>
 <li>Conversions use base units only.</li>
 <li>Integer arithmetic MUST be used.</li>
 <li><code>quote_amount = floor(base_amount × rate / 10^rate_scale)</code>.</li>
@@ -6081,7 +6108,14 @@ rate_scale       = S</p>
 <li><a href="#ecosystem-management" >Ecosystem Management</a></li>
 <li><a href="#credential-schemas-and-participants" >Credential Schemas and Participants</a></li>
 <li><a href="#corporation-management" >Corporation Management</a></li>
-<li><a href="#did-indexing" >DID Indexing</a></li>
+<li><a href="#did-indexing" >DID Indexing</a>
+<ul>
+<li><a href="#ai-agent-discovery" >AI agent discovery</a></li>
+<li><a href="#verifiable-user-agent-content-discovery" >Verifiable User Agent content discovery</a></li>
+<li><a href="#other-consumers" >Other consumers</a></li>
+<li><a href="#indexing-pipeline" >Indexing pipeline</a></li>
+</ul>
+</li>
 <li><a href="#business-models" >Business models</a>
 <ul>
 <li><a href="#trust-deposit" >Trust Deposit</a></li>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ customElements.define("slide-panels",class extends HTMLElement{static get observ
 <p>This specification defines the data model, API, and normative requirements for implementing and interacting with a Verifiable Public Registry.</p>
 <h2 id="about-this-document"><a class="toc-anchor" href="#about-this-document" >§</a> About this Document</h2>
 <p>In order to fully understand the concepts developed in this document, you should have some basic knowledge of <a class="term-reference" href="#term:did">DID</a>, <a class="term-reference" href="#term:didcomm">DIDComm</a>, <a class="term-reference" href="#term:vs">VS</a>, <a class="term-reference" href="#term:ecosystem">ecosystem</a>, ledger-based applications, and more generally, all terms present in the <a href="#terminology" >Terminology</a> section.</p>
-<div id="note-16" class="notice note"><a class="notice-link" href="#note-16">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
+<div id="note-46" class="notice note"><a class="notice-link" href="#note-46">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
 </div>
 <h2 id="introduction"><a class="toc-anchor" href="#introduction" >§</a> Introduction</h2>
 <h3 id="what-is-an-ecosystem"><a class="toc-anchor" href="#what-is-an-ecosystem" >§</a> What is an Ecosystem?</h3>
@@ -526,7 +526,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <li>A portion defined by <code>trust_deposit_rate</code> is allocated to the <strong>participant’s trust deposit</strong>.</li>
 <li>The remaining portion is <strong>transferred directly to the participant’s wallet</strong>.</li>
 </ul>
-<div id="note-17" class="notice note"><a class="notice-link" href="#note-17">NOTE</a><p>Agents that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
+<div id="note-47" class="notice note"><a class="notice-link" href="#note-47">NOTE</a><p>Agents that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
 If not, they <strong>must reject</strong> the issuance or verification request.</p>
 <p>Note: The <strong>User Agent</strong> and <strong>Wallet User Agent</strong> may refer to the same implementation.</p>
 </div>
@@ -538,7 +538,7 @@ If not, they <strong>must reject</strong> the issuance or verification request.<
 <p><em>This section is non-normative.</em></p>
 <p>A <a class="term-reference" href="#term:governance-framework">governance framework</a> must define the governance rules that apply to a <a class="term-reference" href="#term:vpr">VPR</a>.</p>
 <p>A designated <a class="term-reference" href="#term:governance-authority">governance authority</a> (aka a council) is responsible for <strong>enforcing these rules</strong> and, when necessary, <strong>applying financial sanctions</strong> to participants who violate the rules.</p>
-<div id="note-18" class="notice note"><a class="notice-link" href="#note-18">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
+<div id="note-48" class="notice note"><a class="notice-link" href="#note-48">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
 <p>While the <strong>VPR governance framework</strong> defines the global rules for operating the Verifiable Public Registry (e.g., trust deposits, fee distribution, slashing conditions), each <strong>ecosystem</strong> must define its own <strong>EGF</strong> to govern roles, permissions, credential policies, and compliance within its specific domain.</p>
 <p>This separation ensures that ecosystems remain autonomous and can tailor governance to their unique needs, without being constrained by the global rules of the VPR.</p>
 </div>
@@ -908,10 +908,10 @@ as a direct consequence of executing authorized messages.</li>
   <span class="token punctuation">}</span>
 <span class="token punctuation">]</span>
 </code></pre>
-<div id="warning-10" class="notice warning"><a class="notice-link" href="#warning-10">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
+<div id="warning-28" class="notice warning"><a class="notice-link" href="#warning-28">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
 </div>
 <p>A VPR implementation MUST implement all the following requirements.</p>
-<div id="note-19" class="notice note"><a class="notice-link" href="#note-19">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="ec"path-3="v1"path-4="get"href="https://example/verana/ec/v1/get" ><span>https://example/verana/ec/v1/get</span></a>.</p>
+<div id="note-49" class="notice note"><a class="notice-link" href="#note-49">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="ec"path-3="v1"path-4="get"href="https://example/verana/ec/v1/get" ><span>https://example/verana/ec/v1/get</span></a>.</p>
 </div>
 <h3 id="authorization-and-fee-grants"><a class="toc-anchor" href="#authorization-and-fee-grants" >§</a> Authorization and Fee Grants</h3>
 <h4 id="delegable-module-messages"><a class="toc-anchor" href="#delegable-module-messages" >§</a> Delegable Module Messages</h4>
@@ -1668,7 +1668,7 @@ messages.</p>
 </tr>
 </tbody>
 </table>
-<div id="note-20" class="notice note"><a class="notice-link" href="#note-20">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
+<div id="note-50" class="notice note"><a class="notice-link" href="#note-50">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
 </div>
 <h3 id="corporation-module"><a class="toc-anchor" href="#corporation-module" >§</a> Corporation Module</h3>
 <p>This module manages <a class="term-reference" href="#term:corporation">corporation</a> entries — the VPR-level entity that extends a Cosmos SDK <a class="term-reference" href="#term:group">group</a> with a DID, a governance framework, and lifecycle attributes. A <code>Corporation</code> entry MUST exist before its underlying group can be referenced as the <code>corporation</code> (group) in any other VPR Create-* method (see <a href="#mod-co-msg-1-create-new-corporation" >[MOD-CO-MSG-1]</a>).</p>
@@ -1995,7 +1995,7 @@ messages.</p>
 <p><code>doc_digest_sri</code> (string) (<em>mandatory</em>): MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</p>
 </li>
 </ul>
-<div id="note-21" class="notice note"><a class="notice-link" href="#note-21">NOTE</a><p>It is not a problem if several ecosystems are created with the same ecosystem DID. Identifier of a <code>Ecosystem</code> is its id, and the Verifiable Trust Spec includes the id of the <code>Ecosystem</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
+<div id="note-51" class="notice note"><a class="notice-link" href="#note-51">NOTE</a><p>It is not a problem if several ecosystems are created with the same ecosystem DID. Identifier of a <code>Ecosystem</code> is its id, and the Verifiable Trust Spec includes the id of the <code>Ecosystem</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
 </div>
 <h6 id="mod-es-msg-1-2-2-create-new-ecosystem-fee-checks"><a class="toc-anchor" href="#mod-es-msg-1-2-2-create-new-ecosystem-fee-checks" >§</a> [MOD-ES-MSG-1-2-2] Create New Ecosystem fee checks</h6>
 <p>Fee payer MUST have an available balance to cover the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</p>
@@ -2004,7 +2004,7 @@ messages.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>
-<p>create and persist a new <code>Ecosystem</code> entry <code>tr</code>:</p>
+<p>create and persist a new <code>Ecosystem</code> entry <code>ecosystem</code>:</p>
 </li>
 <li>
 <p><code>ecosystem.id</code> : auto-incremented uint64</p>
@@ -2099,7 +2099,7 @@ messages.</p>
 <p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
 </li>
 <li>
-<p><code>id</code> (uint64) (<em>mandatory</em>): a <code>Ecosystem</code> entry <code>tr</code> with id <code>id</code> MUST exist and <code>corporation</code> executing the method MUST be the <code>corporation</code> of the <code>Ecosystem</code> entry <code>tr</code>.</p>
+<p><code>id</code> (uint64) (<em>mandatory</em>): a <code>Ecosystem</code> entry <code>ecosystem</code> with id <code>id</code> MUST exist and <code>corporation</code> executing the method MUST be the <code>corporation</code> of the <code>Ecosystem</code> entry <code>ecosystem</code>.</p>
 </li>
 <li>
 <p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
@@ -2112,7 +2112,7 @@ messages.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>
-<p>load <code>Ecosystem</code> entry <code>tr</code> from <code>id</code> and set:</p>
+<p>load <code>Ecosystem</code> entry <code>ecosystem</code> from <code>id</code> and set:</p>
 </li>
 <li>
 <p><code>ecosystem.did</code>: <code>did</code></p>
@@ -2147,7 +2147,7 @@ messages.</p>
 <p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
 </li>
 <li>
-<p>load <code>Ecosystem</code> <code>tr</code> from <code>id</code>. <code>ecosystem.corporation</code> MUST be the corporation executing the method, else MUST abort.</p>
+<p>load <code>Ecosystem</code> <code>ecosystem</code> from <code>id</code>. <code>ecosystem.corporation</code> MUST be the corporation executing the method, else MUST abort.</p>
 </li>
 <li>
 <p><code>archive</code> (boolean) (<em>mandatory</em>) MUST be a boolean.</p>
@@ -2163,7 +2163,7 @@ messages.</p>
 <p>If all precondition checks passed, method is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
-<li>update <code>Ecosystem</code> entry <code>tr</code> with <code>ecosystem.id</code> equal to <code>id</code>:</li>
+<li>update <code>Ecosystem</code> entry <code>ecosystem</code> with <code>ecosystem.id</code> equal to <code>id</code>:</li>
 <li>if <code>archived</code> is true: set <code>ecosystem.archived</code> to current timestamp.</li>
 <li>if <code>archived</code> is false: set <code>ecosystem.archived</code> to null.</li>
 <li><code>ecosystem.modified</code>: current timestamp</li>
@@ -2283,6 +2283,7 @@ messages.</p>
 <li><code>gfv.corporation</code>: the signing <code>corporation</code> (or null if subject is an Ecosystem)</li>
 <li><code>gfv.created</code>: current timestamp</li>
 <li><code>gfv.version</code>: <code>version</code></li>
+<li><code>gfv.active_since</code>: null</li>
 </ul>
 </li>
 <li>
@@ -2427,7 +2428,7 @@ messages.</p>
 <p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
 </li>
 <li>
-<p><code>ecosystem_id</code> MUST represent an existing <code>Ecosystem</code> entry <code>tr</code> and <code>ecosystem.corporation</code> MUST be the <code>corporation</code> executing the method.</p>
+<p><code>ecosystem_id</code> MUST represent an existing <code>Ecosystem</code> entry <code>ecosystem</code> and <code>ecosystem.corporation</code> MUST be the <code>corporation</code> executing the method.</p>
 </li>
 <li>
 <p><code>json_schema</code> MUST be a valid <a class="term-reference" href="#term:json-schema">Json Schema</a>, and size must not be greater than <code>GlobalVariables.credential_schema_schema_max_size</code>. <code>$id</code> of the <a class="term-reference" href="#term:json-schema">Json Schema</a> is ignored and will be replaced during execution by the auto-generated id of this <code>CredentialSchema</code>.</p>
@@ -2466,7 +2467,7 @@ messages.</p>
 <p><code>pricing_asset</code> (string) (<em>mandatory</em>): <code>&quot;tu&quot;</code> if <code>pricing_asset_type</code> is set to TU, else examples: COIN: <code>denom</code> <code>&quot;uvna&quot;</code>, <code>&quot;ufoo&quot;</code>, <code>&quot;ibc/3A0F9C2E4E2A9B7D6F...&quot;</code>, <code>&quot;factory/verana1.../ueurv&quot;</code>, FIAT: <code>&quot;EUR&quot;</code>, <code>&quot;GBP&quot;</code>,…</p>
 </li>
 </ul>
-<div id="note-22" class="notice note"><a class="notice-link" href="#note-22">NOTE</a><p>When pricing_currency is set to FIAT, pricing_asset MUST be an ISO-4217 currency code.
+<div id="note-52" class="notice note"><a class="notice-link" href="#note-52">NOTE</a><p>When pricing_currency is set to FIAT, pricing_asset MUST be an ISO-4217 currency code.
 The number of decimals and minor unit semantics MUST follow the ISO-4217 standard for that currency.
 FIAT amounts MUST be expressed in minor units and MUST NOT be represented as on-chain coins.
 FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on chain.</p>
@@ -2499,7 +2500,7 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 </ul>
 </li>
 </ul>
-<div id="note-23" class="notice note"><a class="notice-link" href="#note-23">NOTE</a><p>If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM <code>Participant</code> so that onboarding processes can be run.</p>
+<div id="note-53" class="notice note"><a class="notice-link" href="#note-53">NOTE</a><p>If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM <code>Participant</code> so that onboarding processes can be run.</p>
 </div>
 <h4 id="mod-cs-msg-2-update-credential-schema"><a class="toc-anchor" href="#mod-cs-msg-2-update-credential-schema" >§</a> [MOD-CS-MSG-2] Update Credential Schema</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
@@ -2536,7 +2537,7 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 <p><code>id</code> MUST represent an existing <code>CredentialSchema</code> entry <code>cs</code>.</p>
 </li>
 <li>
-<p>load <code>Ecosystem</code> <code>tr</code> from <code>cs.ecosystem_id</code>. <code>ecosystem.corporation</code> MUST be the <code>corporation</code> executing the method, else MUST abort.</p>
+<p>load <code>Ecosystem</code> <code>ecosystem</code> from <code>cs.ecosystem_id</code>. <code>ecosystem.corporation</code> MUST be the <code>corporation</code> executing the method, else MUST abort.</p>
 </li>
 <li>
 <p><code>issuer_grantor_validation_validity_period</code> MUST be between 0 (never expire) and <code>GlobalVariables.credential_schema_issuer_grantor_validation_validity_period_max_days</code> days.</p>
@@ -2602,7 +2603,7 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 <p><code>id</code> MUST represent an existing <code>CredentialSchema</code> entry <code>cs</code>.</p>
 </li>
 <li>
-<p>load <code>Ecosystem</code> <code>tr</code> from <code>cs.ecosystem_id</code>. <code>ecosystem.corporation</code> MUST be the <code>corporation</code> executing the method, else MUST abort.</p>
+<p>load <code>Ecosystem</code> <code>ecosystem</code> from <code>cs.ecosystem_id</code>. <code>ecosystem.corporation</code> MUST be the <code>corporation</code> executing the method, else MUST abort.</p>
 </li>
 <li>
 <p><code>archive</code> (boolean) (<em>mandatory</em>) MUST be a boolean.</p>
@@ -2925,7 +2926,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li>If the <a class="term-reference" href="#term:applicant">applicant</a> qualifies, the <a class="term-reference" href="#term:validator">validator</a> runs <a href="#mod-pp-msg-3-set-participant-op-to-validated" >[MOD-PP-MSG-3]</a> to update the Participant entry; the <a class="term-reference" href="#term:applicant">applicant</a> is then granted the new <code>Participant</code> entries and/or issued a credential.</li>
 </ol>
 <p>Once in the <code>VALIDATED</code> state, a Participant entry remains valid for a specific period (e.g., 365 days), configured in the <a class="term-reference" href="#term:credential-schema">credential schema</a> for credential-schema-related onboarding, or set by the <a class="term-reference" href="#term:ecosystem">ecosystem</a> for user-agent onboarding.</p>
-<div id="note-24" class="notice note"><a class="notice-link" href="#note-24">NOTE</a><p>Even when the Participant entry remains in the <code>VALIDATED</code> state for the configured period, the resulting <code>Participant</code> entry or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the <a class="term-reference" href="#term:applicant">applicant</a> MUST provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration in order to be issued an updated <code>Participant</code> entry and/or credential.</p>
+<div id="note-54" class="notice note"><a class="notice-link" href="#note-54">NOTE</a><p>Even when the Participant entry remains in the <code>VALIDATED</code> state for the configured period, the resulting <code>Participant</code> entry or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the <a class="term-reference" href="#term:applicant">applicant</a> MUST provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration in order to be issued an updated <code>Participant</code> entry and/or credential.</p>
 </div>
 <p>If the <code>VALIDATED</code> state is set to expire, an <a class="term-reference" href="#term:applicant">applicant</a> that wishes to extend the expiration timestamp MUST renew its <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-2-renew-participant-op" >[MOD-PP-MSG-2]</a>).</p>
 <p>At any time, the <a class="term-reference" href="#term:applicant">applicant</a> CAN cancel the <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-6-cancel-participant-op-last-request" >[MOD-PP-MSG-6]</a>).</p>
@@ -3009,7 +3010,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li><code>did</code>, if specified, MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
 <li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-pp-msg-1-1-start-participant-op-parameters" >MOD-PP-MSG-1-1</a>.</li>
 </ul>
-<div id="note-25" class="notice note"><a class="notice-link" href="#note-25">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the onboarding process is REQUIRED or not.</p>
+<div id="note-55" class="notice note"><a class="notice-link" href="#note-55">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the onboarding process is REQUIRED or not.</p>
 </div>
 <h6 id="mod-pp-msg-1-2-2-start-participant-op-permission-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-2-start-participant-op-permission-checks" >§</a> [MOD-PP-MSG-1-2-2] Start Participant OP permission checks</h6>
 <ul>
@@ -3136,7 +3137,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 </ul>
-<div id="note-26" class="notice note"><a class="notice-link" href="#note-26">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
+<div id="note-56" class="notice note"><a class="notice-link" href="#note-56">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
 <h6 id="mod-pp-msg-1-2-4-start-participant-op-overlap-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-4-start-participant-op-overlap-checks" >§</a> [MOD-PP-MSG-1-2-4] Start Participant OP overlap checks</h6>
 <p>We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a <code>corporation</code> from running different OP with differents validators for the same <code>schema_id</code>, <code>role</code>.</p>
@@ -3311,7 +3312,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 </ul>
-<div id="note-27" class="notice note"><a class="notice-link" href="#note-27">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
+<div id="note-57" class="notice note"><a class="notice-link" href="#note-57">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
 <h6 id="mod-pp-msg-2-3-renew-participant-op-execution"><a class="toc-anchor" href="#mod-pp-msg-2-3-renew-participant-op-execution" >§</a> [MOD-PP-MSG-2-3] Renew Participant OP execution</h6>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
@@ -3692,7 +3693,7 @@ else MUST abort.</p>
 <p>To execute this method, <a class="term-reference" href="#term:account">account</a> MUST match at least one these rules, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li>The related <code>CredentialSchema</code> entry is loaded with <code>schema_id</code>, and will be named <code>cs</code> in this section.</li>
-<li>The related <code>Ecosystem</code> entry <code>tr</code> is loaded from <code>cs.ecosystem_id</code>.</li>
+<li>The related <code>Ecosystem</code> entry <code>ecosystem</code> is loaded from <code>cs.ecosystem_id</code>.</li>
 <li><code>corporation</code> executing the method MUST be <code>ecosystem.corporation</code>.</li>
 <li>else MUST abort.</li>
 </ul>
@@ -3891,7 +3892,7 @@ else MUST abort.</p>
 <p><em>Option #2</em>: executed by <code>Ecosystem</code> controller</p>
 <ul>
 <li>load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_participant.schema_id</code></li>
-<li>load <code>Ecosystem</code> <code>tr</code> from <code>cs.ecosystem_id</code></li>
+<li>load <code>Ecosystem</code> <code>ecosystem</code> from <code>cs.ecosystem_id</code></li>
 <li>if <code>corporation</code> running the method is <code>ecosystem.corporation</code>, return true.</li>
 <li>else return false.</li>
 </ul>
@@ -4001,7 +4002,7 @@ else MUST abort.</p>
 <li>if <code>wallet_agent_participant.role</code> is not ISSUER, abort.</li>
 <li>if <code>wallet_agent_participant</code> is not a <a class="term-reference" href="#term:active-participant">active participant</a>, abort.</li>
 </ul>
-<div id="warning-11" class="notice warning"><a class="notice-link" href="#warning-11">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a <code>Participant</code> entry that is not controlled by its owner.</p>
+<div id="warning-29" class="notice warning"><a class="notice-link" href="#warning-29">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a <code>Participant</code> entry that is not controlled by its owner.</p>
 </div>
 <h6 id="mod-pp-msg-10-3-create-or-update-participant-session-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-10-3-create-or-update-participant-session-fee-checks" >§</a> [MOD-PP-MSG-10-3] Create or Update Participant Session fee checks</h6>
 <ul>
@@ -4177,7 +4178,7 @@ else MUST abort.</p>
 <li><code>corporation</code> MUST have available balance ≥ <code>total_payer_trust_deposit</code> + <code>total_payees_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 <hr>
-<div id="warning-12" class="notice warning"><a class="notice-link" href="#warning-12">WARNING</a><ul>
+<div id="warning-30" class="notice warning"><a class="notice-link" href="#warning-30">WARNING</a><ul>
 <li>Trust deposits MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 <li>When paying with COIN ≠ <a class="term-reference" href="#term:native-denom">native denom</a> or with FIAT, payer pays trust deposits on behalf of payees (since payees receive non-native assets that cannot be directly staked).</li>
 </ul>
@@ -4339,7 +4340,7 @@ else MUST abort.</p>
 </ul>
 <p>then, add the <code>cspsr</code> to <code>session.session_records</code></p>
 <p>if current transaction if for issuance of a credential, persist the digest SRI by calling <a href="#mod-di-msg-1-store-digest" >[MOD-DI-MSG-1]</a>.</p>
-<div id="warning-13" class="notice warning"><a class="notice-link" href="#warning-13">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_participant_id</code> OR <code>verifier_participant_id</code></p>
+<div id="warning-31" class="notice warning"><a class="notice-link" href="#warning-31">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_participant_id</code> OR <code>verifier_participant_id</code></p>
 </div>
 <h4 id="mod-pp-msg-11-update-participant-module-parameters"><a class="toc-anchor" href="#mod-pp-msg-11-update-participant-module-parameters" >§</a> [MOD-PP-MSG-11] Update Participant Module Parameters</h4>
 <p>Update Participant Module Parameters.</p>
@@ -4388,7 +4389,7 @@ else MUST abort.</p>
 <li>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>. If no entry found, abort.</li>
 <li><code>amount</code> MUST be lower or equal to <code>applicant_participant.deposit</code> else MUST abort.</li>
 </ul>
-<div id="note-28" class="notice note"><a class="notice-link" href="#note-28">NOTE</a><p>Even if the <code>Participant</code> entry has expired or is revoked, it is still possible to slash it.</p>
+<div id="note-58" class="notice note"><a class="notice-link" href="#note-58">NOTE</a><p>Even if the <code>Participant</code> entry has expired or is revoked, it is still possible to slash it.</p>
 </div>
 <h6 id="mod-pp-msg-12-2-2-slash-participant-trust-deposit-validator-perms"><a class="toc-anchor" href="#mod-pp-msg-12-2-2-slash-participant-trust-deposit-validator-perms" >§</a> [MOD-PP-MSG-12-2-2] Slash Participant Trust Deposit validator perms</h6>
 <p>Either Option #1, or #2 MUST return true, else abort.</p>
@@ -4408,7 +4409,7 @@ else MUST abort.</p>
 <p><em>Option #2</em>: executed by <code>Ecosystem</code> controller</p>
 <ul>
 <li>load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_participant.schema_id</code></li>
-<li>load <code>Ecosystem</code> <code>tr</code> from <code>cs.ecosystem_id</code></li>
+<li>load <code>Ecosystem</code> <code>ecosystem</code> from <code>cs.ecosystem_id</code></li>
 <li>if <code>corporation</code> running the method is <code>ecosystem.corporation</code>, return true.</li>
 <li>else return false.</li>
 </ul>
@@ -4481,7 +4482,7 @@ else MUST abort.</p>
 <h4 id="mod-pp-msg-14-self-create-participant"><a class="toc-anchor" href="#mod-pp-msg-14-self-create-participant" >§</a> [MOD-PP-MSG-14] Self Create Participant</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This simple <code>Participant</code>-creation method can be used to self-create an ISSUER (resp. VERIFIER) <code>Participant</code> entry if issuance mode (resp. verification mode) is set to <code>OPEN</code> for a given schema. As <code>Participant</code> entries are the anchor of ecosystem trust deposit operations, it is required for an issuer/verifier candidate to self-create a <code>Participant</code> entry for being issuer or verifier of a given schema.</p>
-<div id="note-29" class="notice note"><a class="notice-link" href="#note-29">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their <code>Participant</code> entry may be revoked by ecosystem governance authority and their deposit slashed.</p>
+<div id="note-59" class="notice note"><a class="notice-link" href="#note-59">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their <code>Participant</code> entry may be revoked by ecosystem governance authority and their deposit slashed.</p>
 </div>
 <h5 id="mod-pp-msg-14-1-self-create-participant-parameters"><a class="toc-anchor" href="#mod-pp-msg-14-1-self-create-participant-parameters" >§</a> [MOD-PP-MSG-14-1] Self Create Participant parameters</h5>
 <ul>
@@ -4791,7 +4792,7 @@ else MUST abort.</p>
 </li>
 </ul>
 <p>return <code>found_perms</code>.</p>
-<div id="note-30" class="notice note"><a class="notice-link" href="#note-30">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
+<div id="note-60" class="notice note"><a class="notice-link" href="#note-60">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
 </div>
 <h4 id="mod-pp-qry-5-get-participantsession"><a class="toc-anchor" href="#mod-pp-qry-5-get-participantsession" >§</a> [MOD-PP-QRY-5] Get ParticipantSession</h4>
 <h5 id="mod-pp-qry-5-1-get-participantsession-parameters"><a class="toc-anchor" href="#mod-pp-qry-5-1-get-participantsession-parameters" >§</a> [MOD-PP-QRY-5-1] Get ParticipantSession parameters</h5>
@@ -5171,14 +5172,14 @@ else MUST abort.</p>
 </ul>
 <h4 id="mod-td-msg-7-burn-ecosystem-slashed-trust-deposit"><a class="toc-anchor" href="#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit" >§</a> [MOD-TD-MSG-7] Burn Ecosystem Slashed Trust Deposit</h4>
 <p>Burn the portion of the trust deposit of a given account. This method can only be called by the permission module when performing an ecosystem-related slash.</p>
-<div id="warning-14" class="notice warning"><a class="notice-link" href="#warning-14">WARNING</a><p>Make sure to <strong>properly protect access to the execution of this method</strong> else it may lead to very destructive actions.</p>
+<div id="warning-32" class="notice warning"><a class="notice-link" href="#warning-32">WARNING</a><p>Make sure to <strong>properly protect access to the execution of this method</strong> else it may lead to very destructive actions.</p>
 </div>
 <h5 id="mod-td-msg-7-1-burn-ecosystem-slashed-trust-deposit-method-parameters"><a class="toc-anchor" href="#mod-td-msg-7-1-burn-ecosystem-slashed-trust-deposit-method-parameters" >§</a> [MOD-TD-MSG-7-1] Burn Ecosystem Slashed Trust Deposit method parameters</h5>
 <ul>
 <li><code>corporation</code> (group) (<em>mandatory</em>): corporation of the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> we want to burn.</li>
 <li><code>amount</code> (number) (<em>mandatory</em>): value to burn, in <a class="term-reference" href="#term:denom">denom</a>.</li>
 </ul>
-<div id="warning-15" class="notice warning"><a class="notice-link" href="#warning-15">WARNING</a><p><strong>Alternative approach</strong>: For security and consistency, implementers MAY choose to reference the <strong>ID of the slashed permission</strong>, load it and use its defined <code>slashed_deposit</code> value as the slashing amount.
+<div id="warning-33" class="notice warning"><a class="notice-link" href="#warning-33">WARNING</a><p><strong>Alternative approach</strong>: For security and consistency, implementers MAY choose to reference the <strong>ID of the slashed permission</strong>, load it and use its defined <code>slashed_deposit</code> value as the slashing amount.
 The decision between this method and specifying the amount directly is left to implementers.</p>
 </div>
 <h5 id="mod-td-msg-7-2-burn-ecosystem-slashed-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-td-msg-7-2-burn-ecosystem-slashed-trust-deposit-precondition-checks" >§</a> [MOD-TD-MSG-7-2] Burn Ecosystem Slashed Trust Deposit precondition checks</h5>
@@ -5350,7 +5351,7 @@ The decision between this method and specifying the amount directly is left to i
 <p>Check if a <strong>VS Operator Authorization</strong> exists for <code>corporation</code> and <code>grantee</code>. If this is the case, MUST abort.</p>
 </li>
 </ul>
-<div id="warning-16" class="notice warning"><a class="notice-link" href="#warning-16">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>participant.corporation</code> and <code>participant.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-34" class="notice warning"><a class="notice-link" href="#warning-34">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>participant.corporation</code> and <code>participant.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-3-3-grant-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-3-3-grant-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-3-3] Grant Operator Authorization fee checks</h5>
 <ul>
@@ -5427,7 +5428,7 @@ The decision between this method and specifying the amount directly is left to i
 <li>No <code>OperatorAuthorization</code> <code>oauthz</code> where <code>oauthz.corporation</code> = <code>corporation</code> and <code>oauthz.operator</code> = <code>vs_operator</code> MUST exist.</li>
 <li>No other <code>VSOperatorAuthorization</code> <code>vsoauthz'</code> where <code>vsoauthz'.vs_operator</code> = <code>vs_operator</code> AND <code>vsoauthz'.corporation</code> != <code>corporation</code> MUST exist. In other words, a vs-agent VPR account cannot be controlled by multiple corporations.</li>
 </ul>
-<div id="warning-17" class="notice warning"><a class="notice-link" href="#warning-17">WARNING</a><p>A <strong>VS Operator Authorization</strong> record CAN be granted ONLY IF no <strong>OperatorAuthorization</strong> exists for the same <code>(corporation, vs_operator)</code> pair. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-35" class="notice warning"><a class="notice-link" href="#warning-35">WARNING</a><p>A <strong>VS Operator Authorization</strong> record CAN be granted ONLY IF no <strong>OperatorAuthorization</strong> exists for the same <code>(corporation, vs_operator)</code> pair. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-5-3-grant-vs-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-5-3-grant-vs-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-5-3] Grant VS Operator Authorization fee checks</h5>
 <ul>
@@ -5970,7 +5971,7 @@ rate_scale       = S</p>
 </ul>
 </li>
 </ul>
-<div id="warning-18" class="notice warning"><a class="notice-link" href="#warning-18">WARNING</a><ul>
+<div id="warning-36" class="notice warning"><a class="notice-link" href="#warning-36">WARNING</a><ul>
 <li>Conversions use base units only.</li>
 <li>Integer arithmetic MUST be used.</li>
 <li><code>quote_amount = floor(base_amount × rate / 10^rate_scale)</code>.</li>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ customElements.define("slide-panels",class extends HTMLElement{static get observ
 <p>This specification defines the data model, API, and normative requirements for implementing and interacting with a Verifiable Public Registry.</p>
 <h2 id="about-this-document"><a class="toc-anchor" href="#about-this-document" >§</a> About this Document</h2>
 <p>In order to fully understand the concepts developed in this document, you should have some basic knowledge of <a class="term-reference" href="#term:did">DID</a>, <a class="term-reference" href="#term:didcomm">DIDComm</a>, <a class="term-reference" href="#term:vs">VS</a>, <a class="term-reference" href="#term:ecosystem">ecosystem</a>, ledger-based applications, and more generally, all terms present in the <a href="#terminology" >Terminology</a> section.</p>
-<div id="note-76" class="notice note"><a class="notice-link" href="#note-76">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
+<div id="note-1" class="notice note"><a class="notice-link" href="#note-1">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
 </div>
 <h2 id="introduction"><a class="toc-anchor" href="#introduction" >§</a> Introduction</h2>
 <h3 id="what-is-an-ecosystem"><a class="toc-anchor" href="#what-is-an-ecosystem" >§</a> What is an Ecosystem?</h3>
@@ -526,7 +526,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <li>A portion defined by <code>trust_deposit_rate</code> is allocated to the <strong>participant’s trust deposit</strong>.</li>
 <li>The remaining portion is <strong>transferred directly to the participant’s wallet</strong>.</li>
 </ul>
-<div id="note-77" class="notice note"><a class="notice-link" href="#note-77">NOTE</a><p>Agents that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
+<div id="note-2" class="notice note"><a class="notice-link" href="#note-2">NOTE</a><p>Agents that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
 If not, they <strong>must reject</strong> the issuance or verification request.</p>
 <p>Note: The <strong>User Agent</strong> and <strong>Wallet User Agent</strong> may refer to the same implementation.</p>
 </div>
@@ -538,7 +538,7 @@ If not, they <strong>must reject</strong> the issuance or verification request.<
 <p><em>This section is non-normative.</em></p>
 <p>A <a class="term-reference" href="#term:governance-framework">governance framework</a> must define the governance rules that apply to a <a class="term-reference" href="#term:vpr">VPR</a>.</p>
 <p>A designated <a class="term-reference" href="#term:governance-authority">governance authority</a> (aka a council) is responsible for <strong>enforcing these rules</strong> and, when necessary, <strong>applying financial sanctions</strong> to participants who violate the rules.</p>
-<div id="note-78" class="notice note"><a class="notice-link" href="#note-78">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
+<div id="note-3" class="notice note"><a class="notice-link" href="#note-3">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
 <p>While the <strong>VPR governance framework</strong> defines the global rules for operating the Verifiable Public Registry (e.g., trust deposits, fee distribution, slashing conditions), each <strong>ecosystem</strong> must define its own <strong>EGF</strong> to govern roles, permissions, credential policies, and compliance within its specific domain.</p>
 <p>This separation ensures that ecosystems remain autonomous and can tailor governance to their unique needs, without being constrained by the global rules of the VPR.</p>
 </div>
@@ -546,7 +546,7 @@ If not, they <strong>must reject</strong> the issuance or verification request.<
 <p>For simplicity, the data model is presented using an <strong>object-relational structure</strong>. However, this representation may not be optimal for all implementation scenarios.</p>
 <p>Implementors are responsible for <strong>adapting the data model</strong> to suit their chosen architecture.<br>
 For example, a <strong>key-value store</strong> may be more appropriate for a <strong>ledger-based implementation</strong> than a relational model.</p>
-<img src="https://www.plantuml.com/plantuml/svg/pLdTRzis47_NNo7ugUtG8js6OV1JlTX9ZRLnOBi1Xc4GQ96ssKgYHbBEnx3_VSUZFYY9Sknb3tk9fRlZVP1tlpig7vGcKXTf4doedrHC4XQcv27y-U8YlETKxuE0PPhhnt0qYuLwL9gbev2eKClmho0Ctt0w3WkUwPz-XBVlg7bLMl9iPrvZoOXcGD8yPM0bpGqr5PHlUOzCPBpdXpuvra2D3amgBh9n2BOCEI7PhY0xLflxk_7qKiXSIA917dsDuHsz_P_uTor0EYDPpAuaITczaD_kx79qTxSz-FRMxwnhb-sOVCRELCH52lpI43tTK2yWe1KoSLyftu5yf2HteswEHJ9gdacoYlSi9VPirEakd7SmNvN88eMMN2UvKWMJqKwIJ0iP7KZ2AQQAVGHFevn9Ba1TLgGRs56xoyRokSjAMsVQE4ryBn9wid3fYCWsWaWAEn71Ni9Hpf6-gCcVWThofRVYhkJqrvGEzLPyH7fVFfSyDb94AQOzQKIIdP1SxzDs2HLfEBBvCodq7YIUCFfRaV3uSIaIXccbI6u1QhvQVPajuU5kjfnVpU7HJSb1HPMI5nGYq2IuCqPVJgiMiuGTn3UZV2DWCSaCZMstpABCLegqRRVX5H1JuZ9je6Q_VCUC4NAHOeIBszaD_5ml9pVhnJ9QtFooc2odyvlhw7Qvk9ojLi2SNIvMlwtMiyy-Tdqq_ln0OuV_t9WljT3KlZHbJzzludQs_0py-UBcKwcqJejNg-clhyD978kYX4fYdq6fYwzI5Bb5KlFKPYwW2Wb0HIkvK5WG83sXVu1fQXVfnvofSLWz_lu7SjX3pcqJQvyuL4vPtxImVDVitMhOy47LffqLjz3yeH9p0BRMaYM3labnOKviCOLlyaOuQbN5iKZkeOgZBMC8dcvc_ziWfomJwIIjJuSIT8yQibDC12Lg7ApJvjOYpyG0pnhSj35Q8gAHyHqrhh_0dyl5tEJhrNooTfsOFSHxw8bi2M206Xwy8z66ADR7k3yBeJra29LrtoESogpA7xv78Ccf1u1mAytkjs6fQWhLFZex2coGCnQh8t72ksBisfmNXhRTsVbfw8m7p_7eCRexsC_M1-dMoM2Yf3oB3EHAYBGLcvbZ8yeEt7R7JQxgFNHhtKd_SY3nWVwB1aVwjL1zQPKGjUzH9Si9fqCOVnR-LwTluuVwKzsHm8o6FORj_R5_5MMvK5oxf3AEoCEomNWuTPThUIlo28wvJmG3q2TDfaOsOVeYPQ0mcNdS07vSI0adtel7OVaNgY9DYOJomMxT7IIh3GIsYbjWuzd8lb3JePiUjj8Lda1C63Ic8_HCqx_C83FvD9zErhEfmIVJmsxmnO_eAwRgUmLajZji5voUbyf7BJZTmjZnGg77b0lgkCCMp_7HgkXl_90QXFR6iNeM17_qm2nOJmZbCEBm758zZC3pnyMdQMU8l4x4XYHtH7AoIPYo0u6zmXbVopjFUHMfVWmuAVx4t8Jf2vzyMK5zb3ogu_hEkCUSgF7PAywvdhrOqxCNenFrQ0cexKE55YDIUoAPCL6mOI7iwqDCuyuZPmazBhP9HFmjakmUSC9QTKGB1I73xHnmh9JewBedIS9qT5pEgSQriJsrfkq77_kjm1fk0lLX-xR8A7FldyCjOh13MCptjKZa-DeaIaSzXBMp-Tkt0gQOSLWcVb0Dz2qwOm5CEgFt8o2_3KSNxzu1SbBp-I1d6OqIdd8z824XPNXcxhCe6mJL-290xa6sNalRur2KexgHHavt28N9h1uVSTeQ5dGcIYjfHD79z-XaRTHEZz7zdckMSAM385O3EbjNTDGQkljfRnDZ_BvMVczhxMl5Ry9irbPtaU7LZSH1HRMA-WvJdu4D3oucvX1C4rA1kQ-OY03vns7xocAYpIicx0PkLKE2eovnZTPKSyfW39KrSqP7RRc76hnWrOVIqboj1DnKn7XaFZ5mfj0NvKPXMoSuOPjgL0KKM4RFdH9zUxvuXMk8FKsyH0mB5gSjySe6tGDhYiOCHMvf3KkU9jKjmbCaQny2J9jdR0-8T0CP4ElwzwoOuvp9He-iKnij3quGxpeT1BhdpcvxmCGnsQZ2Lsvglmxmk_hn1KvnunBpRRjJkRkjkHwMtwLLXH6Dq0WHmiKEKsGkQZGSpC91bchpMcXZAyG16bkRBRXkiUlfl5vjRWk6udfAEoO_m7RZ_rpixpy0" alt="uml diagram">
+<img src="https://www.plantuml.com/plantuml/svg/pLdTRzis47_NNo7ugUdGejs6OV1JlTX9ZRLnOBi1Xc4GQ96ssKYYHbBEnx3_VSUZFYY9Sknr3tk9fRlZVP1tlpig7vGcKXTf4doedrHC4XQcv37y-Tsxy85JlGy2bcckdyBHB1RgIMcMZaAYGYt3lu8mVCtfE2nufd_w4Tw-e-PLQScpdNcD9IEQ0Kdpb86LD3VKL52-vJqoaV6U7_haM0CrEZ2fkCZ68TWov8HakuBiM6tkxyRJIo5p8Oa6UVGrXdVqzd_YtxK0wOnaCRkI96KFGjxVsUNexcvxyEsjtrdNBjin-OATgOYB5FYb8NgweLv0G2jauhvIlWFvI4dkHjqSYsJKF9Da5UzPIkpPgDDTEEzWlYgHHGejkKvofGecevqacHOoEf24KqmL-mYUHZcJN82wh4WtiADsbutbSvULjiwqSPhuNYJqPE7I4P5j194KTYA2lOIZd2DzKPC_0xNbIs_5NSdfhoaTwgtuYFI-V2vvRAI8KanxqeWaEo6vtgVj4YhIS6JpPrBeFKWyO_It8k7nqr8a3DDAaTm2r7or-Z9RmiFTR3c_ciEZcvA3YYebtr28G9FWpXXzEQrQp19s4FT6-KR0Of8P6jjkcKMPhHHfssx3Ao2cn6NQGCr--OuP8-GYnGWNjxCR-BbUJcxMYsMqkFbbCLbEvpVNqUroSJbRhO0vkroiVbkjPvzzxFfe_Fc1nWx_kJ5VQg6fVMdAdhxVnEri-HduyyNDfr9fdHQlLjDVBy9978kYX4fYdq6fYwzI5Bb5KlFKPYwW2Wb0HIkvK5WG83sZVu1fQXVffvofSLWz_lu7SjXZpcqJQvyuL4vPtxImVDVitMhOy47LffqLjz3yeH9p0BRMaYM3labnOKviCOMlyqOuQbN5iKWUe8gZBMC8dcvc_ziWfomJwIIjJuSIT8yQibDC12Lg7ApJvjOYpyG0pnhSj35Q8gAHyHqrhh_0dyl5tEJhrNooTfsOFSPxw8bi2M206Xwz8z66ADR7k3yBeJra29LrtoESogpA7xv78Ccf1u1mAytkjs6fQWhLFZex2coGCnQh8t72ksBisfmNXhRTsVbfw8m7p_7eCRexsC_MH-dMoM2Yf3oB3EHAYBGLcvbZ8yeEt7R7JQxgFNHhtKd_SY3nWVut3OxqQw7wqYeXQj-ZIfOJJeSm_YpyhqxVnW_rfxeZWHaDUmpR-sF_AifoeRXsIMKSaOTbW_5mwYxNybRa4HnpdmW6e4-QJ8rimlH5oa1XClEu0Voua19El1UFm_8lL4MQ4WdbWzswEqXM6mXi5RV0nhEHVQ6cGpSzRAKhF86OC6XCH-YPfd-PGMRoQJwTh6TJWq-cXztWYn_HLqpLzmh8R7VOBZWzBvMFMd2wXR7ZXKAFAHVKSOSjdkEZLT7V-24r2EsDO_Ki2FxeWLcmdX3AOSJXEQHw687dZujFqyuGUPs83KdkYEHaap1b1m9xXJE-bdUUyYfI_HXmKloPkGdJ5pxvieBwA7bIn_MTSOyvKUEBLvnpFVjcJIzUZ4xKeoMWjWyLMen8xObanaJ1XeMmhmynZJjFd2NqkDWc4V5z9Da3u8IrweWM2aA6spdWM2dHqVL0aeJfwBYSKurhOtjgJTiFFlPRWJNS1Eh3zcsHKURUFuTRn627i9ZlQv78yRL9b8vw26jdypTl14mnux1C_A0Qw5jqnWAOT4RlHq1-4uxUlNqBo4dDvuESPJHAUChrW8I4bE6PkS-YR11Kuui0kKVPUYrjZqDHZkf66ZdT8HGcitfyn6bhMD2PAAsa4KKdtwEJjL4xFKOFUwvPmfKEWbWDw6nTqL5hwEwdlKsCyVjQ-RsjjQyLlmcpMLlTHOPNDn875TKgwZjCVGOsFBYOc4CmJKW5vhvY8WBa7uVjAuk9Dg-Oi1kuLGq9Zhh4DLfJpIc3CLJMp1aTjUKUQl22LHzAItEr4d1J4UEH-SJ0cK9Vb1k5RPtWX6sgKHLGO1azTqhqxVdY5QuXzZJn4Z4iM9osn2iRT0-iAHep5BcbDInvcbIt24-Hh7q8C6rUi3qWqWraGAphtujYZdCc6psoJcsqF3X1lEjq4EYUExlj0HF7PACANxcfVH7WT_NZ2vpYlWZCX-rEsUwsvcvOVfHM5K0qGYE41nSuJ8MvaD5mC0K7MQhDQq6DBGy7PMnXjh2wnQv7ytgrkIeOYkifxPZy07kD_t2nl_y0" alt="uml diagram">
 <h3 id="corporation"><a class="toc-anchor" href="#corporation" >§</a> Corporation</h3>
 <p>A <code>Corporation</code> is the VPR-level entity that extends a Cosmos SDK <a class="term-reference" href="#term:group">group</a> with a DID, a governance framework, and lifecycle attributes. A Corporation may control <a class="term-reference" href="#term:participants">participants</a> in zero or more <a class="term-reference" href="#term:ecosystems">ecosystems</a> and may itself be the controller of zero or more <a class="term-reference" href="#term:ecosystems">ecosystems</a>.</p>
 <p><code>Corporation</code>:</p>
@@ -574,17 +574,17 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 <li><code>active_version</code> (int): (<em>mandatory</em>) active governance framework version.</li>
 </ul>
 <h3 id="governanceframeworkversion"><a class="toc-anchor" href="#governanceframeworkversion" >§</a> GovernanceFrameworkVersion</h3>
-<p>A <code>GovernanceFrameworkVersion</code> represents a single version of either an <a class="term-reference" href="#term:egf">EGF</a> or a <a class="term-reference" href="#term:cgf">CGF</a>. Its owning subject is identified by exactly one of <code>ecosystem_id</code> or <code>corporation_id</code> (XOR).</p>
+<p>A <code>GovernanceFrameworkVersion</code> represents a single version of either an <a class="term-reference" href="#term:egf">EGF</a> or a <a class="term-reference" href="#term:cgf">CGF</a>. Its owning subject is identified by exactly one of <code>ecosystem_id</code> or <code>corporation</code> (XOR).</p>
 <p><code>GovernanceFrameworkVersion</code>:</p>
 <ul>
 <li><code>id</code> (uint64) (<em>mandatory</em>): the id of the GFV.</li>
-<li><code>ecosystem_id</code> (uint64) (<em>conditional</em>): the id of the <a class="term-reference" href="#term:ecosystem">ecosystem</a> that controls this <code>GovernanceFrameworkVersion</code> entry. MUST be set if <code>corporation_id</code> is null.</li>
-<li><code>corporation_id</code> (uint64) (<em>conditional</em>): the id of the <a class="term-reference" href="#term:corporation">corporation</a> that controls this <code>GovernanceFrameworkVersion</code> entry. MUST be set if <code>ecosystem_id</code> is null.</li>
+<li><code>ecosystem_id</code> (uint64) (<em>conditional</em>): the id of the <a class="term-reference" href="#term:ecosystem">ecosystem</a> that controls this <code>GovernanceFrameworkVersion</code> entry. MUST be set if <code>corporation</code> is null.</li>
+<li><code>corporation</code> (group) (<em>conditional</em>): the <a class="term-reference" href="#term:corporation">corporation</a> that controls this <code>GovernanceFrameworkVersion</code> entry (i.e., the underlying Cosmos SDK <a class="term-reference" href="#term:group">group</a> of the owning <code>Corporation</code>). MUST be set if <code>ecosystem_id</code> is null.</li>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this GovernanceFrameworkVersion has been created.</li>
 <li><code>version</code> (int) (<em>mandatory</em>): version of this GF. MUST Starts with 1.</li>
 </ul>
 <blockquote>
-<p>Constraint: exactly one of <code>ecosystem_id</code> and <code>corporation_id</code> MUST be set.</p>
+<p>Constraint: exactly one of <code>ecosystem_id</code> and <code>corporation</code> MUST be set.</p>
 </blockquote>
 <h3 id="governanceframeworkdocument"><a class="toc-anchor" href="#governanceframeworkdocument" >§</a> GovernanceFrameworkDocument</h3>
 <p><code>GovernanceFrameworkDocument</code></p>
@@ -908,10 +908,10 @@ as a direct consequence of executing authorized messages.</li>
   <span class="token punctuation">}</span>
 <span class="token punctuation">]</span>
 </code></pre>
-<div id="warning-46" class="notice warning"><a class="notice-link" href="#warning-46">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
+<div id="warning-1" class="notice warning"><a class="notice-link" href="#warning-1">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
 </div>
 <p>A VPR implementation MUST implement all the following requirements.</p>
-<div id="note-79" class="notice note"><a class="notice-link" href="#note-79">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="ec"path-3="v1"path-4="get"href="https://example/verana/ec/v1/get" ><span>https://example/verana/ec/v1/get</span></a>.</p>
+<div id="note-4" class="notice note"><a class="notice-link" href="#note-4">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="ec"path-3="v1"path-4="get"href="https://example/verana/ec/v1/get" ><span>https://example/verana/ec/v1/get</span></a>.</p>
 </div>
 <h3 id="authorization-and-fee-grants"><a class="toc-anchor" href="#authorization-and-fee-grants" >§</a> Authorization and Fee Grants</h3>
 <h4 id="delegable-module-messages"><a class="toc-anchor" href="#delegable-module-messages" >§</a> Delegable Module Messages</h4>
@@ -1668,7 +1668,7 @@ messages.</p>
 </tr>
 </tbody>
 </table>
-<div id="note-80" class="notice note"><a class="notice-link" href="#note-80">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
+<div id="note-5" class="notice note"><a class="notice-link" href="#note-5">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
 </div>
 <h3 id="corporation-module"><a class="toc-anchor" href="#corporation-module" >§</a> Corporation Module</h3>
 <p>This module manages <a class="term-reference" href="#term:corporation">corporation</a> entries — the VPR-level entity that extends a Cosmos SDK <a class="term-reference" href="#term:group">group</a> with a DID, a governance framework, and lifecycle attributes. A <code>Corporation</code> entry MUST exist before its underlying group can be referenced as the <code>corporation</code> (group) in any other VPR Create-* method (see <a href="#mod-co-msg-1-create-new-corporation" >[MOD-CO-MSG-1]</a>).</p>
@@ -1754,7 +1754,7 @@ messages.</p>
 <p><code>gfv.ecosystem_id</code>: null</p>
 </li>
 <li>
-<p><code>gfv.corporation_id</code>: id of the signing <a class="term-reference" href="#term:group">group</a> (i.e., the key of <code>co</code>)</p>
+<p><code>gfv.corporation</code>: the signing <code>corporation</code> (i.e., the underlying <a class="term-reference" href="#term:group">group</a> of <code>co</code>)</p>
 </li>
 <li>
 <p><code>gfv.created</code>: current timestamp</p>
@@ -1797,8 +1797,10 @@ messages.</p>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>did</code> (string) (<em>mandatory</em>): the new DID of the Corporation.</li>
-<li><code>language</code> (string) (<em>mandatory</em>): primary language tag of this Corporation.</li>
 </ul>
+<blockquote>
+<p>Note: <code>language</code> is set at creation time by <a href="#mod-co-msg-1-create-new-corporation" >[MOD-CO-MSG-1]</a> and is <strong>immutable</strong> thereafter; it cannot be updated through this method.</p>
+</blockquote>
 <h5 id="mod-co-msg-2-2-update-corporation-precondition-checks"><a class="toc-anchor" href="#mod-co-msg-2-2-update-corporation-precondition-checks" >§</a> [MOD-CO-MSG-2-2] Update Corporation precondition checks</h5>
 <p>If any of these precondition checks fail, method MUST abort.</p>
 <h6 id="mod-co-msg-2-2-1-update-corporation-basic-checks"><a class="toc-anchor" href="#mod-co-msg-2-2-1-update-corporation-basic-checks" >§</a> [MOD-CO-MSG-2-2-1] Update Corporation basic checks</h6>
@@ -1821,9 +1823,6 @@ messages.</p>
 <li>
 <p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
 </li>
-<li>
-<p><code>language</code> (string(17)) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>).</p>
-</li>
 </ul>
 <h6 id="mod-co-msg-2-2-2-update-corporation-fee-checks"><a class="toc-anchor" href="#mod-co-msg-2-2-2-update-corporation-fee-checks" >§</a> [MOD-CO-MSG-2-2-2] Update Corporation fee checks</h6>
 <p>Fee payer MUST have available balance in its <a class="term-reference" href="#term:account">account</a> to cover the required <a class="term-reference" href="#term:transaction-fees">transaction fees</a>.</p>
@@ -1836,9 +1835,6 @@ messages.</p>
 </li>
 <li>
 <p><code>co.did</code>: <code>did</code></p>
-</li>
-<li>
-<p><code>co.language</code>: <code>language</code></p>
 </li>
 <li>
 <p><code>co.modified</code>: current timestamp</p>
@@ -1999,7 +1995,7 @@ messages.</p>
 <p><code>doc_digest_sri</code> (string) (<em>mandatory</em>): MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</p>
 </li>
 </ul>
-<div id="note-81" class="notice note"><a class="notice-link" href="#note-81">NOTE</a><p>It is not a problem if several ecosystems are created with the same ecosystem DID. Identifier of a <code>Ecosystem</code> is its id, and the Verifiable Trust Spec includes the id of the <code>Ecosystem</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
+<div id="note-6" class="notice note"><a class="notice-link" href="#note-6">NOTE</a><p>It is not a problem if several ecosystems are created with the same ecosystem DID. Identifier of a <code>Ecosystem</code> is its id, and the Verifiable Trust Spec includes the id of the <code>Ecosystem</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
 </div>
 <h6 id="mod-es-msg-1-2-2-create-new-ecosystem-fee-checks"><a class="toc-anchor" href="#mod-es-msg-1-2-2-create-new-ecosystem-fee-checks" >§</a> [MOD-ES-MSG-1-2-2] Create New Ecosystem fee checks</h6>
 <p>Fee payer MUST have an available balance to cover the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</p>
@@ -2041,7 +2037,7 @@ messages.</p>
 <p><code>gfv.ecosystem_id</code>: <code>ecosystem.id</code></p>
 </li>
 <li>
-<p><code>gfv.corporation_id</code>: null</p>
+<p><code>gfv.corporation</code>: null</p>
 </li>
 <li>
 <p><code>gfv.created</code>: current timestamp</p>
@@ -2239,7 +2235,7 @@ messages.</p>
 <span class="token punctuation">}</span>
 </code></pre>
 <h3 id="governance-framework-module"><a class="toc-anchor" href="#governance-framework-module" >§</a> Governance Framework Module</h3>
-<p>This module handles <a class="term-reference" href="#term:governance-framework">governance framework</a> documents and version activation for both <a class="term-reference" href="#term:ecosystems">ecosystems</a> and <a class="term-reference" href="#term:corporations">corporations</a>. Methods are polymorphic over the owning subject: every message specifies exactly one of <code>ecosystem_id</code> or <code>corporation_id</code> to designate whose governance framework is being modified.</p>
+<p>This module handles <a class="term-reference" href="#term:governance-framework">governance framework</a> documents and version activation for both <a class="term-reference" href="#term:ecosystems">ecosystems</a> and <a class="term-reference" href="#term:corporations">corporations</a>. Methods are polymorphic over the owning subject: every message takes an optional <code>ecosystem_id</code> parameter to designate whose governance framework is being modified — if set, the target subject is that <code>Ecosystem</code> (and the signing <code>corporation</code> MUST be its controller); if not set, the target subject is the signing <code>corporation</code>’s own <a class="term-reference" href="#term:cgf">CGF</a> (a Corporation may only edit its own CGF, so no extra parameter is needed).</p>
 <p>The initial <code>GovernanceFrameworkVersion</code> and its first <code>GovernanceFrameworkDocument</code> are created atomically by <a href="#mod-es-msg-1-create-new-ecosystem" >Create New Ecosystem</a> (and, by parallel construction, by <a href="#mod-co-msg-1-create-new-corporation" >Create New Corporation</a>). After that, subsequent versions and documents are added through this module.</p>
 <h4 id="mod-gf-msg-1-add-governance-framework-document"><a class="toc-anchor" href="#mod-gf-msg-1-add-governance-framework-document" >§</a> [MOD-GF-MSG-1] Add Governance Framework Document</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
@@ -2247,8 +2243,7 @@ messages.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>ecosystem_id</code> (uint64) (<em>conditional</em>): id of the target <a class="term-reference" href="#term:ecosystem">ecosystem</a> whose governance framework will be modified. MUST be set if <code>corporation_id</code> is null.</li>
-<li><code>corporation_id</code> (uint64) (<em>conditional</em>): id of the target <a class="term-reference" href="#term:corporation">corporation</a> whose governance framework will be modified. MUST be set if <code>ecosystem_id</code> is null.</li>
+<li><code>ecosystem_id</code> (uint64) (<em>optional</em>): id of the target <a class="term-reference" href="#term:ecosystem">ecosystem</a> whose governance framework will be modified. If set, the signing <code>corporation</code> MUST be the controller of the target <code>Ecosystem</code>. If not set, the target subject is the signing <code>corporation</code>’s own <a class="term-reference" href="#term:cgf">CGF</a>.</li>
 <li><code>doc_language</code> (string) (<em>mandatory</em>): language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of the governance framework document.</li>
 <li><code>doc_url</code> (string) (<em>mandatory</em>): URL where the document is published.</li>
 <li><code>doc_digest_sri</code> (string) (<em>mandatory</em>): digest_sri of the document.</li>
@@ -2263,14 +2258,13 @@ messages.</p>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
 <li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
-<li>Exactly one of <code>ecosystem_id</code> and <code>corporation_id</code> MUST be set; if both are set or both are null, method MUST abort.</li>
 <li>Define <code>subject</code> as:
 <ul>
-<li>if <code>ecosystem_id</code> is set: the <code>Ecosystem</code> entry with this id. The entry MUST exist and <code>subject.corporation</code> MUST be equal to the <code>corporation</code> executing the method.</li>
-<li>if <code>corporation_id</code> is set: the <code>Corporation</code> entry keyed by <code>corporation_id</code> (i.e., the Corporation whose underlying <a class="term-reference" href="#term:group">group</a> has id <code>corporation_id</code>). The entry MUST exist, and <code>corporation_id</code> MUST equal the <a class="term-reference" href="#term:group">group</a> id of the signing <code>corporation</code> (a Corporation may only edit its own governance framework).</li>
+<li>if <code>ecosystem_id</code> is set: the <code>Ecosystem</code> entry with this id. The entry MUST exist and <code>subject.corporation</code> MUST be equal to the signing <code>corporation</code>.</li>
+<li>if <code>ecosystem_id</code> is not set: the <code>Corporation</code> entry whose underlying <a class="term-reference" href="#term:group">group</a> is the signing <code>corporation</code>. The entry MUST exist (a Corporation may only edit its own governance framework, so no further check is required).</li>
 </ul>
 </li>
-<li><code>version</code>: there MUST exist a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> whose owner matches <code>subject</code> (i.e., <code>gfv.ecosystem_id = ecosystem_id</code> if subject is an Ecosystem, else <code>gfv.corporation_id = corporation_id</code>) and <code>gfv.version = version</code>, OR <code>version</code> MUST be exactly equal to the biggest <code>gfv.version</code> + 1 of all <code>GovernanceFrameworkVersion</code> entries owned by <code>subject</code>. <code>version</code> MUST be greater than <code>subject.active_version</code>.</li>
+<li><code>version</code>: there MUST exist a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> whose owner matches <code>subject</code> (i.e., <code>gfv.ecosystem_id = ecosystem_id</code> if subject is an Ecosystem, else <code>gfv.corporation = corporation</code>) and <code>gfv.version = version</code>, OR <code>version</code> MUST be exactly equal to the biggest <code>gfv.version</code> + 1 of all <code>GovernanceFrameworkVersion</code> entries owned by <code>subject</code>. <code>version</code> MUST be greater than <code>subject.active_version</code>.</li>
 <li><code>doc_language</code> (string) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>).</li>
 <li><code>doc_url</code> (string) (<em>mandatory</em>): MUST be a valid URL.</li>
 <li><code>doc_digest_sri</code> (string) (<em>mandatory</em>): MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</li>
@@ -2286,7 +2280,7 @@ messages.</p>
 <ul>
 <li><code>gfv.id</code>: auto-incremented uint64</li>
 <li><code>gfv.ecosystem_id</code>: <code>ecosystem_id</code> (or null if subject is a Corporation)</li>
-<li><code>gfv.corporation_id</code>: <code>corporation_id</code> (or null if subject is an Ecosystem)</li>
+<li><code>gfv.corporation</code>: the signing <code>corporation</code> (or null if subject is an Ecosystem)</li>
 <li><code>gfv.created</code>: current timestamp</li>
 <li><code>gfv.version</code>: <code>version</code></li>
 </ul>
@@ -2316,8 +2310,7 @@ messages.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>ecosystem_id</code> (uint64) (<em>conditional</em>): id of the target <a class="term-reference" href="#term:ecosystem">ecosystem</a>. MUST be set if <code>corporation_id</code> is null.</li>
-<li><code>corporation_id</code> (uint64) (<em>conditional</em>): id of the target <a class="term-reference" href="#term:corporation">corporation</a>. MUST be set if <code>ecosystem_id</code> is null.</li>
+<li><code>ecosystem_id</code> (uint64) (<em>optional</em>): id of the target <a class="term-reference" href="#term:ecosystem">ecosystem</a>. If set, the signing <code>corporation</code> MUST be its controller. If not set, the target subject is the signing <code>corporation</code>’s own <a class="term-reference" href="#term:cgf">CGF</a>.</li>
 </ul>
 <h5 id="mod-gf-msg-2-2-increase-active-governance-framework-version-precondition-checks"><a class="toc-anchor" href="#mod-gf-msg-2-2-increase-active-governance-framework-version-precondition-checks" >§</a> [MOD-GF-MSG-2-2] Increase Active Governance Framework Version precondition checks</h5>
 <p>If any of these precondition checks fail, method MUST abort.</p>
@@ -2336,17 +2329,14 @@ messages.</p>
 <p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
 </li>
 <li>
-<p>Exactly one of <code>ecosystem_id</code> and <code>corporation_id</code> MUST be set; if both are set or both are null, method MUST abort.</p>
-</li>
-<li>
 <p>Define <code>subject</code> as:</p>
 <ul>
-<li>if <code>ecosystem_id</code> is set: the <code>Ecosystem</code> entry with this id. The entry MUST exist and <code>subject.corporation</code> MUST be equal to the <code>corporation</code> executing the method.</li>
-<li>if <code>corporation_id</code> is set: the <code>Corporation</code> entry keyed by <code>corporation_id</code> (i.e., the Corporation whose underlying <a class="term-reference" href="#term:group">group</a> has id <code>corporation_id</code>). The entry MUST exist, and <code>corporation_id</code> MUST equal the <a class="term-reference" href="#term:group">group</a> id of the signing <code>corporation</code>.</li>
+<li>if <code>ecosystem_id</code> is set: the <code>Ecosystem</code> entry with this id. The entry MUST exist and <code>subject.corporation</code> MUST be equal to the signing <code>corporation</code>.</li>
+<li>if <code>ecosystem_id</code> is not set: the <code>Corporation</code> entry whose underlying <a class="term-reference" href="#term:group">group</a> is the signing <code>corporation</code>. The entry MUST exist.</li>
 </ul>
 </li>
 <li>
-<p>Find a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> owned by <code>subject</code> (matching <code>gfv.ecosystem_id</code> or <code>gfv.corporation_id</code> as appropriate) whose <code>gfv.version</code> is equal to <code>subject.active_version</code> + 1. If none is found, transaction MUST abort.</p>
+<p>Find a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> owned by <code>subject</code> (matching <code>gfv.ecosystem_id</code> or <code>gfv.corporation</code> as appropriate) whose <code>gfv.version</code> is equal to <code>subject.active_version</code> + 1. If none is found, transaction MUST abort.</p>
 </li>
 <li>
 <p>Find a <code>GovernanceFrameworkDocument</code> <code>gfd</code> for <code>gfd.gfv_id</code> = <code>gfv.id</code> and <code>gfd.language</code> = <code>subject.language</code>. If no document is found (and thus no document exists for the default language of this version for this subject), transaction MUST abort.</p>
@@ -2378,14 +2368,14 @@ messages.</p>
 <li><code>id</code> (uint64) (<em>mandatory</em>): MUST be a valid uint64.</li>
 </ul>
 <h5 id="mod-gf-qry-1-3-get-governance-framework-version-execution"><a class="toc-anchor" href="#mod-gf-qry-1-3-get-governance-framework-version-execution" >§</a> [MOD-GF-QRY-1-3] Get Governance Framework Version execution</h5>
-<p>Return the <code>GovernanceFrameworkVersion</code> entry with <code>id</code>, including its owning subject reference (<code>ecosystem_id</code> or <code>corporation_id</code>) and its nested <code>GovernanceFrameworkDocument</code> entries (filtered by <code>preferred_language</code> if set).</p>
+<p>Return the <code>GovernanceFrameworkVersion</code> entry with <code>id</code>, including its owning subject reference (<code>ecosystem_id</code> or <code>corporation</code>) and its nested <code>GovernanceFrameworkDocument</code> entries (filtered by <code>preferred_language</code> if set).</p>
 <h4 id="mod-gf-qry-2-list-governance-framework-versions"><a class="toc-anchor" href="#mod-gf-qry-2-list-governance-framework-versions" >§</a> [MOD-GF-QRY-2] List Governance Framework Versions</h4>
 <p>Anyone CAN execute this method.</p>
 <h5 id="mod-gf-qry-2-1-list-governance-framework-versions-query-parameters"><a class="toc-anchor" href="#mod-gf-qry-2-1-list-governance-framework-versions-query-parameters" >§</a> [MOD-GF-QRY-2-1] List Governance Framework Versions query parameters</h5>
-<p>Exactly one of <code>ecosystem_id</code> and <code>corporation_id</code> MUST be set:</p>
+<p>Exactly one of <code>ecosystem_id</code> and <code>corporation</code> MUST be set:</p>
 <ul>
-<li><code>ecosystem_id</code> (uint64) (<em>conditional</em>): filter by ecosystem. MUST be set if <code>corporation_id</code> is null.</li>
-<li><code>corporation_id</code> (uint64) (<em>conditional</em>): filter by corporation. MUST be set if <code>ecosystem_id</code> is null.</li>
+<li><code>ecosystem_id</code> (uint64) (<em>conditional</em>): filter by ecosystem. MUST be set if <code>corporation</code> is null.</li>
+<li><code>corporation</code> (group) (<em>conditional</em>): filter by corporation (the underlying Cosmos SDK <a class="term-reference" href="#term:group">group</a> of the target <code>Corporation</code>). MUST be set if <code>ecosystem_id</code> is null.</li>
 <li><code>active_only</code> (boolean) (<em>optional</em>): if true, return only the entry corresponding to the subject’s <code>active_version</code>.</li>
 <li><code>preferred_language</code> (string) (<em>optional</em>): if set, return only one document per version, preferring <code>preferred_language</code>.</li>
 <li><code>response_max_size</code> (small number) (<em>optional</em>): default to 64. Max 1,024.</li>
@@ -2393,7 +2383,7 @@ messages.</p>
 <h5 id="mod-gf-qry-2-2-list-governance-framework-versions-query-checks"><a class="toc-anchor" href="#mod-gf-qry-2-2-list-governance-framework-versions-query-checks" >§</a> [MOD-GF-QRY-2-2] List Governance Framework Versions query checks</h5>
 <p>If any of these checks fail, <a class="term-reference" href="#term:query">query</a> MUST fail.</p>
 <ul>
-<li>Exactly one of <code>ecosystem_id</code> and <code>corporation_id</code> MUST be set.</li>
+<li>Exactly one of <code>ecosystem_id</code> and <code>corporation</code> MUST be set.</li>
 <li><code>response_max_size</code> must be between 1 and 1,024. Default to 64 if unspecified.</li>
 </ul>
 <h5 id="mod-gf-qry-2-3-list-governance-framework-versions-execution"><a class="toc-anchor" href="#mod-gf-qry-2-3-list-governance-framework-versions-execution" >§</a> [MOD-GF-QRY-2-3] List Governance Framework Versions execution</h5>
@@ -2476,7 +2466,7 @@ messages.</p>
 <p><code>pricing_asset</code> (string) (<em>mandatory</em>): <code>&quot;tu&quot;</code> if <code>pricing_asset_type</code> is set to TU, else examples: COIN: <code>denom</code> <code>&quot;uvna&quot;</code>, <code>&quot;ufoo&quot;</code>, <code>&quot;ibc/3A0F9C2E4E2A9B7D6F...&quot;</code>, <code>&quot;factory/verana1.../ueurv&quot;</code>, FIAT: <code>&quot;EUR&quot;</code>, <code>&quot;GBP&quot;</code>,…</p>
 </li>
 </ul>
-<div id="note-82" class="notice note"><a class="notice-link" href="#note-82">NOTE</a><p>When pricing_currency is set to FIAT, pricing_asset MUST be an ISO-4217 currency code.
+<div id="note-7" class="notice note"><a class="notice-link" href="#note-7">NOTE</a><p>When pricing_currency is set to FIAT, pricing_asset MUST be an ISO-4217 currency code.
 The number of decimals and minor unit semantics MUST follow the ISO-4217 standard for that currency.
 FIAT amounts MUST be expressed in minor units and MUST NOT be represented as on-chain coins.
 FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on chain.</p>
@@ -2509,7 +2499,7 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 </ul>
 </li>
 </ul>
-<div id="note-83" class="notice note"><a class="notice-link" href="#note-83">NOTE</a><p>If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM <code>Participant</code> so that onboarding processes can be run.</p>
+<div id="note-8" class="notice note"><a class="notice-link" href="#note-8">NOTE</a><p>If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM <code>Participant</code> so that onboarding processes can be run.</p>
 </div>
 <h4 id="mod-cs-msg-2-update-credential-schema"><a class="toc-anchor" href="#mod-cs-msg-2-update-credential-schema" >§</a> [MOD-CS-MSG-2] Update Credential Schema</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
@@ -2912,7 +2902,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <h4 id="participant-module-overview"><a class="toc-anchor" href="#participant-module-overview" >§</a> Participant Module Overview</h4>
 <p><em>This section is non-normative.</em></p>
 <p>Participants are linked to a Credential Schema and representable as a tree.</p>
-<img src="https://www.plantuml.com/plantuml/svg/XPDHRu8m483V-oikusLxC24naOM7HKLKacqku4osbwNG4xk1aBOwbyN_lahLRH7nNk3eyNrNUdIbeaAjyenqZtSoeHb2JZTmQzlmoPbQ420bJJveYd3bRsXUwW9F8CEbuZI3A5bWJk590tZ2IxfKC1M8Lq0b91A-2G4THVoEYTA0f91VKc4ElQf22R3QyvZ57Lq9-n15XYxutYHwYQR-0ro7HQ5kZikCCnTD8wuIlUhvzfyba7A50aP2TrC8w5SgdfueWYXwziEtKTXxd4x2MW5F--S5dW6Rn78wZeCCpbZgwLuDV8Q2p_cV_WULPdtQ_ymFWs5mOGVhTD0ayGtya5gs7Tjp-wogNk7N6CP5nZJm5Ih1mcJMSDYtdVO9VZov7-pXMx8bElHaj5ftkrDp8H585KgGPjRAtraZUhqgCsVGM7f0hYyWrmPv_2JDqBrvzuRPOtDv5vUi-kNCzGS0" alt="uml diagram">
+<img src="https://www.plantuml.com/plantuml/svg/XP9TQy8m58RlyoiEzcQx40g27LuCRQrQsEPedR3TZBGvrcojbIHsZk5_NqnKDgpRWP2SdCFxlFdeIqM5sfG5wPzMCgC5GactSEEwyC6PMX8WQvgzqnoX5MvfkTODWK26AyLf0Kcsn9B2enRW6L_JbOAPG6m1bP19-284T5Jf6sPA2sIL_9GAInYO3YN0wInIbdPr9nn2L0Ns80ocoNCo2-_XAgugTNqgCyvwQ8tqb1YO_TqlIYJb1WMCXNPJ2V0DYkTdY2X9diBuTHmF7cRJk170S_yo8B32Dd6yhkSXWmkKPlMWGNoEWY_u3_z3WwdF_S_3E1f5_voWpeT_GK8hVamTrqtTXNiHrOm86mYJgc1Qy0KCO6apPpJoNQzp9Z-PtWqFuZko8phqpsYtR_UlHlGmItFFfqgTazeMZkO9EJp5VjC22UdZYfa_RkTl" alt="uml diagram">
 <p><code>ECOSYSTEM</code> Participants are created directly by the <a class="term-reference" href="#term:credential-schema">credential schema</a> owner. All other Participants are created by running an <a class="term-reference" href="#term:onboarding-process">onboarding process</a> — except when onboarding mode is set to <code>OPEN</code> for ISSUER and/or VERIFIER Participants, which any account CAN create directly:</p>
 <ul>
 <li><code>ISSUER</code> Participants when <code>issuer_onboarding_mode</code> is <code>OPEN</code>;</li>
@@ -2935,7 +2925,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li>If the <a class="term-reference" href="#term:applicant">applicant</a> qualifies, the <a class="term-reference" href="#term:validator">validator</a> runs <a href="#mod-pp-msg-3-set-participant-op-to-validated" >[MOD-PP-MSG-3]</a> to update the Participant entry; the <a class="term-reference" href="#term:applicant">applicant</a> is then granted the new <code>Participant</code> entries and/or issued a credential.</li>
 </ol>
 <p>Once in the <code>VALIDATED</code> state, a Participant entry remains valid for a specific period (e.g., 365 days), configured in the <a class="term-reference" href="#term:credential-schema">credential schema</a> for credential-schema-related onboarding, or set by the <a class="term-reference" href="#term:ecosystem">ecosystem</a> for user-agent onboarding.</p>
-<div id="note-84" class="notice note"><a class="notice-link" href="#note-84">NOTE</a><p>Even when the Participant entry remains in the <code>VALIDATED</code> state for the configured period, the resulting <code>Participant</code> entry or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the <a class="term-reference" href="#term:applicant">applicant</a> MUST provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration in order to be issued an updated <code>Participant</code> entry and/or credential.</p>
+<div id="note-9" class="notice note"><a class="notice-link" href="#note-9">NOTE</a><p>Even when the Participant entry remains in the <code>VALIDATED</code> state for the configured period, the resulting <code>Participant</code> entry or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the <a class="term-reference" href="#term:applicant">applicant</a> MUST provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration in order to be issued an updated <code>Participant</code> entry and/or credential.</p>
 </div>
 <p>If the <code>VALIDATED</code> state is set to expire, an <a class="term-reference" href="#term:applicant">applicant</a> that wishes to extend the expiration timestamp MUST renew its <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-2-renew-participant-op" >[MOD-PP-MSG-2]</a>).</p>
 <p>At any time, the <a class="term-reference" href="#term:applicant">applicant</a> CAN cancel the <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-6-cancel-participant-op-last-request" >[MOD-PP-MSG-6]</a>).</p>
@@ -3019,7 +3009,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li><code>did</code>, if specified, MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
 <li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-pp-msg-1-1-start-participant-op-parameters" >MOD-PP-MSG-1-1</a>.</li>
 </ul>
-<div id="note-85" class="notice note"><a class="notice-link" href="#note-85">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the onboarding process is REQUIRED or not.</p>
+<div id="note-10" class="notice note"><a class="notice-link" href="#note-10">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the onboarding process is REQUIRED or not.</p>
 </div>
 <h6 id="mod-pp-msg-1-2-2-start-participant-op-permission-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-2-start-participant-op-permission-checks" >§</a> [MOD-PP-MSG-1-2-2] Start Participant OP permission checks</h6>
 <ul>
@@ -3146,7 +3136,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 </ul>
-<div id="note-86" class="notice note"><a class="notice-link" href="#note-86">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
+<div id="note-11" class="notice note"><a class="notice-link" href="#note-11">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
 <h6 id="mod-pp-msg-1-2-4-start-participant-op-overlap-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-4-start-participant-op-overlap-checks" >§</a> [MOD-PP-MSG-1-2-4] Start Participant OP overlap checks</h6>
 <p>We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a <code>corporation</code> from running different OP with differents validators for the same <code>schema_id</code>, <code>role</code>.</p>
@@ -3321,7 +3311,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 </ul>
-<div id="note-87" class="notice note"><a class="notice-link" href="#note-87">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
+<div id="note-12" class="notice note"><a class="notice-link" href="#note-12">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
 <h6 id="mod-pp-msg-2-3-renew-participant-op-execution"><a class="toc-anchor" href="#mod-pp-msg-2-3-renew-participant-op-execution" >§</a> [MOD-PP-MSG-2-3] Renew Participant OP execution</h6>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
@@ -4011,7 +4001,7 @@ else MUST abort.</p>
 <li>if <code>wallet_agent_participant.role</code> is not ISSUER, abort.</li>
 <li>if <code>wallet_agent_participant</code> is not a <a class="term-reference" href="#term:active-participant">active participant</a>, abort.</li>
 </ul>
-<div id="warning-47" class="notice warning"><a class="notice-link" href="#warning-47">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a <code>Participant</code> entry that is not controlled by its owner.</p>
+<div id="warning-2" class="notice warning"><a class="notice-link" href="#warning-2">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a <code>Participant</code> entry that is not controlled by its owner.</p>
 </div>
 <h6 id="mod-pp-msg-10-3-create-or-update-participant-session-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-10-3-create-or-update-participant-session-fee-checks" >§</a> [MOD-PP-MSG-10-3] Create or Update Participant Session fee checks</h6>
 <ul>
@@ -4187,7 +4177,7 @@ else MUST abort.</p>
 <li><code>corporation</code> MUST have available balance ≥ <code>total_payer_trust_deposit</code> + <code>total_payees_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 <hr>
-<div id="warning-48" class="notice warning"><a class="notice-link" href="#warning-48">WARNING</a><ul>
+<div id="warning-3" class="notice warning"><a class="notice-link" href="#warning-3">WARNING</a><ul>
 <li>Trust deposits MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 <li>When paying with COIN ≠ <a class="term-reference" href="#term:native-denom">native denom</a> or with FIAT, payer pays trust deposits on behalf of payees (since payees receive non-native assets that cannot be directly staked).</li>
 </ul>
@@ -4349,7 +4339,7 @@ else MUST abort.</p>
 </ul>
 <p>then, add the <code>cspsr</code> to <code>session.session_records</code></p>
 <p>if current transaction if for issuance of a credential, persist the digest SRI by calling <a href="#mod-di-msg-1-store-digest" >[MOD-DI-MSG-1]</a>.</p>
-<div id="warning-49" class="notice warning"><a class="notice-link" href="#warning-49">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_participant_id</code> OR <code>verifier_participant_id</code></p>
+<div id="warning-4" class="notice warning"><a class="notice-link" href="#warning-4">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_participant_id</code> OR <code>verifier_participant_id</code></p>
 </div>
 <h4 id="mod-pp-msg-11-update-participant-module-parameters"><a class="toc-anchor" href="#mod-pp-msg-11-update-participant-module-parameters" >§</a> [MOD-PP-MSG-11] Update Participant Module Parameters</h4>
 <p>Update Participant Module Parameters.</p>
@@ -4398,7 +4388,7 @@ else MUST abort.</p>
 <li>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>. If no entry found, abort.</li>
 <li><code>amount</code> MUST be lower or equal to <code>applicant_participant.deposit</code> else MUST abort.</li>
 </ul>
-<div id="note-88" class="notice note"><a class="notice-link" href="#note-88">NOTE</a><p>Even if the <code>Participant</code> entry has expired or is revoked, it is still possible to slash it.</p>
+<div id="note-13" class="notice note"><a class="notice-link" href="#note-13">NOTE</a><p>Even if the <code>Participant</code> entry has expired or is revoked, it is still possible to slash it.</p>
 </div>
 <h6 id="mod-pp-msg-12-2-2-slash-participant-trust-deposit-validator-perms"><a class="toc-anchor" href="#mod-pp-msg-12-2-2-slash-participant-trust-deposit-validator-perms" >§</a> [MOD-PP-MSG-12-2-2] Slash Participant Trust Deposit validator perms</h6>
 <p>Either Option #1, or #2 MUST return true, else abort.</p>
@@ -4491,7 +4481,7 @@ else MUST abort.</p>
 <h4 id="mod-pp-msg-14-self-create-participant"><a class="toc-anchor" href="#mod-pp-msg-14-self-create-participant" >§</a> [MOD-PP-MSG-14] Self Create Participant</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This simple <code>Participant</code>-creation method can be used to self-create an ISSUER (resp. VERIFIER) <code>Participant</code> entry if issuance mode (resp. verification mode) is set to <code>OPEN</code> for a given schema. As <code>Participant</code> entries are the anchor of ecosystem trust deposit operations, it is required for an issuer/verifier candidate to self-create a <code>Participant</code> entry for being issuer or verifier of a given schema.</p>
-<div id="note-89" class="notice note"><a class="notice-link" href="#note-89">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their <code>Participant</code> entry may be revoked by ecosystem governance authority and their deposit slashed.</p>
+<div id="note-14" class="notice note"><a class="notice-link" href="#note-14">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their <code>Participant</code> entry may be revoked by ecosystem governance authority and their deposit slashed.</p>
 </div>
 <h5 id="mod-pp-msg-14-1-self-create-participant-parameters"><a class="toc-anchor" href="#mod-pp-msg-14-1-self-create-participant-parameters" >§</a> [MOD-PP-MSG-14-1] Self Create Participant parameters</h5>
 <ul>
@@ -4801,7 +4791,7 @@ else MUST abort.</p>
 </li>
 </ul>
 <p>return <code>found_perms</code>.</p>
-<div id="note-90" class="notice note"><a class="notice-link" href="#note-90">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
+<div id="note-15" class="notice note"><a class="notice-link" href="#note-15">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
 </div>
 <h4 id="mod-pp-qry-5-get-participantsession"><a class="toc-anchor" href="#mod-pp-qry-5-get-participantsession" >§</a> [MOD-PP-QRY-5] Get ParticipantSession</h4>
 <h5 id="mod-pp-qry-5-1-get-participantsession-parameters"><a class="toc-anchor" href="#mod-pp-qry-5-1-get-participantsession-parameters" >§</a> [MOD-PP-QRY-5-1] Get ParticipantSession parameters</h5>
@@ -5181,14 +5171,14 @@ else MUST abort.</p>
 </ul>
 <h4 id="mod-td-msg-7-burn-ecosystem-slashed-trust-deposit"><a class="toc-anchor" href="#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit" >§</a> [MOD-TD-MSG-7] Burn Ecosystem Slashed Trust Deposit</h4>
 <p>Burn the portion of the trust deposit of a given account. This method can only be called by the permission module when performing an ecosystem-related slash.</p>
-<div id="warning-50" class="notice warning"><a class="notice-link" href="#warning-50">WARNING</a><p>Make sure to <strong>properly protect access to the execution of this method</strong> else it may lead to very destructive actions.</p>
+<div id="warning-5" class="notice warning"><a class="notice-link" href="#warning-5">WARNING</a><p>Make sure to <strong>properly protect access to the execution of this method</strong> else it may lead to very destructive actions.</p>
 </div>
 <h5 id="mod-td-msg-7-1-burn-ecosystem-slashed-trust-deposit-method-parameters"><a class="toc-anchor" href="#mod-td-msg-7-1-burn-ecosystem-slashed-trust-deposit-method-parameters" >§</a> [MOD-TD-MSG-7-1] Burn Ecosystem Slashed Trust Deposit method parameters</h5>
 <ul>
 <li><code>corporation</code> (group) (<em>mandatory</em>): corporation of the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> we want to burn.</li>
 <li><code>amount</code> (number) (<em>mandatory</em>): value to burn, in <a class="term-reference" href="#term:denom">denom</a>.</li>
 </ul>
-<div id="warning-51" class="notice warning"><a class="notice-link" href="#warning-51">WARNING</a><p><strong>Alternative approach</strong>: For security and consistency, implementers MAY choose to reference the <strong>ID of the slashed permission</strong>, load it and use its defined <code>slashed_deposit</code> value as the slashing amount.
+<div id="warning-6" class="notice warning"><a class="notice-link" href="#warning-6">WARNING</a><p><strong>Alternative approach</strong>: For security and consistency, implementers MAY choose to reference the <strong>ID of the slashed permission</strong>, load it and use its defined <code>slashed_deposit</code> value as the slashing amount.
 The decision between this method and specifying the amount directly is left to implementers.</p>
 </div>
 <h5 id="mod-td-msg-7-2-burn-ecosystem-slashed-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-td-msg-7-2-burn-ecosystem-slashed-trust-deposit-precondition-checks" >§</a> [MOD-TD-MSG-7-2] Burn Ecosystem Slashed Trust Deposit precondition checks</h5>
@@ -5360,7 +5350,7 @@ The decision between this method and specifying the amount directly is left to i
 <p>Check if a <strong>VS Operator Authorization</strong> exists for <code>corporation</code> and <code>grantee</code>. If this is the case, MUST abort.</p>
 </li>
 </ul>
-<div id="warning-52" class="notice warning"><a class="notice-link" href="#warning-52">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>participant.corporation</code> and <code>participant.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-7" class="notice warning"><a class="notice-link" href="#warning-7">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>participant.corporation</code> and <code>participant.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-3-3-grant-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-3-3-grant-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-3-3] Grant Operator Authorization fee checks</h5>
 <ul>
@@ -5437,7 +5427,7 @@ The decision between this method and specifying the amount directly is left to i
 <li>No <code>OperatorAuthorization</code> <code>oauthz</code> where <code>oauthz.corporation</code> = <code>corporation</code> and <code>oauthz.operator</code> = <code>vs_operator</code> MUST exist.</li>
 <li>No other <code>VSOperatorAuthorization</code> <code>vsoauthz'</code> where <code>vsoauthz'.vs_operator</code> = <code>vs_operator</code> AND <code>vsoauthz'.corporation</code> != <code>corporation</code> MUST exist. In other words, a vs-agent VPR account cannot be controlled by multiple corporations.</li>
 </ul>
-<div id="warning-53" class="notice warning"><a class="notice-link" href="#warning-53">WARNING</a><p>A <strong>VS Operator Authorization</strong> record CAN be granted ONLY IF no <strong>OperatorAuthorization</strong> exists for the same <code>(corporation, vs_operator)</code> pair. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-8" class="notice warning"><a class="notice-link" href="#warning-8">WARNING</a><p>A <strong>VS Operator Authorization</strong> record CAN be granted ONLY IF no <strong>OperatorAuthorization</strong> exists for the same <code>(corporation, vs_operator)</code> pair. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-5-3-grant-vs-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-5-3-grant-vs-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-5-3] Grant VS Operator Authorization fee checks</h5>
 <ul>
@@ -5980,7 +5970,7 @@ rate_scale       = S</p>
 </ul>
 </li>
 </ul>
-<div id="warning-54" class="notice warning"><a class="notice-link" href="#warning-54">WARNING</a><ul>
+<div id="warning-9" class="notice warning"><a class="notice-link" href="#warning-9">WARNING</a><ul>
 <li>Conversions use base units only.</li>
 <li>Integer arithmetic MUST be used.</li>
 <li><code>quote_amount = floor(base_amount × rate / 10^rate_scale)</code>.</li>

--- a/index.html
+++ b/index.html
@@ -85,7 +85,7 @@ customElements.define("slide-panels",class extends HTMLElement{static get observ
 <p>This specification defines the data model, API, and normative requirements for implementing and interacting with a Verifiable Public Registry.</p>
 <h2 id="about-this-document"><a class="toc-anchor" href="#about-this-document" >§</a> About this Document</h2>
 <p>In order to fully understand the concepts developed in this document, you should have some basic knowledge of <a class="term-reference" href="#term:did">DID</a>, <a class="term-reference" href="#term:didcomm">DIDComm</a>, <a class="term-reference" href="#term:vs">VS</a>, <a class="term-reference" href="#term:ecosystem">ecosystem</a>, ledger-based applications, and more generally, all terms present in the <a href="#terminology" >Terminology</a> section.</p>
-<div id="note-1" class="notice note"><a class="notice-link" href="#note-1">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
+<div id="note-16" class="notice note"><a class="notice-link" href="#note-16">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
 </div>
 <h2 id="introduction"><a class="toc-anchor" href="#introduction" >§</a> Introduction</h2>
 <h3 id="what-is-an-ecosystem"><a class="toc-anchor" href="#what-is-an-ecosystem" >§</a> What is an Ecosystem?</h3>
@@ -526,7 +526,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <li>A portion defined by <code>trust_deposit_rate</code> is allocated to the <strong>participant’s trust deposit</strong>.</li>
 <li>The remaining portion is <strong>transferred directly to the participant’s wallet</strong>.</li>
 </ul>
-<div id="note-2" class="notice note"><a class="notice-link" href="#note-2">NOTE</a><p>Agents that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
+<div id="note-17" class="notice note"><a class="notice-link" href="#note-17">NOTE</a><p>Agents that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
 If not, they <strong>must reject</strong> the issuance or verification request.</p>
 <p>Note: The <strong>User Agent</strong> and <strong>Wallet User Agent</strong> may refer to the same implementation.</p>
 </div>
@@ -538,7 +538,7 @@ If not, they <strong>must reject</strong> the issuance or verification request.<
 <p><em>This section is non-normative.</em></p>
 <p>A <a class="term-reference" href="#term:governance-framework">governance framework</a> must define the governance rules that apply to a <a class="term-reference" href="#term:vpr">VPR</a>.</p>
 <p>A designated <a class="term-reference" href="#term:governance-authority">governance authority</a> (aka a council) is responsible for <strong>enforcing these rules</strong> and, when necessary, <strong>applying financial sanctions</strong> to participants who violate the rules.</p>
-<div id="note-3" class="notice note"><a class="notice-link" href="#note-3">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
+<div id="note-18" class="notice note"><a class="notice-link" href="#note-18">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
 <p>While the <strong>VPR governance framework</strong> defines the global rules for operating the Verifiable Public Registry (e.g., trust deposits, fee distribution, slashing conditions), each <strong>ecosystem</strong> must define its own <strong>EGF</strong> to govern roles, permissions, credential policies, and compliance within its specific domain.</p>
 <p>This separation ensures that ecosystems remain autonomous and can tailor governance to their unique needs, without being constrained by the global rules of the VPR.</p>
 </div>
@@ -908,10 +908,10 @@ as a direct consequence of executing authorized messages.</li>
   <span class="token punctuation">}</span>
 <span class="token punctuation">]</span>
 </code></pre>
-<div id="warning-1" class="notice warning"><a class="notice-link" href="#warning-1">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
+<div id="warning-10" class="notice warning"><a class="notice-link" href="#warning-10">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
 </div>
 <p>A VPR implementation MUST implement all the following requirements.</p>
-<div id="note-4" class="notice note"><a class="notice-link" href="#note-4">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="ec"path-3="v1"path-4="get"href="https://example/verana/ec/v1/get" ><span>https://example/verana/ec/v1/get</span></a>.</p>
+<div id="note-19" class="notice note"><a class="notice-link" href="#note-19">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="ec"path-3="v1"path-4="get"href="https://example/verana/ec/v1/get" ><span>https://example/verana/ec/v1/get</span></a>.</p>
 </div>
 <h3 id="authorization-and-fee-grants"><a class="toc-anchor" href="#authorization-and-fee-grants" >§</a> Authorization and Fee Grants</h3>
 <h4 id="delegable-module-messages"><a class="toc-anchor" href="#delegable-module-messages" >§</a> Delegable Module Messages</h4>
@@ -1668,7 +1668,7 @@ messages.</p>
 </tr>
 </tbody>
 </table>
-<div id="note-5" class="notice note"><a class="notice-link" href="#note-5">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
+<div id="note-20" class="notice note"><a class="notice-link" href="#note-20">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
 </div>
 <h3 id="corporation-module"><a class="toc-anchor" href="#corporation-module" >§</a> Corporation Module</h3>
 <p>This module manages <a class="term-reference" href="#term:corporation">corporation</a> entries — the VPR-level entity that extends a Cosmos SDK <a class="term-reference" href="#term:group">group</a> with a DID, a governance framework, and lifecycle attributes. A <code>Corporation</code> entry MUST exist before its underlying group can be referenced as the <code>corporation</code> (group) in any other VPR Create-* method (see <a href="#mod-co-msg-1-create-new-corporation" >[MOD-CO-MSG-1]</a>).</p>
@@ -1995,7 +1995,7 @@ messages.</p>
 <p><code>doc_digest_sri</code> (string) (<em>mandatory</em>): MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</p>
 </li>
 </ul>
-<div id="note-6" class="notice note"><a class="notice-link" href="#note-6">NOTE</a><p>It is not a problem if several ecosystems are created with the same ecosystem DID. Identifier of a <code>Ecosystem</code> is its id, and the Verifiable Trust Spec includes the id of the <code>Ecosystem</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
+<div id="note-21" class="notice note"><a class="notice-link" href="#note-21">NOTE</a><p>It is not a problem if several ecosystems are created with the same ecosystem DID. Identifier of a <code>Ecosystem</code> is its id, and the Verifiable Trust Spec includes the id of the <code>Ecosystem</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
 </div>
 <h6 id="mod-es-msg-1-2-2-create-new-ecosystem-fee-checks"><a class="toc-anchor" href="#mod-es-msg-1-2-2-create-new-ecosystem-fee-checks" >§</a> [MOD-ES-MSG-1-2-2] Create New Ecosystem fee checks</h6>
 <p>Fee payer MUST have an available balance to cover the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</p>
@@ -2466,7 +2466,7 @@ messages.</p>
 <p><code>pricing_asset</code> (string) (<em>mandatory</em>): <code>&quot;tu&quot;</code> if <code>pricing_asset_type</code> is set to TU, else examples: COIN: <code>denom</code> <code>&quot;uvna&quot;</code>, <code>&quot;ufoo&quot;</code>, <code>&quot;ibc/3A0F9C2E4E2A9B7D6F...&quot;</code>, <code>&quot;factory/verana1.../ueurv&quot;</code>, FIAT: <code>&quot;EUR&quot;</code>, <code>&quot;GBP&quot;</code>,…</p>
 </li>
 </ul>
-<div id="note-7" class="notice note"><a class="notice-link" href="#note-7">NOTE</a><p>When pricing_currency is set to FIAT, pricing_asset MUST be an ISO-4217 currency code.
+<div id="note-22" class="notice note"><a class="notice-link" href="#note-22">NOTE</a><p>When pricing_currency is set to FIAT, pricing_asset MUST be an ISO-4217 currency code.
 The number of decimals and minor unit semantics MUST follow the ISO-4217 standard for that currency.
 FIAT amounts MUST be expressed in minor units and MUST NOT be represented as on-chain coins.
 FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on chain.</p>
@@ -2499,7 +2499,7 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 </ul>
 </li>
 </ul>
-<div id="note-8" class="notice note"><a class="notice-link" href="#note-8">NOTE</a><p>If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM <code>Participant</code> so that onboarding processes can be run.</p>
+<div id="note-23" class="notice note"><a class="notice-link" href="#note-23">NOTE</a><p>If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM <code>Participant</code> so that onboarding processes can be run.</p>
 </div>
 <h4 id="mod-cs-msg-2-update-credential-schema"><a class="toc-anchor" href="#mod-cs-msg-2-update-credential-schema" >§</a> [MOD-CS-MSG-2] Update Credential Schema</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
@@ -2925,7 +2925,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li>If the <a class="term-reference" href="#term:applicant">applicant</a> qualifies, the <a class="term-reference" href="#term:validator">validator</a> runs <a href="#mod-pp-msg-3-set-participant-op-to-validated" >[MOD-PP-MSG-3]</a> to update the Participant entry; the <a class="term-reference" href="#term:applicant">applicant</a> is then granted the new <code>Participant</code> entries and/or issued a credential.</li>
 </ol>
 <p>Once in the <code>VALIDATED</code> state, a Participant entry remains valid for a specific period (e.g., 365 days), configured in the <a class="term-reference" href="#term:credential-schema">credential schema</a> for credential-schema-related onboarding, or set by the <a class="term-reference" href="#term:ecosystem">ecosystem</a> for user-agent onboarding.</p>
-<div id="note-9" class="notice note"><a class="notice-link" href="#note-9">NOTE</a><p>Even when the Participant entry remains in the <code>VALIDATED</code> state for the configured period, the resulting <code>Participant</code> entry or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the <a class="term-reference" href="#term:applicant">applicant</a> MUST provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration in order to be issued an updated <code>Participant</code> entry and/or credential.</p>
+<div id="note-24" class="notice note"><a class="notice-link" href="#note-24">NOTE</a><p>Even when the Participant entry remains in the <code>VALIDATED</code> state for the configured period, the resulting <code>Participant</code> entry or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the <a class="term-reference" href="#term:applicant">applicant</a> MUST provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration in order to be issued an updated <code>Participant</code> entry and/or credential.</p>
 </div>
 <p>If the <code>VALIDATED</code> state is set to expire, an <a class="term-reference" href="#term:applicant">applicant</a> that wishes to extend the expiration timestamp MUST renew its <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-2-renew-participant-op" >[MOD-PP-MSG-2]</a>).</p>
 <p>At any time, the <a class="term-reference" href="#term:applicant">applicant</a> CAN cancel the <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-6-cancel-participant-op-last-request" >[MOD-PP-MSG-6]</a>).</p>
@@ -3009,7 +3009,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li><code>did</code>, if specified, MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
 <li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-pp-msg-1-1-start-participant-op-parameters" >MOD-PP-MSG-1-1</a>.</li>
 </ul>
-<div id="note-10" class="notice note"><a class="notice-link" href="#note-10">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the onboarding process is REQUIRED or not.</p>
+<div id="note-25" class="notice note"><a class="notice-link" href="#note-25">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the onboarding process is REQUIRED or not.</p>
 </div>
 <h6 id="mod-pp-msg-1-2-2-start-participant-op-permission-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-2-start-participant-op-permission-checks" >§</a> [MOD-PP-MSG-1-2-2] Start Participant OP permission checks</h6>
 <ul>
@@ -3048,7 +3048,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <p>else if <code>role</code> (ParticipantRole) is equal to VERIFIER:</p>
 <ul>
 <li>
-<p>if <code>cs.verifier_onboarding_mode</code> is equal to GRANTOR: <code>validator_participant.role</code> MUST be VERIFIER_GRANTOR, else MUST abort.</p>
+<p>if <code>cs.verifier_onboarding_mode</code> is equal to GRANTOR_ONBOARDING_PROCESS: <code>validator_participant.role</code> MUST be VERIFIER_GRANTOR, else MUST abort.</p>
 </li>
 <li>
 <p>else if <code>cs.verifier_onboarding_mode</code> is equal to ECOSYSTEM_ONBOARDING_PROCESS: <code>validator_participant.role</code> MUST be ECOSYSTEM, else MUST abort.</p>
@@ -3136,7 +3136,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 </ul>
-<div id="note-11" class="notice note"><a class="notice-link" href="#note-11">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
+<div id="note-26" class="notice note"><a class="notice-link" href="#note-26">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
 <h6 id="mod-pp-msg-1-2-4-start-participant-op-overlap-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-4-start-participant-op-overlap-checks" >§</a> [MOD-PP-MSG-1-2-4] Start Participant OP overlap checks</h6>
 <p>We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a <code>corporation</code> from running different OP with differents validators for the same <code>schema_id</code>, <code>role</code>.</p>
@@ -3311,7 +3311,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 </ul>
-<div id="note-12" class="notice note"><a class="notice-link" href="#note-12">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
+<div id="note-27" class="notice note"><a class="notice-link" href="#note-27">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
 <h6 id="mod-pp-msg-2-3-renew-participant-op-execution"><a class="toc-anchor" href="#mod-pp-msg-2-3-renew-participant-op-execution" >§</a> [MOD-PP-MSG-2-3] Renew Participant OP execution</h6>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
@@ -4001,7 +4001,7 @@ else MUST abort.</p>
 <li>if <code>wallet_agent_participant.role</code> is not ISSUER, abort.</li>
 <li>if <code>wallet_agent_participant</code> is not a <a class="term-reference" href="#term:active-participant">active participant</a>, abort.</li>
 </ul>
-<div id="warning-2" class="notice warning"><a class="notice-link" href="#warning-2">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a <code>Participant</code> entry that is not controlled by its owner.</p>
+<div id="warning-11" class="notice warning"><a class="notice-link" href="#warning-11">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a <code>Participant</code> entry that is not controlled by its owner.</p>
 </div>
 <h6 id="mod-pp-msg-10-3-create-or-update-participant-session-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-10-3-create-or-update-participant-session-fee-checks" >§</a> [MOD-PP-MSG-10-3] Create or Update Participant Session fee checks</h6>
 <ul>
@@ -4177,7 +4177,7 @@ else MUST abort.</p>
 <li><code>corporation</code> MUST have available balance ≥ <code>total_payer_trust_deposit</code> + <code>total_payees_trust_deposit</code> + <code>total_user_agent_reward</code> + <code>total_wallet_agent_reward</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 <hr>
-<div id="warning-3" class="notice warning"><a class="notice-link" href="#warning-3">WARNING</a><ul>
+<div id="warning-12" class="notice warning"><a class="notice-link" href="#warning-12">WARNING</a><ul>
 <li>Trust deposits MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 <li>When paying with COIN ≠ <a class="term-reference" href="#term:native-denom">native denom</a> or with FIAT, payer pays trust deposits on behalf of payees (since payees receive non-native assets that cannot be directly staked).</li>
 </ul>
@@ -4339,7 +4339,7 @@ else MUST abort.</p>
 </ul>
 <p>then, add the <code>cspsr</code> to <code>session.session_records</code></p>
 <p>if current transaction if for issuance of a credential, persist the digest SRI by calling <a href="#mod-di-msg-1-store-digest" >[MOD-DI-MSG-1]</a>.</p>
-<div id="warning-4" class="notice warning"><a class="notice-link" href="#warning-4">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_participant_id</code> OR <code>verifier_participant_id</code></p>
+<div id="warning-13" class="notice warning"><a class="notice-link" href="#warning-13">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_participant_id</code> OR <code>verifier_participant_id</code></p>
 </div>
 <h4 id="mod-pp-msg-11-update-participant-module-parameters"><a class="toc-anchor" href="#mod-pp-msg-11-update-participant-module-parameters" >§</a> [MOD-PP-MSG-11] Update Participant Module Parameters</h4>
 <p>Update Participant Module Parameters.</p>
@@ -4388,7 +4388,7 @@ else MUST abort.</p>
 <li>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>. If no entry found, abort.</li>
 <li><code>amount</code> MUST be lower or equal to <code>applicant_participant.deposit</code> else MUST abort.</li>
 </ul>
-<div id="note-13" class="notice note"><a class="notice-link" href="#note-13">NOTE</a><p>Even if the <code>Participant</code> entry has expired or is revoked, it is still possible to slash it.</p>
+<div id="note-28" class="notice note"><a class="notice-link" href="#note-28">NOTE</a><p>Even if the <code>Participant</code> entry has expired or is revoked, it is still possible to slash it.</p>
 </div>
 <h6 id="mod-pp-msg-12-2-2-slash-participant-trust-deposit-validator-perms"><a class="toc-anchor" href="#mod-pp-msg-12-2-2-slash-participant-trust-deposit-validator-perms" >§</a> [MOD-PP-MSG-12-2-2] Slash Participant Trust Deposit validator perms</h6>
 <p>Either Option #1, or #2 MUST return true, else abort.</p>
@@ -4481,7 +4481,7 @@ else MUST abort.</p>
 <h4 id="mod-pp-msg-14-self-create-participant"><a class="toc-anchor" href="#mod-pp-msg-14-self-create-participant" >§</a> [MOD-PP-MSG-14] Self Create Participant</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This simple <code>Participant</code>-creation method can be used to self-create an ISSUER (resp. VERIFIER) <code>Participant</code> entry if issuance mode (resp. verification mode) is set to <code>OPEN</code> for a given schema. As <code>Participant</code> entries are the anchor of ecosystem trust deposit operations, it is required for an issuer/verifier candidate to self-create a <code>Participant</code> entry for being issuer or verifier of a given schema.</p>
-<div id="note-14" class="notice note"><a class="notice-link" href="#note-14">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their <code>Participant</code> entry may be revoked by ecosystem governance authority and their deposit slashed.</p>
+<div id="note-29" class="notice note"><a class="notice-link" href="#note-29">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their <code>Participant</code> entry may be revoked by ecosystem governance authority and their deposit slashed.</p>
 </div>
 <h5 id="mod-pp-msg-14-1-self-create-participant-parameters"><a class="toc-anchor" href="#mod-pp-msg-14-1-self-create-participant-parameters" >§</a> [MOD-PP-MSG-14-1] Self Create Participant parameters</h5>
 <ul>
@@ -4791,7 +4791,7 @@ else MUST abort.</p>
 </li>
 </ul>
 <p>return <code>found_perms</code>.</p>
-<div id="note-15" class="notice note"><a class="notice-link" href="#note-15">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
+<div id="note-30" class="notice note"><a class="notice-link" href="#note-30">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
 </div>
 <h4 id="mod-pp-qry-5-get-participantsession"><a class="toc-anchor" href="#mod-pp-qry-5-get-participantsession" >§</a> [MOD-PP-QRY-5] Get ParticipantSession</h4>
 <h5 id="mod-pp-qry-5-1-get-participantsession-parameters"><a class="toc-anchor" href="#mod-pp-qry-5-1-get-participantsession-parameters" >§</a> [MOD-PP-QRY-5-1] Get ParticipantSession parameters</h5>
@@ -5171,14 +5171,14 @@ else MUST abort.</p>
 </ul>
 <h4 id="mod-td-msg-7-burn-ecosystem-slashed-trust-deposit"><a class="toc-anchor" href="#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit" >§</a> [MOD-TD-MSG-7] Burn Ecosystem Slashed Trust Deposit</h4>
 <p>Burn the portion of the trust deposit of a given account. This method can only be called by the permission module when performing an ecosystem-related slash.</p>
-<div id="warning-5" class="notice warning"><a class="notice-link" href="#warning-5">WARNING</a><p>Make sure to <strong>properly protect access to the execution of this method</strong> else it may lead to very destructive actions.</p>
+<div id="warning-14" class="notice warning"><a class="notice-link" href="#warning-14">WARNING</a><p>Make sure to <strong>properly protect access to the execution of this method</strong> else it may lead to very destructive actions.</p>
 </div>
 <h5 id="mod-td-msg-7-1-burn-ecosystem-slashed-trust-deposit-method-parameters"><a class="toc-anchor" href="#mod-td-msg-7-1-burn-ecosystem-slashed-trust-deposit-method-parameters" >§</a> [MOD-TD-MSG-7-1] Burn Ecosystem Slashed Trust Deposit method parameters</h5>
 <ul>
 <li><code>corporation</code> (group) (<em>mandatory</em>): corporation of the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> we want to burn.</li>
 <li><code>amount</code> (number) (<em>mandatory</em>): value to burn, in <a class="term-reference" href="#term:denom">denom</a>.</li>
 </ul>
-<div id="warning-6" class="notice warning"><a class="notice-link" href="#warning-6">WARNING</a><p><strong>Alternative approach</strong>: For security and consistency, implementers MAY choose to reference the <strong>ID of the slashed permission</strong>, load it and use its defined <code>slashed_deposit</code> value as the slashing amount.
+<div id="warning-15" class="notice warning"><a class="notice-link" href="#warning-15">WARNING</a><p><strong>Alternative approach</strong>: For security and consistency, implementers MAY choose to reference the <strong>ID of the slashed permission</strong>, load it and use its defined <code>slashed_deposit</code> value as the slashing amount.
 The decision between this method and specifying the amount directly is left to implementers.</p>
 </div>
 <h5 id="mod-td-msg-7-2-burn-ecosystem-slashed-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-td-msg-7-2-burn-ecosystem-slashed-trust-deposit-precondition-checks" >§</a> [MOD-TD-MSG-7-2] Burn Ecosystem Slashed Trust Deposit precondition checks</h5>
@@ -5350,7 +5350,7 @@ The decision between this method and specifying the amount directly is left to i
 <p>Check if a <strong>VS Operator Authorization</strong> exists for <code>corporation</code> and <code>grantee</code>. If this is the case, MUST abort.</p>
 </li>
 </ul>
-<div id="warning-7" class="notice warning"><a class="notice-link" href="#warning-7">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>participant.corporation</code> and <code>participant.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-16" class="notice warning"><a class="notice-link" href="#warning-16">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>participant.corporation</code> and <code>participant.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-3-3-grant-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-3-3-grant-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-3-3] Grant Operator Authorization fee checks</h5>
 <ul>
@@ -5427,7 +5427,7 @@ The decision between this method and specifying the amount directly is left to i
 <li>No <code>OperatorAuthorization</code> <code>oauthz</code> where <code>oauthz.corporation</code> = <code>corporation</code> and <code>oauthz.operator</code> = <code>vs_operator</code> MUST exist.</li>
 <li>No other <code>VSOperatorAuthorization</code> <code>vsoauthz'</code> where <code>vsoauthz'.vs_operator</code> = <code>vs_operator</code> AND <code>vsoauthz'.corporation</code> != <code>corporation</code> MUST exist. In other words, a vs-agent VPR account cannot be controlled by multiple corporations.</li>
 </ul>
-<div id="warning-8" class="notice warning"><a class="notice-link" href="#warning-8">WARNING</a><p>A <strong>VS Operator Authorization</strong> record CAN be granted ONLY IF no <strong>OperatorAuthorization</strong> exists for the same <code>(corporation, vs_operator)</code> pair. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-17" class="notice warning"><a class="notice-link" href="#warning-17">WARNING</a><p>A <strong>VS Operator Authorization</strong> record CAN be granted ONLY IF no <strong>OperatorAuthorization</strong> exists for the same <code>(corporation, vs_operator)</code> pair. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-5-3-grant-vs-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-5-3-grant-vs-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-5-3] Grant VS Operator Authorization fee checks</h5>
 <ul>
@@ -5970,7 +5970,7 @@ rate_scale       = S</p>
 </ul>
 </li>
 </ul>
-<div id="warning-9" class="notice warning"><a class="notice-link" href="#warning-9">WARNING</a><ul>
+<div id="warning-18" class="notice warning"><a class="notice-link" href="#warning-18">WARNING</a><ul>
 <li>Conversions use base units only.</li>
 <li>Integer arithmetic MUST be used.</li>
 <li><code>quote_amount = floor(base_amount × rate / 10^rate_scale)</code>.</li>

--- a/index.html
+++ b/index.html
@@ -48,7 +48,7 @@ customElements.define("slide-panels",class extends HTMLElement{static get observ
       
                     <article id="content">
                       <h1 id="verifiable-public-registry-v4-specification"><a class="toc-anchor" href="#verifiable-public-registry-v4-specification" >§</a> Verifiable Public Registry v4 Specification</h1>
-<p><strong>Latest draft:</strong> <a path-0="verana-labs.github.io"path-1="verifiable-trust-vpr-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-vpr-spec/" >spec v4-draft18</a></p>
+<p><strong>Latest draft:</strong> <a path-0="verana-labs.github.io"path-1="verifiable-trust-vpr-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-vpr-spec/" >spec v4-draft21</a></p>
 <p><strong>Latest stable:</strong> <a path-0="verana-labs.github.io"path-1="verifiable-trust-vpr-spec"path-2="index-v3.html"href="https://verana-labs.github.io/verifiable-trust-vpr-spec/index-v3.html" >spec v3</a></p>
 <dl>
 <dt><strong>Editors:</strong></dt>
@@ -79,34 +79,44 @@ customElements.define("slide-panels",class extends HTMLElement{static get observ
 <hr>
 <h2 id="abstract"><a class="toc-anchor" href="#abstract" >§</a> Abstract</h2>
 <p>Decentralized trust ecosystems need shared infrastructure to answer a fundamental question: who is authorized to issue, verify, or govern credentials in a given context? Without a common registry layer, each ecosystem operates in isolation, trust decisions depend on ad hoc configurations, and there is no interoperable way for Verifiable Services and Verifiable User Agents to resolve the legitimacy of a credential or its issuer.</p>
-<p>The <strong>Verifiable Public Registry (VPR)</strong> is a decentralized “registry of registries” that provides this foundational infrastructure. It allows ecosystems to create and manage their own trust registries, define credential schemas with fine-grained permission policies, and assign roles — issuers, verifiers, grantors — through a transparent, on-chain governance model.</p>
+<p>The <strong>Verifiable Public Registry (VPR)</strong> is a decentralized “registry of registries” that provides this foundational infrastructure. It allows ecosystems to create and manage their own ecosystems, define credential schemas with fine-grained permission policies, and assign roles — issuers, verifiers, grantors — through a transparent, on-chain governance model.</p>
 <p>The VPR exposes a standardized query API that Verifiable Services and Verifiable User Agents use during trust resolution to confirm, in real time, whether a given participant is authorized to perform a specific action under a specific credential schema. This is what makes the trust in <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust</a> actually verifiable.</p>
 <p>The VPR is DID-method-agnostic — it stores registrations, not validations — leaving trust decisions and cryptographic verification where they belong: with the relying parties. It supports flexible permission management modes (open, ecosystem-controlled, or grantor-delegated), enabling ecosystems to tailor governance to their specific requirements.</p>
 <p>This specification defines the data model, API, and normative requirements for implementing and interacting with a Verifiable Public Registry.</p>
 <h2 id="about-this-document"><a class="toc-anchor" href="#about-this-document" >§</a> About this Document</h2>
-<p>In order to fully understand the concepts developed in this document, you should have some basic knowledge of <a class="term-reference" href="#term:did">DID</a>, <a class="term-reference" href="#term:didcomm">DIDComm</a>, <a class="term-reference" href="#term:vs">VS</a>, <a class="term-reference" href="#term:trust-registry">trust registry</a>, ledger-based applications, and more generally, all terms present in the <a href="#terminology" >Terminology</a> section.</p>
+<p>In order to fully understand the concepts developed in this document, you should have some basic knowledge of <a class="term-reference" href="#term:did">DID</a>, <a class="term-reference" href="#term:didcomm">DIDComm</a>, <a class="term-reference" href="#term:vs">VS</a>, <a class="term-reference" href="#term:ecosystem">ecosystem</a>, ledger-based applications, and more generally, all terms present in the <a href="#terminology" >Terminology</a> section.</p>
 <div id="note-76" class="notice note"><a class="notice-link" href="#note-76">NOTE</a><p>Before exploring this spec, it is highly recommended to <strong>first read</strong> the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust Spec</a>.</p>
 </div>
 <h2 id="introduction"><a class="toc-anchor" href="#introduction" >§</a> Introduction</h2>
-<h3 id="what-is-a-trust-registry"><a class="toc-anchor" href="#what-is-a-trust-registry" >§</a> What is a Trust Registry?</h3>
+<h3 id="what-is-an-ecosystem"><a class="toc-anchor" href="#what-is-an-ecosystem" >§</a> What is an Ecosystem?</h3>
 <p><em>This section is non-normative.</em></p>
-<p>A trust registry is an approved list of recognized ecosystem participants, such as trust registry operators, credential <a class="term-reference" href="#term:issuers">issuers</a> and <a class="term-reference" href="#term:verifiers">verifiers</a> that are authorized to onboard ecosystem participants, and or issue/verify certain credentials in an ecosystem.</p>
-<p>A trust registry typically expose APIs that are consumed by services that would like to <a class="term-reference" href="#term:query">query</a> its database, and take decisions based on the returned result:</p>
+<p>An ecosystem is an approved list of recognized participants, such as ecosystem operators, credential <a class="term-reference" href="#term:issuers">issuers</a> and <a class="term-reference" href="#term:verifiers">verifiers</a>, that are authorized to onboard ecosystem participants, and or issue/verify certain credentials in an ecosystem.</p>
+<p>An ecosystem typically expose APIs that are consumed by services that would like to <a class="term-reference" href="#term:query">query</a> its database, and take decisions based on the returned result:</p>
 <ul>
 <li>can <a class="term-reference" href="#term:participant">participant</a> #1 issue credential for <code>schema</code> ABC of <code>ecosystem</code> E1?</li>
-<li>can <a class="term-reference" href="#term:participant">participant</a> #2 request credential presentation of credential issued by <code>issuer</code> DEF from <code>schema</code> GHI of <code>ecosystem</code> E2, for <code>jurisdiction</code> France in <code>context</code> CONTEXT?</li>
+<li>can <a class="term-reference" href="#term:participant">participant</a> #2 request credential presentation of credential issued by <code>issuer</code> DEF from <code>schema</code> GHI of <code>ecosystem</code> E2 in <code>context</code> CONTEXT?</li>
 </ul>
 <h3 id="what-is-a-verifiable-public-registry"><a class="toc-anchor" href="#what-is-a-verifiable-public-registry" >§</a> What is a Verifiable Public Registry?</h3>
 <p><em>This section is non-normative.</em></p>
 <p>A Verifiable Public Registry (VPR) is a “registry of registries”, a public service that provides foundational infrastructure for decentralized trust ecosystems. It offers:</p>
 <ul>
 <li>
-<p>trust registry management:<br>
-ecosystems can create and manage their own trust registries, each with:</p>
+<p><a class="term-reference" href="#term:corporation">corporation</a> lifecycle and directory:</p>
 <ul>
-<li>defined <a class="term-reference" href="#term:credential-schemas">credential schemas</a></li>
-<li>assigned roles for <a class="term-reference" href="#term:issuers">issuers</a>, <a class="term-reference" href="#term:verifiers">verifiers</a>, and <a class="term-reference" href="#term:grantors">grantors</a> (trust registry operators)</li>
+<li>corporation onboarding, with associated <a class="term-reference" href="#term:did">DID</a> and <a class="term-reference" href="#term:corporation-governance-framework">corporation governance framework</a> publication</li>
+<li>multi-member governance via a Cosmos SDK <a class="term-reference" href="#term:group">group</a> (members, voting policy, threshold)</li>
+<li>a public corporation directory queryable by indexers, <a class="term-reference" href="#term:verifiable-services">verifiable services</a>, and <a class="term-reference" href="#term:verifiable-user-agents">verifiable user agents</a></li>
+<li>corporations are the foundational actors of the VPR: they control <a class="term-reference" href="#term:participants">participants</a> and may themselves control <a class="term-reference" href="#term:ecosystems">ecosystems</a>.</li>
+</ul>
+</li>
+<li>
+<p>ecosystem management:</p>
+<ul>
+<li>governance framework publication and versionning</li>
+<li><a class="term-reference" href="#term:credential-schemas">credential schemas</a> publication</li>
+<li>participant onboarding</li>
 <li>custom business models and permission policies</li>
+<li>and more.</li>
 </ul>
 </li>
 <li>
@@ -114,8 +124,8 @@ ecosystems can create and manage their own trust registries, each with:</p>
 A standardized API used by <a class="term-reference" href="#term:verifiable-services">verifiable services</a> (VSs) and <a class="term-reference" href="#term:verifiable-user-agents">verifiable user agents</a> (VUAs) to perform trust resolution, enabling them to query registry data and validate roles and permissions in real time.</p>
 </li>
 </ul>
-<img src="https://www.plantuml.com/plantuml/svg/fT5D2i8m40NWVKunj1Se2EAo_kr5nFqacTPeQqioLOjuTzCQYg0BYxD8idZl8p2fOxJSb8L8XvTJM12KU8DPai3LQ3u843Mg4-O4qPwioGnAdzaqiZ0AjfGRnxQD01rSQWjt8S1F9O-a6AATRHmFAQWoMAlAjOwfX7ZUjzWYn9DCQZdrxQxy664iWY7VZD78CY3g7sGL4Fs9_6oiWq7VZUuG_ayYfRFkD_Uwdm00" alt="uml diagram">
-<p>Permission directory is intended to be <strong>crawled by indexers</strong>, which resolve the listed DIDs, identify associated <a class="term-reference" href="#term:verifiable-services">verifiable services</a>, and index them.</p>
+<img src="https://www.plantuml.com/plantuml/svg/ZT3D2i8m30VmUvyYR2ym4CJZ_DXTTl2UjjciRcwqcJh4TxURHGGTcaEIm_z78AbZjDpLbKXVcrDO4THuXKMImCLetWiGBQeZbWJHZgmf34gVsNQoCWfoAerZsqU03iwjXPiGuAkH1r8CKQOQrpkc6kBbc66B4CyAgUNSPuVeVLAiWf1luWTP1wB-9vj0z2UP45aGz5qCJVXx8gMJ7l_xd0y0" alt="uml diagram">
+<p>Participant directory is intended to be <strong>crawled by indexers</strong>, which resolve the listed DIDs, identify associated <a class="term-reference" href="#term:verifiable-services">verifiable services</a>, and index them.</p>
 <p>Indexers may expose this data through APIs for querying the indexed services or use it to build a search engine for querying the database of indexed <a class="term-reference" href="#term:verifiable-services">verifiable services</a>.</p>
 <h3 id="conformance"><a class="toc-anchor" href="#conformance" >§</a> Conformance</h3>
 <p>As well as sections marked as non-normative, all authoring guidelines, diagrams, examples, and notes in this specification are non-normative. Everything else in this specification is normative.
@@ -125,13 +135,17 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <dt><span id="term:accounts"><span id="term:account">account</span></span>:</dt>
 <dd>A <a class="term-reference" href="#term:verifiable-public-registry">verifiable public registry</a> account.</dd>
 <dt><span id="term:applicants"><span id="term:applicant">applicant</span></span>:</dt>
-<dd>A <a class="term-reference" href="#term:account">account</a> that starts a <a class="term-reference" href="#term:validation-process">validation process</a>.</dd>
+<dd>A <a class="term-reference" href="#term:account">account</a> that starts a <a class="term-reference" href="#term:onboarding-process">onboarding process</a>.</dd>
 <dt><span id="term:corporations"><span id="term:corporation">corporation</span></span>:</dt>
-<dd>An <a class="term-reference" href="#term:group">group</a> which is the owner of a specific resource in an <a class="term-reference" href="#term:vpr">VPR</a>.</dd>
+<dd>A legal/organizational entity that controls Participants in zero or more <a class="term-reference" href="#term:ecosystems">ecosystems</a> and may itself be the controller of zero or more <a class="term-reference" href="#term:ecosystems">ecosystems</a>. A <code>Corporation</code> extends a Cosmos SDK <a class="term-reference" href="#term:group">group</a> with VPR-level attributes (DID, governance framework, lifecycle).</dd>
+<dt><span id="term:cgf"><span id="term:corporation-governance-framework">corporation governance framework</span></span>:</dt>
+<dd>The governance framework (GF) of a <a class="term-reference" href="#term:corporation">corporation</a>.</dd>
+<dt><span id="term:cga"><span id="term:corporation-governance-authority">corporation governance authority</span></span>:</dt>
+<dd>The governance authority (GA) of a <a class="term-reference" href="#term:corporation">corporation</a>.</dd>
 <dt><span id="term:credential-schemas"><span id="term:credential-schema">credential schema</span></span>:</dt>
 <dd>An <a class="term-reference" href="#term:vpr">VPR</a> resource which represents a verifiable credential definition and the associated permissions and business rules for issuing, verifying or holding a credential linked to this credential schema.</dd>
-<dt><span id="term:csp"><span id="term:credential-schema-permissions"><span id="term:credential-schema-permission">credential schema permission</span></span></span>:</dt>
-<dd>A permission, linked to a <a class="term-reference" href="#term:credential-schema">credential schema</a>, that represent, in a given <a class="term-reference" href="#term:ecosystem">ecosystem</a>, a grant for being <a class="term-reference" href="#term:issuer">issuer</a>, <a class="term-reference" href="#term:verifier">verifier</a>, <a class="term-reference" href="#term:issuer-grantor">issuer grantor</a>, or <a class="term-reference" href="#term:verifier-grantor">verifier grantor</a> of a <a class="term-reference" href="#term:credential-schema">credential schema</a>.</dd>
+<dt><span id="term:csp"><span id="term:credential-schema-participants"><span id="term:credential-schema-participant">credential schema participant</span></span></span>:</dt>
+<dd>A <code>Participant</code> entry, linked to a <a class="term-reference" href="#term:credential-schema">credential schema</a>, that represents, in a given <a class="term-reference" href="#term:ecosystem">ecosystem</a>, a grant for being <a class="term-reference" href="#term:issuer">issuer</a>, <a class="term-reference" href="#term:verifier">verifier</a>, <a class="term-reference" href="#term:issuer-grantor">issuer grantor</a>, or <a class="term-reference" href="#term:verifier-grantor">verifier grantor</a> of a <a class="term-reference" href="#term:credential-schema">credential schema</a>.</dd>
 <dt><span id="term:dids"><span id="term:did"><span id="term:decentralized-identifier">decentralized identifier</span></span></span>:</dt>
 <dd>A decentralized identifier, as specified in [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</dd>
 <dt><span id="term:didcomm"><span id="term:decentralized-identifier-communication">decentralized identifier communication</span></span>:</dt>
@@ -156,15 +170,15 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <dt><span id="term:ga"><span id="term:governance-authority">governance authority</span></span>:</dt>
 <dd>The governance authority (GA) of a <a class="term-reference" href="#term:vpr">VPR</a>.</dd>
 <dt><span id="term:grantors"><span id="term:grantor">grantor</span></span>:</dt>
-<dd>A role an <a class="term-reference" href="#term:entity">entity</a> is granted by an <a class="term-reference" href="#term:ecosystem">ecosystem</a> for operating its <a class="term-reference" href="#term:trust-registry">trust registry</a>.</dd>
+<dd>A role an <a class="term-reference" href="#term:entity">entity</a> is granted by an <a class="term-reference" href="#term:ecosystem">ecosystem</a> for operating its <a class="term-reference" href="#term:ecosystem">ecosystem</a>.</dd>
 <dt><span id="term:groups"><span id="term:group">group</span></span>:</dt>
-<dd>A <a class="term-reference" href="#term:verifiable-public-registry">verifiable public registry</a> group.</dd>
+<dd>The underlying Cosmos SDK group primitive that a <a class="term-reference" href="#term:corporation">corporation</a> extends. Members and policies are managed by the group module; VPR-level attributes (DID, governance framework, lifecycle) live on the corresponding <a class="term-reference" href="#term:corporation">corporation</a> entry.</dd>
 <dt><span id="term:holders"><span id="term:holder">holder</span></span>:</dt>
 <dd>A role an entity might perform by possessing one or more verifiable credentials and generating verifiable presentations from them. A holder is often, but not always, a <a class="term-reference" href="#term:subject">subject</a> of the verifiable credentials they are holding. Holders store their credentials in credential repositories. Example holders include organizations, persons, things.</dd>
 <dt><span id="term:issuers"><span id="term:issuer">issuer</span></span>:</dt>
 <dd>A role an <a class="term-reference" href="#term:entity">entity</a> is granted by an <a class="term-reference" href="#term:ecosystem">ecosystem</a> or an <a class="term-reference" href="#term:issuer-grantor">issuer grantor</a> for issuing credentials of a given <a class="term-reference" href="#term:credential-schema">credential schema</a> to <a class="term-reference" href="#term:holders">holders</a>.</dd>
 <dt><span id="term:issuer-grantors"><span id="term:issuer-grantor">issuer grantor</span></span>:</dt>
-<dd>A trust registry operator role an <a class="term-reference" href="#term:entity">entity</a> is granted by an <a class="term-reference" href="#term:ecosystem">ecosystem</a> for a given <a class="term-reference" href="#term:credential-schema">credential schema</a> for adding or revoking issuers.</dd>
+<dd>An ecosystem operator role an <a class="term-reference" href="#term:entity">entity</a> is granted by an <a class="term-reference" href="#term:ecosystem">ecosystem</a> for a given <a class="term-reference" href="#term:credential-schema">credential schema</a> for adding or revoking issuers.</dd>
 <dt><span id="term:json-schemas"><span id="term:json-schema"><span id="term:json-schemas"><span id="term:json-schema">json schema</span></span></span></span></dt>
 <dd>a Json Schema, as specified in <a path-0="json-schema.org"path-1="specification"href="https://json-schema.org/specification" >https://json-schema.org/specification</a>.</dd>
 <dt><span id="term:keeper">keeper</span>:</dt>
@@ -182,27 +196,27 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <dt><span id="term:transaction-fees">transaction fees</span>:</dt>
 <dd>Fees required, in <a class="term-reference" href="#term:denom">denom</a>, to execute a <a class="term-reference" href="#term:transaction">transaction</a> in an <a class="term-reference" href="#term:vpr">VPR</a>.</dd>
 <dt><span id="term:trust-deposits"><span id="term:trust-deposit">trust deposit</span></span>:</dt>
-<dd>A financial deposit that is used as a trust guarantee. For a given <a class="term-reference" href="#term:corporation">corporation</a>, its trust deposit is increased when running validation process (either as an <a class="term-reference" href="#term:applicant">applicant</a> or as a <a class="term-reference" href="#term:validator">validator</a>).</dd>
+<dd>A financial deposit that is used as a trust guarantee. For a given <a class="term-reference" href="#term:corporation">corporation</a>, its trust deposit is increased when running onboarding process (either as an <a class="term-reference" href="#term:applicant">applicant</a> or as a <a class="term-reference" href="#term:validator">validator</a>).</dd>
 <dt><span id="term:trust-fees"><span id="term:trust-fee">trust fee</span></span>:</dt>
 <dd>Fees paid by a <a class="term-reference" href="#term:participant">participant</a> that are distributed to other <a class="term-reference" href="#term:participants">participants</a>.</dd>
 <dt><span id="term:network-fees"><span id="term:network-fee">network fee</span></span>:</dt>
 <dd>Fees paid by a <a class="term-reference" href="#term:participant">participant</a> that are distributed to network validators and trust deposit holders.</dd>
 <dt><span id="term:tus"><span id="term:tu"><span id="term:trust-units"><span id="term:trust-unit">trust unit</span></span></span></span>:</dt>
 <dd>A fake denom that is not usable as a token (cannot be transferred, or used for paying in transactions). Trust unit is used to define fees in Permissions. Fees defined in trust units are automatically converted to <a class="term-reference" href="#term:native-denom">native denom</a> when a transaction is executed, using an exchange rate <code>TU/[[ref: native denom]]</code>. Trust unit is used to compensate <a class="term-reference" href="#term:native-denom">native denom</a> fluctuation.</dd>
-<dt><span id="term:trust-registries"><span id="term:trust-registry">trust registry</span></span></dt>
-<dd>An approved list of <a class="term-reference" href="#term:issuers">issuers</a> and <a class="term-reference" href="#term:verifiers">verifiers</a> that are authorized to issue/verify certain credentials in an ecosystem.</dd>
+<dt><span id="term:ecosystems"><span id="term:ecosystem">ecosystem</span></span></dt>
+<dd>An approved list of <a class="term-reference" href="#term:participants">participants</a> that are authorized to issue/verify certain credentials in an ecosystem.</dd>
 <dt><span id="term:uris"><span id="term:uri">URI</span></span></dt>
 <dd>An Universal Resource Identifier, as specified in <a path-0="datatracker.ietf.org"path-1="doc"path-2="html"path-3="rfc3986"href="https://datatracker.ietf.org/doc/html/rfc3986" >rfc3986</a>.</dd>
-<dt><span id="term:active-permissions"><span id="term:active-permission">active permission</span></span>:</dt>
-<dd>A credential schema permission of a given type, which effective_from timestamp is lower than current timestamp, and (effective_until timestamp is null or greater than current timestamp), and revoked is null and slashed is null.</dd>
-<dt><span id="term:future-permissions"><span id="term:future-permission">future permission</span></span>:</dt>
-<dd>A credential schema permission of a given type, which effective_from timestamp is higher than current timestamp, and (effective_until timestamp is null or greater than effective_from timestamp), and revoked is null and slashed is null.</dd>
-<dt><span id="term:validation-process">validation process</span>:</dt>
+<dt><span id="term:active-participants"><span id="term:active-participant">active participant</span></span>:</dt>
+<dd>A participant of a given role, which effective_from timestamp is lower than current timestamp, and (effective_until timestamp is null or greater than current timestamp), and revoked is null and slashed is null.</dd>
+<dt><span id="term:future-participants"><span id="term:future-participant">future participant</span></span>:</dt>
+<dd>A participant of a given role, which effective_from timestamp is higher than current timestamp, and (effective_until timestamp is null or greater than effective_from timestamp), and revoked is null and slashed is null.</dd>
+<dt><span id="term:onboarding-process">onboarding process</span>:</dt>
 <dd>A process run by <a class="term-reference" href="#term:applicants">applicants</a> that want to, for a specific <a class="term-reference" href="#term:credential-schema">credential schema</a>, be a <a class="term-reference" href="#term:issuer">issuer</a>, be a <a class="term-reference" href="#term:verifier">verifier</a>, or simply hold a verifiable credential linked to the <a class="term-reference" href="#term:credential-schema">credential schema</a>.</dd>
 <dt><span id="term:validator">validator</span>:</dt>
-<dd>A role an <a class="term-reference" href="#term:entity">entity</a> performs by participating in validation processes with <a class="term-reference" href="#term:applicants">applicants</a> in order to register them as <a class="term-reference" href="#term:issuer">issuer</a>, or <a class="term-reference" href="#term:verifier">verifier</a> of a <a class="term-reference" href="#term:credential-schema">credential schema</a>, or to deliver a verifiable credential to them.</dd>
+<dd>A role an <a class="term-reference" href="#term:entity">entity</a> performs by participating in onboarding processes with <a class="term-reference" href="#term:applicants">applicants</a> in order to register them as <a class="term-reference" href="#term:issuer">issuer</a>, or <a class="term-reference" href="#term:verifier">verifier</a> of a <a class="term-reference" href="#term:credential-schema">credential schema</a>, or to deliver a verifiable credential to them.</dd>
 <dt><span id="term:vprs"><span id="term:vpr"><span id="term:verifiable-public-registry">verifiable public registry</span></span></span>:</dt>
-<dd>a public, normally decentralized, ledger-based network, which provides: trust registry features, that can be used by all its <a class="term-reference" href="#term:participants">participants</a>: create trust registries, for each trust registry, define its credential schemas, who can issue, verify credential of a specific credential schema,… and a tokenized business model for charging/rewarding <a class="term-reference" href="#term:participants">participants</a>.</dd>
+<dd>a public, normally decentralized, ledger-based network, which provides: ecosystem features, that can be used by all its <a class="term-reference" href="#term:participants">participants</a>: create ecosystems, for each ecosystem, define its credential schemas, who can issue, verify credential of a specific credential schema,… and a tokenized business model for charging/rewarding <a class="term-reference" href="#term:participants">participants</a>.</dd>
 <dt><span id="term:vss"><span id="term:vs"><span id="term:verifiable-services"><span id="term:verifiable-service">verifiable service</span></span></span></span>:</dt>
 <dd>A service, identified by a resolvable <a class="term-reference" href="#term:did">DID</a> that can be deployed anywhere by its owner, and that is conforming to this spec and has a resolvable Proof-of-Trust. See <a class="term-reference" href="#term:vt-spec">VT Spec</a>.</dd>
 <dt><span id="term:vuas"><span id="term:vua"><span id="term:verifiable-user-agents"><span id="term:verifiable-user-agent">verifiable user agent</span></span></span></span>:</dt>
@@ -212,7 +226,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <dt><span id="term:verifiers"><span id="term:verifier">verifier</span></span>:</dt>
 <dd>A role an <a class="term-reference" href="#term:entity">entity</a> is granted by an <a class="term-reference" href="#term:ecosystem">ecosystem</a> or a <a class="term-reference" href="#term:verifier-grantor">verifier grantor</a> for verifying credentials of a given <a class="term-reference" href="#term:credential-schema">credential schema</a>.</dd>
 <dt><span id="term:verifier-grantors"><span id="term:verifier-grantor">verifier grantor</span></span>:</dt>
-<dd>A trust registry operator role an <a class="term-reference" href="#term:entity">entity</a> is granted by an <a class="term-reference" href="#term:ecosystem">ecosystem</a> for a given <a class="term-reference" href="#term:credential-schema">credential schema</a> for adding or revoking verifiers.</dd>
+<dd>An ecosystem operator role an <a class="term-reference" href="#term:entity">entity</a> is granted by an <a class="term-reference" href="#term:ecosystem">ecosystem</a> for a given <a class="term-reference" href="#term:credential-schema">credential schema</a> for adding or revoking verifiers.</dd>
 <dt><span id="term:verifiable-credentials"><span id="term:verifiable-credential">verifiable credential</span></span>:</dt>
 <dd>A verifiable credential as defined in [<a class="spec-reference" href="#ref:VC-DATA-MODEL">VC-DATA-MODEL</a>].</dd>
 </dl>
@@ -228,44 +242,44 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <li>Object attributes and Json Content in general can be returned in any order.</li>
 </ul>
 <h2 id="features-of-a-verifiable-public-registry-vpr"><a class="toc-anchor" href="#features-of-a-verifiable-public-registry-vpr" >§</a> Features of a Verifiable Public Registry (VPR)</h2>
-<h3 id="trust-registry-management"><a class="toc-anchor" href="#trust-registry-management" >§</a> Trust Registry Management</h3>
+<h3 id="ecosystem-management"><a class="toc-anchor" href="#ecosystem-management" >§</a> Ecosystem Management</h3>
 <p><em>This section is non-normative.</em></p>
-<p>In an <a class="term-reference" href="#term:vpr">VPR</a>, any <a class="term-reference" href="#term:corporation">corporation</a> can create a <code>TrustRegistry</code> entry that represents a <a class="term-reference" href="#term:trust-registry">trust registry</a> of an ecosystem. Each <code>TrustRegistry</code> entry must provide, at a minimum:</p>
+<p>In an <a class="term-reference" href="#term:vpr">VPR</a>, any <a class="term-reference" href="#term:corporation">corporation</a> can create an <code>Ecosystem</code> entry to represent an <a class="term-reference" href="#term:ecosystem">ecosystem</a> it controls. Each <code>Ecosystem</code> entry MUST provide, at a minimum:</p>
 <ul>
 <li>an ecosystem controlled resolvable <a class="term-reference" href="#term:did">DID</a>;</li>
 <li>one or more <a class="term-reference" href="#term:ecosystem-governance-framework">ecosystem governance framework</a> document(s);</li>
 <li>zero or more <a class="term-reference" href="#term:credential-schemas">credential schemas</a>.</li>
 </ul>
 <p>The Verifiable Public Registry (VPR) is agnostic to the specific DID methods used. Trust resolution is performed externally, outside the VPR, allowing flexibility and interoperability across ecosystems.</p>
-<img src="https://www.plantuml.com/plantuml/svg/NOv12i9040Jlyuf6Fn0Gn6FU87vWiZj9LhExC3Cn1l7lYeA7zAMBfWxTchFwd2Tg_sI19q7c1qvDWoL57mbKkwi4n-wYipdECYHpNNTWWojZV-Yxs1tn97mYeTfgBXannSqILA8KJpp1mYYPRICCzIvQk0H1hvnbgNf3hC7eHTHAYT-xltu3" alt="uml diagram">
-<h3 id="credential-schemas-and-permissions"><a class="toc-anchor" href="#credential-schemas-and-permissions" >§</a> Credential Schemas and Permissions</h3>
+<img src="https://www.plantuml.com/plantuml/svg/NOun3i9G34FtdC8g5wY4X1YxS90qIMcX_t_f9r0GukuW40prOklPWpiFhd59CtN_vCAp8V4D-xR5CccC12hzoIJG7AJutSDI0tP4PMosGw_z3W_2M_RhePEkY5HJop7n39VH4ljgS2nNgvcp68RAoPPIpz0YJa-Yph9-ddxz1G00" alt="uml diagram">
+<h3 id="credential-schemas-and-participants"><a class="toc-anchor" href="#credential-schemas-and-participants" >§</a> Credential Schemas and Participants</h3>
 <p><em>This section is non-normative.</em></p>
-<p><a class="term-reference" href="#term:credential-schemas">Credential schemas</a> are created and managed by trust registry corporation (<a class="term-reference" href="#term:ecosystems">ecosystems</a>). Each <a class="term-reference" href="#term:credential-schema">Credential schema</a> includes, at a minimum:</p>
+<p><a class="term-reference" href="#term:credential-schemas">Credential schemas</a> are created and managed by <a class="term-reference" href="#term:ecosystems">ecosystems</a> (i.e., by the <a class="term-reference" href="#term:corporation">corporation</a> controlling each <a class="term-reference" href="#term:ecosystem">ecosystem</a>). Each <a class="term-reference" href="#term:credential-schema">Credential schema</a> includes, at a minimum:</p>
 <ul>
-<li>A <strong>Json Schema</strong> that defines the structure of the corresponding <a class="term-reference" href="#term:verifiable-credential">verifiable credential</a></li>
-<li>A <strong>IssuerOnboardingMode</strong> for <strong>issuance policy</strong>, which determines how <code>ISSUER</code> permissions are granted. Modes include:
+<li>A <strong>Json Schema</strong> that defines the structure of the corresponding <a class="term-reference" href="#term:verifiable-credential">verifiable credential</a>.</li>
+<li>An <strong>IssuerOnboardingMode</strong> for <strong>issuance policy</strong>, which determines how <code>ISSUER</code> <code>Participant</code> entries are created. Modes include:
 <ul>
-<li><code>OPEN</code>: <code>ISSUER</code> permissions can be self-created by anyone.</li>
-<li><code>ECOSYSTEM_VALIDATION_PROCESS</code>: <code>ISSUER</code> permissions are granted directly by the <a class="term-reference" href="#term:ecosystem">ecosystem</a>, the trust registry corporation through the execution of a Validation Process.</li>
-<li><code>GRANTOR_VALIDATION_PROCESS</code>: <code>ISSUER</code> permissions are granted by one or several <a class="term-reference" href="#term:issuer-grantor">issuer grantor</a>(s) (trust registry operator(s) responsible for selecting issuers for the credential schema of this <a class="term-reference" href="#term:ecosystem">ecosystem</a>), selected by the <a class="term-reference" href="#term:ecosystem">ecosystem</a> through the execution of a Validation Process.</li>
+<li><code>OPEN</code>: <code>ISSUER</code> Participants can be self-created by any <a class="term-reference" href="#term:corporation">corporation</a>.</li>
+<li><code>ECOSYSTEM_ONBOARDING_PROCESS</code>: <code>ISSUER</code> Participants are created directly by the controlling <a class="term-reference" href="#term:ecosystem">ecosystem</a> through an <a class="term-reference" href="#term:onboarding-process">onboarding process</a>.</li>
+<li><code>GRANTOR_ONBOARDING_PROCESS</code>: <code>ISSUER</code> Participants are created by one or several <a class="term-reference" href="#term:issuer-grantor">issuer grantor</a>(s) — ecosystem operators responsible for onboarding issuers for the credential schema of this <a class="term-reference" href="#term:ecosystem">ecosystem</a> — selected by the <a class="term-reference" href="#term:ecosystem">ecosystem</a> through an <a class="term-reference" href="#term:onboarding-process">onboarding process</a>.</li>
 </ul>
 </li>
-<li>A <strong>VerifierOnboardingMode</strong> for <strong>verification policy</strong>, which determines how <code>VERIFIER</code> permissions are granted. Modes include:
+<li>A <strong>VerifierOnboardingMode</strong> for <strong>verification policy</strong>, which determines how <code>VERIFIER</code> <code>Participant</code> entries are created. Modes include:
 <ul>
-<li><code>OPEN</code>: <code>VERIFIER</code> permissions can be created by anyone.</li>
-<li><code>ECOSYSTEM_VALIDATION_PROCESS</code>: <code>VERIFIER</code> permissions are granted directly by the <a class="term-reference" href="#term:ecosystem">ecosystem</a>, the Trust Registry corporation through the execution of a Validation Process.</li>
-<li><code>GRANTOR_VALIDATION_PROCESS</code>: <code>VERIFIER</code> permissions are granted by one or several <a class="term-reference" href="#term:verifier-grantor">verifier grantor</a>(s) (trust registry operator(s) responsible for selecting verifiers for the credential schema of this <a class="term-reference" href="#term:ecosystem">ecosystem</a>), selected by the <a class="term-reference" href="#term:ecosystem">ecosystem</a>, through the execution of a Validation Process.</li>
+<li><code>OPEN</code>: <code>VERIFIER</code> Participants can be self-created by any <a class="term-reference" href="#term:corporation">corporation</a>.</li>
+<li><code>ECOSYSTEM_ONBOARDING_PROCESS</code>: <code>VERIFIER</code> Participants are created directly by the controlling <a class="term-reference" href="#term:ecosystem">ecosystem</a> through an <a class="term-reference" href="#term:onboarding-process">onboarding process</a>.</li>
+<li><code>GRANTOR_ONBOARDING_PROCESS</code>: <code>VERIFIER</code> Participants are created by one or several <a class="term-reference" href="#term:verifier-grantor">verifier grantor</a>(s) — ecosystem operators responsible for onboarding verifiers for the credential schema of this <a class="term-reference" href="#term:ecosystem">ecosystem</a> — selected by the <a class="term-reference" href="#term:ecosystem">ecosystem</a> through an <a class="term-reference" href="#term:onboarding-process">onboarding process</a>.</li>
 </ul>
 </li>
-<li>An <strong>HolderOnboardingMode</strong> for <strong>holder policy</strong>, which determines how <code>HOLDER</code> permissions are granted. Modes include:
+<li>A <strong>HolderOnboardingMode</strong> for <strong>holder policy</strong>, which determines how <code>HOLDER</code> <code>Participant</code> entries are created. Modes include:
 <ul>
-<li><code>ISSUER_VALIDATION_PROCESS</code>: <code>HOLDER</code> permissions are granted directly by issuers to holder through the execution of a Validation Process.</li>
-<li><code>PERMISSIONLESS</code>: holder that want to obtain credentials from an issuer do not require a permission in the VPR.</li>
+<li><code>ISSUER_ONBOARDING_PROCESS</code>: <code>HOLDER</code> Participants are created directly by <a class="term-reference" href="#term:issuers">issuers</a> for holders, through an <a class="term-reference" href="#term:onboarding-process">onboarding process</a>.</li>
+<li><code>PERMISSIONLESS</code>: a holder that wants to obtain credentials from an <a class="term-reference" href="#term:issuer">issuer</a> does not require a <code>Participant</code> entry in the VPR.</li>
 </ul>
 </li>
-<li>A <strong>Permission tree</strong> that defines the roles and relationships involved in managing the schema’s lifecycle. Each created permission in the tree can define business rules, see below <a href="#business-models" >Business Models</a>.</li>
+<li>A <strong>Participant tree</strong> that defines the roles and relationships involved in managing the schema’s lifecycle. Each <code>Participant</code> entry in the tree can define business rules; see <a href="#business-models" >Business Models</a> below.</li>
 </ul>
-<img src="https://www.plantuml.com/plantuml/svg/ZPDTJy8m58Rl-ojEu4OlJ9QGCCE50SQ09IfccoHwOxhjCAhxIbicnF3VBUkOak2mD-r9t_C-FJtjK4ZAvIPDoB1PYP0c22dTmgrXm2UBv9e0AMZuGME4ZhsbQQ445iS8Cybe0bwunfJ24_AK2S7o37oEs04g81JmHGYeaGVl64gL7-PY9oIcCAeKaaEtjmgYeA-KK8-YiV9t1Gx0jXRUY-VR3t3bvhcyReGHYmQeJpJ0e_EesjwVO1qXDiXXncacSmxZYitY5gRZUS-s-pPpHu_-mZrBPF7uRvIb4JhecdtJn0Wkyivph3EO9NAsOhzgcbJ0igscfUqwK-T2LMKyQSFP6dCCkuOH62lZ7z3pCBjcdS3cUH8fxrUeM6iTTQVJiM7sMaZpnVsavko9iYH4lQwRcxj3emSG7-v9zK3ev_gJJDHsfTAzQbCU3Sjsmr8RDfVKQbbZ3mcwqbRr4BEe-h1w_WO0" alt="uml diagram">
+<img src="https://www.plantuml.com/plantuml/svg/XPDHRu8m483V-HKNUTaUJ4XCPE5XKH6LP9iBE9FviXGuiHi8QIjpMVRVLocw6G7xKYvtVD-L7WCk21ExDD46foSUaWGX9NkuCmpuf97OQA3b9FmWCKB7sPCqbmKsmmYtWf84_723AO5d2Q0XpSbMm88XTe1m23byQnh8bGNl60e923F-nGMcC2mh10EzjmwYe2yheLeiIz02nvxxh_x2UOGRByl4xIaTqSX2rOY5HzwmJF-SoLpETyXWocHJ6ODHQQJnXSdr_HV7UvjwmwV5tAlrq7ZKBB0LM0MwsJTDZA31Ka-tQ-1BP7HD__K_BZN5PVzBntCdxfKJ5F6uJU8e-37K3ICmraQZgbxXL8OpnInB8abSGMdOg4YVJ4Q6sRlWp-OFuoRwgg9BlgR9mUbsxm-tQK78a0ZamDKevd-ZgCbyMQRkfhNqY2ok80k5F7sgTcXbFhoXZjvUFi1jLFwHQly5" alt="uml diagram">
 <p>Participant roles are defined in the table below:</p>
 <table>
 <thead>
@@ -277,15 +291,15 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <tbody>
 <tr>
 <td><strong>Ecosystem</strong></td>
-<td>Create and control trust registries and credential Schemas. Recognize other participants by granting permission(s) to them.</td>
+<td>Create and control <a class="term-reference" href="#term:ecosystems">ecosystems</a> and credential schemas. Recognize other participants by validating them onto the schema (creating their <code>Participant</code> entries).</td>
 </tr>
 <tr>
 <td><strong>Issuer Grantor</strong></td>
-<td>Trust Registry operator that grants Issuer permissions to candidate issuers.</td>
+<td>Ecosystem operator that creates <code>ISSUER</code> <code>Participant</code> entries for candidate issuers.</td>
 </tr>
 <tr>
 <td><strong>Verifier Grantor</strong></td>
-<td>Trust Registry operator that grants Verifier permissions to candidate verifiers.</td>
+<td>Ecosystem operator that creates <code>VERIFIER</code> <code>Participant</code> entries for candidate verifiers.</td>
 </tr>
 <tr>
 <td><strong>Issuer</strong></td>
@@ -297,7 +311,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 </tr>
 <tr>
 <td><strong>Holder</strong></td>
-<td>Holds a credential. Holder permission provide credential status (active, revoked…)</td>
+<td>Holds a credential. <code>HOLDER</code> <code>Participant</code> entries carry credential status (active, revoked, …).</td>
 </tr>
 </tbody>
 </table>
@@ -350,36 +364,44 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <p>To participate in an <a class="term-reference" href="#term:ecosystem">ecosystem</a> and assume a role associated with a specific <a class="term-reference" href="#term:credential-schema">credential schema</a>:</p>
 <ul>
 <li>
-<p>if schema is <code>OPEN</code> for issuance and/or verification: an entity must have an <a class="term-reference" href="#term:account">account</a> in the <a class="term-reference" href="#term:vpr">VPR</a> and self-create its permission.</p>
+<p>if the schema is <code>OPEN</code> for issuance and/or verification: a <a class="term-reference" href="#term:corporation">corporation</a> MUST have a registered <code>Corporation</code> entry in the <a class="term-reference" href="#term:vpr">VPR</a> and self-create its <code>Participant</code> entry.</p>
 </li>
 <li>
-<p>if schema is not <code>OPEN</code> for issuance and/or verification: an entity must have an <a class="term-reference" href="#term:account">account</a> in the <a class="term-reference" href="#term:vpr">VPR</a> and complete a <a class="term-reference" href="#term:validation-process">validation process</a> to obtain the required permission.</p>
+<p>if the schema is not <code>OPEN</code> for issuance and/or verification: a <a class="term-reference" href="#term:corporation">corporation</a> MUST have a registered <code>Corporation</code> entry in the <a class="term-reference" href="#term:vpr">VPR</a> and complete an <a class="term-reference" href="#term:onboarding-process">onboarding process</a> to obtain its <code>Participant</code> entry.</p>
 </li>
 </ul>
-<p>The <a class="term-reference" href="#term:validation-process">validation process</a> involves two parties:</p>
+<p>The <a class="term-reference" href="#term:onboarding-process">onboarding process</a> involves two parties:</p>
 <ul>
-<li>The <a class="term-reference" href="#term:applicant">applicant</a> — the entity requesting permission for a credential schema within the ecosystem.</li>
-<li>The <a class="term-reference" href="#term:validator">validator</a> — an entity that already holds permission for the same credential schema and has been delegated authority to validate applicants and issue permissions.</li>
+<li>The <a class="term-reference" href="#term:applicant">applicant</a> — the <a class="term-reference" href="#term:corporation">corporation</a> requesting a <code>Participant</code> entry for a credential schema within the ecosystem.</li>
+<li>The <a class="term-reference" href="#term:validator">validator</a> — a corporation that already holds a <code>Participant</code> entry for the same credential schema and has been delegated authority to validate applicants and create new <code>Participant</code> entries.</li>
 </ul>
-<p>Running a validation process <strong>typically involves the payment of <a class="term-reference" href="#term:trust-fees">trust fees</a></strong>. <a class="term-reference" href="#term:trust-fee">Trust fee</a> amount to be paid by the <a class="term-reference" href="#term:applicant">applicant</a> is defined in the permission of the <a class="term-reference" href="#term:validator">validator</a> involved in the <a class="term-reference" href="#term:validation-process">validation process</a>:</p>
-<img src="https://www.plantuml.com/plantuml/svg/fPHTJy8m58RlzojEs3L9bOIPNHY-XfYOI42zyAvR3wEwhxHbGep_tRAE2iOD4dkpvlJj-puzwpQGYWgrIHDdO6SoeWb2IhTmGmXySARM3ZW5ZTvfZD2PqnqKAA2a2MTKyJo3AI8ibTX4QYEm0rH29E7JSK2FF7p3I44dY7AvamfJ648NnW8PPehJ19RH6bCAYpnNC4UHSYcrP-MY1BYzLSZ2ldQ3UZ3EVDpIj4ZGnuFfq2xV2PgfN00jYeH7UduCgkNAXokYp_NqBAizNoUKzr9kzDaE9gC_KNzHyhY1ZiSZMw-D_qKrleZ6Q5slxtd8e0bjRCkpF67do1guNb3m5J_grqGJdaSicnfMnXDRjzujODUD7RExWqjwLXxKBY4XMP4clA1EEecg-_TwIT3QQDtfT4Iytb5CONLFkm9zc3q-J8957QS3zPVGxTxkhveFyRxP-jLA4_6prT7BbSfSWLQbaUpLXgbDN8UNxU6b2RUzRDCw0ynOzTSnpsy0" alt="uml diagram">
+<p>Running an <a class="term-reference" href="#term:onboarding-process">onboarding process</a> <strong>typically involves the payment of <a class="term-reference" href="#term:trust-fees">trust fees</a></strong>. The <a class="term-reference" href="#term:trust-fee">trust fee</a> amount to be paid by the <a class="term-reference" href="#term:applicant">applicant</a> is defined in the <a class="term-reference" href="#term:validator">validator</a>'s <code>Participant</code> entry:</p>
+<img src="https://www.plantuml.com/plantuml/svg/fPHTJuCm58Rl-HKdute9kcGOBio-c3CnSTdK2-zAUyQgVAKjkCNut-qemyq88x4tDATlt_Vf0JgIYWYLnv4rgcUIaWWX9ZkuSHpuu4njBR0oGjz9YD1RaZraAA0W4MT4yJI1EIAibSYfoWNsW4YW4Zuj2_H8WpUa2de-JULUAenX37sO2cIOA4uYMDCjnWHMQQfWgH4uvHb9L6cZ1DY3JS22eRQ3QZ3EFDoHE8lGmwFhk5w-4tftAe1aMSIfdf-IQhdouChH1tjwbkMUhpFCUobpVRYZoUHFrj-OF6p0u-6ahbVE_yAQTiCnOjiTkYuoQ6ARrkL56h5BQ0rWBoZuXfzqRAOHEp0MJIqhmbbThyrRoAuRUrRlzZjrhJZARSS9d8tJnETNKMTPLGTVEoLjZTYUpoUEEpZ94QaEWCNZmynVLIawH_y4_VxjuIFpW0ea2YL8uvpzE5jwlPIPbzykDPg3tB2qgglyua9-OVBhDhQAhH4chBnspFCR" alt="uml diagram">
+<h3 id="corporation-management"><a class="toc-anchor" href="#corporation-management" >§</a> Corporation Management</h3>
+<p><em>This section is non-normative.</em></p>
+<p>A <a class="term-reference" href="#term:corporation">corporation</a> is the VPR-level entity that represents an authority acting in the registry. It extends a Cosmos SDK <a class="term-reference" href="#term:group">group</a> (whose members and policies are managed by the group module) with VPR-specific attributes: a <a class="term-reference" href="#term:did">DID</a>, a <a class="term-reference" href="#term:corporation-governance-framework">corporation governance framework</a> (CGF), and lifecycle metadata. A <code>Corporation</code> entry has no <code>id</code> of its own — it is keyed by its underlying <a class="term-reference" href="#term:group">group</a> (1:1).</p>
+<p>A corporation interacts with the VPR in two complementary ways:</p>
+<ul>
+<li>as the <strong>controller</strong> of zero or more <a class="term-reference" href="#term:ecosystems">ecosystems</a> — i.e., the corporation owns the corresponding <code>Ecosystem</code> entries. The controlling corporation manages each ecosystem’s <a class="term-reference" href="#term:egf">EGF</a>, its <a class="term-reference" href="#term:credential-schemas">credential schemas</a>, and the root <code>ECOSYSTEM</code> <code>Participant</code> entries of those schemas.</li>
+<li>as the <strong>owner of zero or more <code>Participant</code> entries</strong> in zero or more <a class="term-reference" href="#term:ecosystems">ecosystems</a> — i.e., the corporation acts as <code>ISSUER</code>, <code>VERIFIER</code>, <code>ISSUER_GRANTOR</code>, <code>VERIFIER_GRANTOR</code>, <code>HOLDER</code>, or root <code>ECOSYSTEM</code> for <a class="term-reference" href="#term:credential-schemas">credential schemas</a> of those ecosystems.</li>
+</ul>
+<p>The two roles are <strong>independent</strong>: a corporation MAY control no ecosystem at all and only hold <code>Participant</code> entries in third-party ecosystems; or it MAY control several ecosystems and additionally hold <code>Participant</code> entries in others; or any combination of the two.</p>
+<img src="https://www.plantuml.com/plantuml/svg/VLDRQy8m57xFhpZeWnjCoIQpqWSnRPK9WmrbmuUzfEqH8xtHH5J6_llIHckbwbDplfplakHqB1NFrJQEoBXQoO17237Vmv1Is8bGhGb9_Gq62bfkccTfpfL84rYsW4i8DBA4zdJglGuf_1A0K8GsxdcSHMYNk-IFa0vCWbGUfCAuu2GgJwC8G_0FSA5PELNjm4eVPD3kh_pG7pHCa6c79iynFESspsaaswqnnyj482Hijb81XqnVaGX4nXDrnSyrVkvjF_TgJi_mlDiyp-IyYDMHy7cE0wXlLA2iv6UBnTTaNc_vIHvgMPzW4Qmnvj1-VYpzCvtR6bWMXfN6zsG-cyxkg7XD5NqAIdswefNAsyUxTqU3dJLUZXgi62U7Mdr2p7HrkwFY_UtJuCWwxjJnseO-a0tfBgatwtXDZ9qmeYcztgXuGXj4GdHtMNh7afcIcPACCGdBNyTy_m40" alt="uml diagram">
+<p>The same <code>Corporation</code> entry is the single entry point for the corporation’s governance (the CGF), authorization delegation (via <code>OperatorAuthorization</code> to one or more <code>operator</code> accounts), and trust-deposit accounting (<code>TrustDeposit</code>). See the <a href="#corporation-module" >Corporation Module</a> for the methods that manage <code>Corporation</code> entries.</p>
 <h3 id="did-indexing"><a class="toc-anchor" href="#did-indexing" >§</a> DID Indexing</h3>
 <p><em>This section is non-normative.</em></p>
-<p>The Permission registry is a can be used by crawlers to index the metadata associated with <a class="term-reference" href="#term:verifiable-services">verifiable services</a>.</p>
-<p>Search engines can iterate over the permissions, and index <a class="term-reference" href="#term:vss">VSs</a> by resolving the service identifier (at the moment a <a class="term-reference" href="#term:did">DID</a>, that could be extended in the future), verify if service is a <a class="term-reference" href="#term:verifiable-service">verifiable service</a>, and in such a case extracting their verifiable metadata, such as <a class="term-reference" href="#term:linked-vp">linked-vp</a> presented credentials.</p>
-<p>The index is particularly important for <a class="term-reference" href="#term:verifiable-user-agents">verifiable user agents</a>, such as social browsers, CDN enabled browsers… However, it can also be leveraged by <strong>traditional, form-based search engines</strong>, which may return simple links for accessing <a class="term-reference" href="#term:vss">VSs</a>.</p>
-<img src="https://www.plantuml.com/plantuml/svg/bP8nQyCm48Lt_OeZNcEgk10NKufBisGhb7INhKkYLhPJdMmda1zVIx8D8LqwwKxVtTDxe9oiCBQjDCldYagX4IfnXYVEeLVI7bbJV65fOV6Efb94ggd1u46HDPS520Aff9o7tepeDHeFob13zBWlPB6UPxQrnBEVKAwwuvyV4As2jAKLHEawJL7Uu6J2oJtUlNfOcAOdzphd1T_pcUzejDSE1NFcuVaQnxFR39H58on2qmtj7wdPD1h7rvVWCHiWDRf3s6mtIpYW1QtgRvHnTwBbc5CAA-vsat_iJf7yhh_FuAT5SmdDhVR8IuD3beVs95sa8CPSz91waio0ZatldBJQiXnhwJz6E7y1" alt="uml diagram">
+<p>The <code>Participant</code> registry CAN be used by crawlers to index the metadata associated with <a class="term-reference" href="#term:verifiable-services">verifiable services</a>.</p>
+<p>Search engines can iterate over <code>Participant</code> entries and index <a class="term-reference" href="#term:vss">VSs</a> by resolving the service identifier (currently a <a class="term-reference" href="#term:did">DID</a>, extensible in the future), verify whether the service is a <a class="term-reference" href="#term:verifiable-service">verifiable service</a>, and in that case extract its verifiable metadata, such as <a class="term-reference" href="#term:linked-vp">linked-vp</a> presented credentials.</p>
+<p>The index is particularly important for <a class="term-reference" href="#term:verifiable-user-agents">verifiable user agents</a>, such as social browsers, CDN enabled browser, or any service or AI agent that wants to search for a specific service and connect to it. However, it can also be leveraged by <strong>traditional, form-based search engines</strong>, which may return simple links for accessing <a class="term-reference" href="#term:vss">VSs</a>.</p>
+<img src="https://www.plantuml.com/plantuml/svg/bP8nQyCm48Lt_OeZNcEgk10NKufBisGhb7INhKkYLh5TwMmda1zVIx8D8LqwwKxVkzDxeDoICDIUDCldofP28vp46PuuXrv9EhAw-CAIOF4-Q5If6b4H63meI-Qo0651AYbdrPiHlKRZGHbgY1xtXIpMisPRIJnxXNBL7V_yW6WLLfDTGPIkqnJb3KucdDpZtQk7XQbxwrxdlE1xFlET7UsrGy6SUNY-nl7iDWD5Q0GXrDtG_XMRJTeulhu4aza0RQqxXCrsiuG34cXLVQECkyOknw1IaBYRJVunEsNoi_u-WvyMpIKqjxj7NXeSmZoqZNIPmZBcieVOqyeCxB7kdPDM4yknalvhXFCN" alt="uml diagram">
 <h3 id="business-models"><a class="toc-anchor" href="#business-models" >§</a> Business models</h3>
 <h4 id="trust-deposit"><a class="toc-anchor" href="#trust-deposit" >§</a> Trust Deposit</h4>
 <p><em>This section is non-normative.</em></p>
-<p>In a <a class="term-reference" href="#term:vpr">VPR</a>, each <a class="term-reference" href="#term:account">account</a> is associated with a <a class="term-reference" href="#term:trust-deposit">trust deposit</a>.</p>
-<p>This <a class="term-reference" href="#term:trust-deposit">trust deposit</a> is automatically funded through transactions involving <strong>trust operations</strong>, such as:</p>
-<ul>
-<li>Paying trust fees between participants when enforcing ecosystem governance rules for services, credential issuance, or presentation…</li>
-</ul>
+<p>In a <a class="term-reference" href="#term:vpr">VPR</a>, each <a class="term-reference" href="#term:corporation">corporation</a> is associated with a <a class="term-reference" href="#term:trust-deposit">trust deposit</a>.</p>
+<p>This <a class="term-reference" href="#term:trust-deposit">trust deposit</a> is automatically funded through transactions involving <strong>trust operations</strong>, such as onboarding processes, credential issuance, or presentation…</p>
 <p>The trust deposit is fundamental to the <strong>“Proof-of-Trust” (PoT)</strong> mechanism of the <a class="term-reference" href="#term:verifiable-trust-specification">Verifiable Trust Specification</a>, and it operates as follows:</p>
 <ul>
-<li>The more you use the <a class="term-reference" href="#term:vpr">VPR</a>, the more your <a class="term-reference" href="#term:trust-deposit">trust deposit</a> grows.</li>
+<li>The more a <a class="term-reference" href="#term:corporation">corporation</a> uses the <a class="term-reference" href="#term:vpr">VPR</a>, the more its <a class="term-reference" href="#term:trust-deposit">trust deposit</a> grows.</li>
 <li>Trust deposits <strong>generate yield</strong>: block execution fees are distributed not only to network validators, but also to <strong>trust deposit holders</strong>.</li>
 <li><strong>network-level penalties</strong>: If a participant violates the <a class="term-reference" href="#term:governance-framework">governance framework</a> of the <a class="term-reference" href="#term:vpr">VPR</a> or engages in <strong>fraudulent activity</strong>, their <strong>trust deposit may be partially or fully slashed</strong> by the <a class="term-reference" href="#term:vpr">VPR</a>'s governance authority.</li>
 <li><strong>ecosystem-level penalties</strong>: If a participant operates within an ecosystem (e.g., as a <a class="term-reference" href="#term:grantor">grantor</a>, <a class="term-reference" href="#term:issuer">issuer</a>, <a class="term-reference" href="#term:verifier">verifier</a>, or <a class="term-reference" href="#term:holder">holder</a>,…) and <strong>fails to comply</strong> with that ecosystem’s governance framework (EGF), their <strong>ecosystem-specific trust deposit can be slashed</strong> by the corresponding ecosystem governance authority.</li>
@@ -389,32 +411,9 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <li>Holding a large trust deposit <strong>does not grant governance rights</strong> in the <a class="term-reference" href="#term:vpr">VPR</a>: participants who generate high transaction volume <strong>cannot gain control</strong> over the governance of the <a class="term-reference" href="#term:vpr">VPR</a> solely through usage or deposit size.</li>
 </ul>
 <p>This system ensures that participation in the trust ecosystem is backed by economic accountability, reinforcing the integrity, governability and verifiability of the <a class="term-reference" href="#term:vpr">VPR</a>.</p>
-<h4 id="object-creation"><a class="toc-anchor" href="#object-creation" >§</a> Object creation</h4>
+<h4 id="onboarding-process-trust-fees"><a class="toc-anchor" href="#onboarding-process-trust-fees" >§</a> Onboarding Process Trust Fees</h4>
 <p><em>This section is non-normative.</em></p>
-<p>The following operations <strong>only require payment of network fees</strong> (no trust deposit is involved):</p>
-<ul>
-<li>
-<p><strong>Trust Registries</strong>: requires paying only <a class="term-reference" href="#term:network-fees">network fees</a></p>
-</li>
-<li>
-<p><strong>Credential Schemas</strong>: requires paying only <a class="term-reference" href="#term:network-fees">network fees</a></p>
-</li>
-<li>
-<p>Updating the <strong>governance framework documents</strong> of an ecosystem trust registry</p>
-</li>
-<li>
-<p>Updating a Credential Schema</p>
-</li>
-<li>
-<p>Updating a Trust Registry</p>
-</li>
-<li>
-<p>…</p>
-</li>
-</ul>
-<h4 id="validation-process-trust-fees"><a class="toc-anchor" href="#validation-process-trust-fees" >§</a> Validation process trust fees</h4>
-<p><em>This section is non-normative.</em></p>
-<p>We’ve explained in the <a href="#credential-schemas-and-permissions" >Credential Schemas and Permissions</a> section above what is a validation process.</p>
+<p>We’ve explained in the <a href="#credential-schemas-and-participants" >Credential Schemas and Participants</a> section above what is an onboarding process.</p>
 <p>The table below summarizes the possible combinations of applicants and validators:</p>
 <table>
 <thead>
@@ -477,24 +476,24 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 </tbody>
 </table>
 <ul>
-<li>(1): if <em>issuer onboarding mode</em> is set to GRANTOR_VALIDATION_PROCESS.</li>
-<li>(2): if <em>verifier onboarding mode</em> is set to GRANTOR_VALIDATION_PROCESS.</li>
-<li>(3): if <em>issuer onboarding mode</em> is set to ECOSYSTEM_VALIDATION_PROCESS.</li>
-<li>(4): if <em>verifier onboarding mode</em> is set to ECOSYSTEM_VALIDATION_PROCESS.</li>
-<li>(5): if <em>holder onboarding mode</em> is set to ISSUEr_VALIDATION_PROCESS.</li>
+<li>(1): if <em>issuer onboarding mode</em> is set to GRANTOR_ONBOARDING_PROCESS.</li>
+<li>(2): if <em>verifier onboarding mode</em> is set to GRANTOR_ONBOARDING_PROCESS.</li>
+<li>(3): if <em>issuer onboarding mode</em> is set to ECOSYSTEM_ONBOARDING_PROCESS.</li>
+<li>(4): if <em>verifier onboarding mode</em> is set to ECOSYSTEM_ONBOARDING_PROCESS.</li>
+<li>(5): if <em>holder onboarding mode</em> is set to ISSUER_ONBOARDING_PROCESS.</li>
 </ul>
-<p>Validation process is started by the applicant.</p>
-<p><em>Example of a candidate <a class="term-reference" href="#term:issuer">issuer</a> (<a class="term-reference" href="#term:applicant">applicant</a>) that would like to be granted an ISSUER permission for a credential schema of an ecosystem, by a <a class="term-reference" href="#term:validator">validator</a> that has a ISSUER_GRANTOR permission:</em></p>
-<img src="https://www.plantuml.com/plantuml/svg/hLRBRjim4BphAnRfeKdW204A54NGbzlaOA2786uC5F25bbOsKOfKIIfk_hv3Mf9bAqtLeeOFbhsxipipNFgZyyBwkbI9ouHYAiLFUdDvILkP-qqYCcyidKohIibCQB_KfzAvcYtXAPUvy7osrDCiCxNs9oGSTQ7DbpIonk9-UfZ_oPgjGr3I5bW85OADtHTOMmGQ6zBdCRkBMSn7fVKxxmARBvEa0ZCoanMYKOUjBAHOWQFRUeKUwOxNqddxkCk-lQCNhufLldgT90CIBYxUXuWhoYnZNjAyfOSTdZGQPFlD7f-IKEpjnSL1IY-SDL3J8KgNSXpRrCYJ0RkniJrfG3DQS-R9cxOA6bhCwNfsJGLGSfAwLp-js9PBlMeWf5wJ2B6VJLcsjH0s18wzze67ISJm9fXs6yxJ4QtFQ1kKGkULDHbplkErrwpCtwLfclIoXbMK4Vb0crtYKiEmz12Cy4X-mz3TcKm6Peyf8Ud8Si7M1ahGKiaZEB3yeyRGeNzJ4DuWmrkZbXgVUmYYhKIYaVuKFA4t9zVwR0HLZX6yJza36ZGV9MyAZsXwbujuha34X1vDJS9o9AWjTpJ0pfKJAEPjZNcHyeJ00wJjHcQRwCJSH9XMRnjF8b9m48MctJ7_C9O757pU4fQTKGySaOC3rWo9wXLzvqVtBwgQhMRhDhAAj0IUGcNCiU9k58u7BVmscy_lR-uek0g31VR-XzXZ6dzEsSQP2dbn1lWTGnn9gWqMby616QprIH-9Njp4rnMTdfig64IeypDGKM6bHBG2I6ORZX8yAHLvuRuxz51MYf_SQuDPfkWxzayA37jPXftQ66MfRosw9EadX4rMIAK2L65iwIQHll2OcwmkOLmNLiYVMOTUeK2hFlICJOValwRbxyVzPceRjJgOjxjmKvgzL8gqsRRN2uxDq6WO893MROFeViZSMw57Drnx1mRN-VxAmYe72Zo-c7wPNK-_tbmlTGEz1pnrPn6psszfl0eFk6q0ht3zPYoXsivl1RCRiqF0VTZUmrcRA_BtCozrEAKe7ccBrWb9EImXXNBTCN3PXakH9X_X6_ol-WK0" alt="uml diagram">
-<p>The <strong>total fees</strong> paid by the applicant consists of:</p>
+<p>Onboarding process is started by the applicant.</p>
+<p><em>Example of a candidate <a class="term-reference" href="#term:issuer">issuer</a> (<a class="term-reference" href="#term:applicant">applicant</a>) that would like to obtain an <code>ISSUER</code> <code>Participant</code> entry for a credential schema of an ecosystem, validated by a <a class="term-reference" href="#term:validator">validator</a> that holds an <code>ISSUER_GRANTOR</code> <code>Participant</code> entry:</em></p>
+<img src="https://www.plantuml.com/plantuml/svg/hLPTQzim57tthxYi3sjA6mg3CSgwDLlA28mIcZKm23IABSUYikH9ShFkr-z8SHotJbDtBEGXDlVhd7lklRcmZXbNvZAoCPESSlQRFfoUqaeaBejOxBIXDuEYa29coitKeR2sv8Rmb8Y4ETwRgK4SwrAvDyGirQRLI-eOOtepUEp_nUYLXL6q2J1bqXjhimsmD33KnhjFWdTjCvrqScjMNXjMBwEe03CY5WMi4OSRaGgs04VZSe4QwPelXNNcOUqzlgQ3T-aYMRoFeXO99oUVlCKP1RP9guLc9X5gIONHCRSMVBjiMqBamtqyELaxnOQ396ARg3Hk5COLIW0sNTmYECpEQNnvDHnTVUkrwwX3xebLfKkYLYi2YYt3A4mhnMD7JjFzvZrD9pGS3Ib5meI4cgawrss3q7xjq7mxKuigl-U6-K1VTPvl4WcjsbK5JCsgsax4GGrwPZEUz3lW6j7Aqm5OeJqyMRTdDn2HdFVx_QWHe1rGQfOymtc8x39XIIJW2fpTUwKzq4w2RaL2XgVSM5zTpZlGOVYl4lWz59qIlk356Ird2hztGugrARHXWJfMIUSG_A4uAvQgru52os6yTTbcrmKtGITLu0u8rhwmvmLqUKmFkYHcC12gZXR0kEoP8Jb6HvqfGG9STmYWbN6LYJWBCavqIBVHWmap3nUCFDAl5yhdhdmWu7wT66wrlESXivV2agDlvOBk-8FzbrRhbO9KCb7K_FZ8mB7WDHIe6sq6I4FpqMHoStazftc3l7cr5lw70Bg0UAxRllfAkX9-0G-c1e2Uj5TfR46DAMeTa-Dc9Zgu39ypEZpIXTSwaqSzq59W_OHiAJBfbTz4qAcGv9YziwWXBoJVkI1RM0QeEzHF4cmxaVi5NObcfiO6LPA0FB7rKY6bJvLgazlZG9z_J7HSvcY0zJlcPTOn3Zx0HWdeRIZQEx-QbjV3_RaPp2RS-ihtQVHMIb9w1R0WM_pXBykkiLYV7DFDkVLISyyiileeGlBJmVVHSF3ZSeXZMUVtRTwNlXSkyIEQgpBESFzZBj30jVHIpcsNrO8s-Es-TzIgrO_kePbhZXwjvFKgwS-KdsPa2vm6MVdZcI28ODBM8sBZZEUi7rr0K_YdznS0" alt="uml diagram">
+<p>The <strong>total fees</strong> paid by the applicant consist of:</p>
 <ul>
-<li>The validation <a class="term-reference" href="#term:trust-fees">trust fees</a> defined in the permission of the validator participating in the validation process, <strong>plus</strong></li>
-<li>An additional amount equal to the <code>trust_deposit_rate</code> of that validation <a class="term-reference" href="#term:trust-fees">trust fees</a>, which is <strong>allocated to the applicant’s trust deposit</strong> when the validation process begins.</li>
+<li>The validation <a class="term-reference" href="#term:trust-fees">trust fees</a> defined in the validator’s <code>Participant</code> entry (the one acting as the validator in the onboarding process), <strong>plus</strong></li>
+<li>an additional amount equal to the <code>trust_deposit_rate</code> of that validation <a class="term-reference" href="#term:trust-fees">trust fees</a>, which is <strong>allocated to the applicant’s <a class="term-reference" href="#term:trust-deposit">trust deposit</a></strong> when the onboarding process begins, <strong>plus</strong></li>
 <li><a class="term-reference" href="#term:network-fees">network fees</a> (not part of the escrowed amount).</li>
 </ul>
 <p>Example, using 20% for <code>trust_deposit_rate</code>:</p>
 <img src="https://www.plantuml.com/plantuml/svg/NP112i8m44NtSugXBgNGkh3GXRIWDwWxDp49McsRa4ce8DxT6DjY70OIVdxU7wOYounrVGVLSYFEEeazUs2-oJ8SMs6lW02W6R-pYyIarhfhEHjiWeom9NBIuAhO5eKK-0JqfSutoQstOisvSf6LJPvG9vk6cEP8GNpzVM-C8ujxgHMrln0hOiewXe3l6N8WRjGO3IA3130Fb9fqDudb1vPd4sqn-FSvk8po02evYB32x_a6" alt="uml diagram">
-<p>Upon completion of the validation process, <strong>escrowed trust fees are distributed to the validator</strong> as follows:</p>
+<p>Upon completion of the onboarding process, <strong>escrowed trust fees are distributed to the validator</strong> as follows:</p>
 <ul>
 <li>A portion defined by <code>trust_deposit_rate</code> is allocated to the <strong>validator’s trust deposit</strong>.</li>
 <li>The remaining amount is <strong>transferred directly to the validator’s wallet</strong>.</li>
@@ -502,22 +501,22 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <img src="https://www.plantuml.com/plantuml/svg/NL3B3e8m4BptApPS3GbmCXmC6WtnZZSlQsaG1KgwIp0n_Blb6N1ww6GwCzqs8aR3JLc8Q64aiL1GuWVymFEWpLD-2b6ZV6EcmBaIDSf0RB1YRU3a01Ba6Nm5MEZ7IqcshXYEKkgcukaS9qEFE-_sjZcvqI1r_yd4DCHmLhMcVCvpkYq8DWMTcECNaaQtcylL80cBaO5ht8Ej3FiUtnkBB9-NiAzn1mU6wraNcTDmFOA8L9KEVpZkFm00" alt="uml diagram">
 <h4 id="pay-per-trust-fees"><a class="toc-anchor" href="#pay-per-trust-fees" >§</a> “Pay-Per” trust fees</h4>
 <p><em>This section is non-normative.</em></p>
-<p><strong>Pay-per-issuance</strong> and <strong>pay-per-verification</strong> <a class="term-reference" href="#term:trust-fees">trust fees</a> are defined <strong>at the permission level</strong> for each role within the ecosystem.</p>
-<img src="https://www.plantuml.com/plantuml/svg/ZPFBRi8m44Nt_eeHMIEP8g3AeWg4gEgkwclls4DmcmUoJKfLyUyrIGW5oORP9DBSkNDydKJQC6MsHKwY_arpbYCKR0VtbCAt56PDW6mO_s8PmY3XbVxH1Wi8vZ24MA70qaYMmojVOy4W60s0QU0QVWa1MrNwYTpSD0alLMNW6LKXjPPLsJWP1S5ubOfqQXsXAo55Y3jMR78CyMWyxzjsVCjAZc1R9eGHXRTttNThL78bEJDsHQUuEodsPzHFrWaLF2fMcigIB5pe5zGoSz3ARE72d5oZdFWXW_XMk4u_cyvcAC156ljOngx4FXhj_yoMvrYMfoExmAfTcTNPqdjvrqY2vCPWwdw2qfIkg8idwRRjYItxWGw73uSR3o4xdDb6gjiDczwUs7QZQgFtAO-6jT-mRWrxPAzbXALe_lFs-GS0" alt="uml diagram">
-<p>Entities acting as <strong>issuers</strong> or <strong>verifiers</strong> for a given credential schema <strong>may be required to pay trust fees</strong> based on the schema’s configuration and permission tree.</p>
-<p>If trust fee payment is required, the entity <strong>must execute a transaction</strong> in the <a class="term-reference" href="#term:vpr">VPR</a> to pay the appropriate <a class="term-reference" href="#term:trust-fees">trust fees</a> <strong>before issuing or verifying a credential</strong>.</p>
+<p><strong>Pay-per-issuance</strong> and <strong>pay-per-verification</strong> <a class="term-reference" href="#term:trust-fees">trust fees</a> are defined <strong>on each <code>Participant</code> entry</strong> for each role within the ecosystem.</p>
+<img src="https://www.plantuml.com/plantuml/svg/ZPD9QyCm48Nl-XL3V0ue3KcA3oKhfRVIxJwM9evQRqYAcrBotwlQZhE0dCn5WddpzF4aJOr5RRTfmgRjpWXC25BSmJtdyAsatJ1W1OelZ0bwAv6R7sCfXM06VLXeafHPXGcyYWsb2C6W1sX06FXb35pbqIS9UzCalEIvXMT7eeGgCBELbTKG3DUHZCRE4fgIIeQqmxH8AAI3ywnjAsEsc0a2rx8X33YylPksMv9MQoNGgZnh57T7nVuC-yavaOP7xN1oHpBtiLzYgzY3g-AvZtDq3NFKJHaiRgPh1YRZoOGa-50NNJ13NsOVbVOqjUKvbmDgq2wvIbzgPRpilBzhAC7grcZATeJpYA-v3sZL7BTdhjmZxVSV_Yyz1A49BHamzH75qP-vVYMhq--K7YpBAvPbRTbITvjEAPFLXw_NFm00" alt="uml diagram">
+<p><a class="term-reference" href="#term:corporations">Corporations</a> acting as <strong>issuers</strong> or <strong>verifiers</strong> for a given credential schema <strong>may be required to pay trust fees</strong> based on the schema’s configuration and <code>Participant</code> tree.</p>
+<p>If trust fee payment is required, the entity <strong>must execute a transaction</strong> in the <a class="term-reference" href="#term:vpr">VPR</a> to pay the appropriate <a class="term-reference" href="#term:trust-fees">trust fees</a> <strong>before issuing or verifying a credential</strong>, else HOLDER agent will not accept the operation.</p>
 <p>Key Points for “Pay-Per” Business Models</p>
 <ul>
 <li>
-<p>For a given credential schema, <strong>ecosystem</strong> and their participants may define <strong>pay-per-issuance</strong> (or <strong>pay-per-verification</strong>) <a class="term-reference" href="#term:trust-fees">trust fees</a> in their respective permissions.</p>
+<p>For a given credential schema, the <strong>ecosystem</strong> and its participants may define <strong>pay-per-issuance</strong> (or <strong>pay-per-verification</strong>) <a class="term-reference" href="#term:trust-fees">trust fees</a> on their respective <code>Participant</code> entries.</p>
 </li>
 <li>
-<p>In such cases, a participant ISSUER (or VERIFIER) <strong>must pay</strong>:</p>
+<p>In such cases, an <code>ISSUER</code> (or <code>VERIFIER</code>) <code>Participant</code> <strong>must pay</strong>:</p>
 <ul>
-<li>The corresponding <strong>issuance</strong> (or <strong>verification</strong>) trust fees for each involved permission;</li>
-<li>An additional amount equal to the <code>trust_deposit_rate</code> of the calculated trust fees, allocated to the <strong>applicant’s trust deposit</strong>;</li>
-<li>An amount equal to <code>wallet_user_agent_reward_rate</code> of the calculated trust fees, used to <strong>reward the Wallet User Agent</strong>;</li>
-<li>An amount equal to <code>user_agent_reward_rate</code> of the calculated trust fees, used to <strong>reward the User Agent</strong>.</li>
+<li>the corresponding <strong>issuance</strong> (or <strong>verification</strong>) trust fees for each involved <code>Participant</code> entry along the <code>Participant</code> tree;</li>
+<li>an additional amount equal to the <code>trust_deposit_rate</code> of the calculated trust fees, allocated to the <strong>payer’s <a class="term-reference" href="#term:trust-deposit">trust deposit</a></strong>;</li>
+<li>(optional) an amount equal to <code>wallet_user_agent_reward_rate</code> of the calculated trust fees, used to <strong>reward the Wallet User Agent</strong>;</li>
+<li>(optional) an amount equal to <code>user_agent_reward_rate</code> of the calculated trust fees, used to <strong>reward the User Agent</strong>.</li>
 </ul>
 </li>
 </ul>
@@ -527,18 +526,18 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 <li>A portion defined by <code>trust_deposit_rate</code> is allocated to the <strong>participant’s trust deposit</strong>.</li>
 <li>The remaining portion is <strong>transferred directly to the participant’s wallet</strong>.</li>
 </ul>
-<div id="note-77" class="notice note"><a class="notice-link" href="#note-77">NOTE</a><p><strong>Wallet User Agents</strong> and <strong>User Agents</strong> that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
+<div id="note-77" class="notice note"><a class="notice-link" href="#note-77">NOTE</a><p>Agents that implement the <a class="term-reference" href="#term:vt-spec">VT spec</a> <strong>must verify</strong> that the ISSUER or VERIFIER has fulfilled the required trust fee payment.<br>
 If not, they <strong>must reject</strong> the issuance or verification request.</p>
 <p>Note: The <strong>User Agent</strong> and <strong>Wallet User Agent</strong> may refer to the same implementation.</p>
 </div>
-<p>Distribution example for the issuance by ISSUER #C of a credential, using the permission tree above, 20% for <code>trust_deposit_rate</code>, 10% for <code>wallet_user_agent_reward_rate</code> and <code>user_agent_reward_rate</code>.</p>
+<p>Distribution example for the issuance by <code>ISSUER</code> #C of a credential, using the <code>Participant</code> tree above, 20% for <code>trust_deposit_rate</code>, 10% for <code>wallet_user_agent_reward_rate</code> and <code>user_agent_reward_rate</code>.</p>
 <img src="https://www.plantuml.com/plantuml/svg/bTDDRu9040RW-_wAYHuR36AhnaCZ_OZnBk7IomZRBIs2ONT3cyR_tks2XXqaQRdmCVCEJtPXBHLMIXzojhvSoGHp3WVyXANlGvsbweq1OqTCFb1m63qdfVoIYXzW78u09QWAnhFNVRgVmpS3SvJxTvueqmbXafIwK6qRjdLxlAYR9UmYQP-SI6vNQQdWYHzBcPtJAYNne1C_TO1RAJMlO5DXeKfZUx03Ca5qsut3oqINPyRV3kXChi_BXCCpyQcZexZnOnDhxnRpnOAd5EZwR2jPGY-O3Ycl8Us8tZhEEYESXOoaiOM2jmAD11Y5Zb0ZtU3f91ZWcMZVfv4keZyXk8ijnZpd2WYnxXbZWgp_euolCki_EDbvkxpAkpSVxyg-oBTDRYqJjdP7IgafQMnYasl5Uh3wExJTwLLdWzcQ5wdzrPlp3m00" alt="uml diagram">
-<p>Distribution example for the verification by VERIFIER #E of a credential issued by ISSUER #C, using the permission tree above, 20% for <code>trust_deposit_rate</code>, 10% for <code>wallet_user_agent_reward_rate</code> and <code>user_agent_reward_rate</code>.</p>
+<p>Distribution example for the verification by <code>VERIFIER</code> #E of a credential issued by <code>ISSUER</code> #C, using the <code>Participant</code> tree above, 20% for <code>trust_deposit_rate</code>, 10% for <code>wallet_user_agent_reward_rate</code> and <code>user_agent_reward_rate</code>.</p>
 <img src="https://www.plantuml.com/plantuml/svg/bPHBSu8m58Nt-HLtPDcH2VM1TT6HLiTnxsFJJO18QL4Saa0x7VzxCL1B4kWZ6mZddZiV9uyPuoJZuf2WsVMD1IIXS21lCC4OYZZapmWGEf7WbKGKUeiWPU-CqmDONWy80vw1DTZxeJ-63mJbIFqN6l2o4hmWICMHrsMarkLuuZVE6DOR9Z-TDUCw4up3d9vI5d_PUQZvXmtxkK6uOapG39OPEVAqX7kG3U98mrij5RuuQl9fxJMVYHT72jxbxnGw7Svwh6prp1sxBWrrG9LFbkePtdPIja7A5aQEpMLeecvf5k_ZPf9psIRNazogIUPwaexTjTBRjYnp8qji3tzZj1QLzph7sCTxh9Ege7MnYjjtx-n95syRRjt5s01E9_M6bOHUH6iEGJJCZQTm2g8l-z0UTKLQUar6GGmws-cYsv4aeHmqoCAWt6cOnRyuTwsWnLz84VfUkNxMloylXway35ZMwMeULMgh65VYo133YoWFZ2mOcBql5O9KTjjjbOiVz0lPTUjCrIs3PlGOodkvUdu2" alt="uml diagram">
 <h2 id="governance-of-a-vpr"><a class="toc-anchor" href="#governance-of-a-vpr" >§</a> Governance of a VPR</h2>
 <p><em>This section is non-normative.</em></p>
 <p>A <a class="term-reference" href="#term:governance-framework">governance framework</a> must define the governance rules that apply to a <a class="term-reference" href="#term:vpr">VPR</a>.</p>
-<p>A designated <a class="term-reference" href="#term:governance-authority">governance authority</a> is responsible for <strong>enforcing these rules</strong> and, when necessary, <strong>applying financial sanctions</strong> to participants who violate the rules.</p>
+<p>A designated <a class="term-reference" href="#term:governance-authority">governance authority</a> (aka a council) is responsible for <strong>enforcing these rules</strong> and, when necessary, <strong>applying financial sanctions</strong> to participants who violate the rules.</p>
 <div id="note-78" class="notice note"><a class="notice-link" href="#note-78">NOTE</a><p><strong>Ecosystem Governance Frameworks (EGFs)</strong> operate <strong>independently</strong> from the <a class="term-reference" href="#term:vpr">VPR</a> <a class="term-reference" href="#term:governance-framework">governance framework</a>.</p>
 <p>While the <strong>VPR governance framework</strong> defines the global rules for operating the Verifiable Public Registry (e.g., trust deposits, fee distribution, slashing conditions), each <strong>ecosystem</strong> must define its own <strong>EGF</strong> to govern roles, permissions, credential policies, and compliance within its specific domain.</p>
 <p>This separation ensures that ecosystems remain autonomous and can tailor governance to their unique needs, without being constrained by the global rules of the VPR.</p>
@@ -547,35 +546,53 @@ If not, they <strong>must reject</strong> the issuance or verification request.<
 <p>For simplicity, the data model is presented using an <strong>object-relational structure</strong>. However, this representation may not be optimal for all implementation scenarios.</p>
 <p>Implementors are responsible for <strong>adapting the data model</strong> to suit their chosen architecture.<br>
 For example, a <strong>key-value store</strong> may be more appropriate for a <strong>ledger-based implementation</strong> than a relational model.</p>
-<img src="https://www.plantuml.com/plantuml/svg/hHZPZjisy5rV8UnJco91qXP5uASOQ-_6QB9Us8w1eYW8MgHjPYLH9IdlKUJVEpn4KHQrQpTziQMPuToSGn-amaBLHPvyy4yompbD2_oGld_xDhrdHEsJX9QAgSVqOYLggHPqnwGIZnSfbgaIwJz9chvYP9JMh5I__GflFn7z2ZIitEdNJ52iA80KAoX8AYeDBJXXMzO3Ov7jsQ4FliCXIvmf8487AYJZvIW5qHgSut9NuntrfDzQvQyvK9UupEYLm0Mzv-9kROyRItRRGyoKkEwXNBgZuWKv4vxL1U2T87Awe9v10Aj57huIjWDw90KBhVRgN0fAz3FEbzcU5jZeaCdJLJWlJbybBv4qaa8bcPGr5MWdSAcuG0USCu8LkD0-WgQeee9nO5VMnGOyQhsi9PzxpCawKyPfv7kUavE9dIAyt70i27W2WIyXb3C3dtlmPu1sTEcTM3jC_unJg7VYeu7twIl1Cas5fQGgaaOutt71rBxeNg6wI2zi_enhjGUA9sFzBSzPzhZWEJLf9N5bwy5ikVmoNS33UhgONStWCKp9GKODa--uY00JeCx8w7BQRT57w87VQUOR3eTngM5qkwMsocm5BxfoMrmDDkKXqXgg_HKBix6GyS9OEB-Tti3VzM9yivelq7hyQJOPhsRp6tIxc5zEbqj0JY_dop-Mg-dd6Dg79fuVHjZXVnSMIoqZQkz4sUZ7HTnE5vy13y1FZgbFYn-Mazz_JCTPncjNAh5z1gPXVHMyhcmbrKzTv1nk8OPIqKakGymnW9wCVb3Jv0wfnuhAKTey_lcNmT27YWbpgXjnk3dkVfFQuaEnw-Mmu8FqeeCJjrGKK1-0g7DYGJCkY3bNONkNqbV0ka2Ts_2S1VTmUz6MKbCqmup-hyPDQCcBSU6ZGh3HYsXmS8cmeV3rpwVBhQquOrrmLg2cDSu2JHNIkXkEgo_mSpcVwJozcerNeHBJXsmFlP0ke0WO3W_HoME39UtNjhzhhY9WC9KUloCp05cMl_ni2aX58eN7k59xlrkEccRG-37mAA21JajiGXAOTqNfjOwNCMsxCwODndWmZi-6CVHWFqiVH92aaInrOqEiD7_Nj4U-maZP0yiSotqFAcY56Hcgn6TLwIPMjeV3RP77ZLiFS3s4xT1P_1IX5PTCXI1d1ugWh34HZEz5NMqh157l0q40T3ETLyY6jq_Y38NvAQ86uBDQ20XutzWM5JyewwB00fBTzDJZSQzn8A1brYaD4KVsYTe-klQ1MghczeDDncYJZj3P9hERQprks9OpdUXgeZlDZNc9rjqbxIHsE17NZ9oNoSy924gw5XCjMn59OG4s_hMrrpnQ5dst3x4nPTZhvOimgAC6nZNVnDsy4E02a9yNuFdZ_DFaQCwxpla6vsii6DxaLDgURRSihQfRIzosqFp1weaaUw9XjlI9Jzud33-27-Np_CvODKxa-E8MSgvctytfnTtbH3vAVmM8bOGE0iaz5bIBgEamaMd1GqYjpYEZENcUR9Fpx0u9UW_Zg9KQaDOIJ8O56egOepZYTO_pd2hqFDstesyW4olQVWAnwxmLt1hQzq-MOrRecn30XXl4O7-m5J_M80qcrYGDDUhLLpi_ltxDOU8OfIxpasRexi0fJM0gkNXt0U3NwSNRDs-WS1AzubUq92Xd1LD9qWmH76WUHEVLSHsbt0tAcjfWZaT1c8_y46Tcdc72OAwpb9hKAFZEAEY5sXaEtU-PeZcJe6ec1tXs5cJ3DGqzPMVvKGerlU9ko0ezrk1RCzkppIOmVBgbE4ZaMVWDmllVcWSRmWZoHBSNcUXrGLi4HHsCi1k3DhDgeE06uwCM1D5pjOfug0ujI35Ssi6XuUUyfa2k4aw0FmOQmT8DmlKkpwWqqcMeiEr_8DPsHjJedbX4Jm5NGrlfKIfV8L-WSpVTNl8NQBj4oR7_s_pNiqju1uOfEpT5kpj24qIzm_K4ycD5aaI9uuJPRG_6NThvCatq9yyUXTuUtETAsSby7VGmRrkCyTWWIdPndNotyGjItQPCfs1qq7xkQqzNTlnrGgsgv4Zc1_2B-Svj__y5" alt="uml diagram">
-<h3 id="trustregistry"><a class="toc-anchor" href="#trustregistry" >§</a> TrustRegistry</h3>
-<p><code>TrustRegistry</code>:</p>
+<img src="https://www.plantuml.com/plantuml/svg/pLdTRzis47_NNo7ugUtG8js6OV1JlTX9ZRLnOBi1Xc4GQ96ssKgYHbBEnx3_VSUZFYY9Sknb3tk9fRlZVP1tlpig7vGcKXTf4doedrHC4XQcv27y-U8YlETKxuE0PPhhnt0qYuLwL9gbev2eKClmho0Ctt0w3WkUwPz-XBVlg7bLMl9iPrvZoOXcGD8yPM0bpGqr5PHlUOzCPBpdXpuvra2D3amgBh9n2BOCEI7PhY0xLflxk_7qKiXSIA917dsDuHsz_P_uTor0EYDPpAuaITczaD_kx79qTxSz-FRMxwnhb-sOVCRELCH52lpI43tTK2yWe1KoSLyftu5yf2HteswEHJ9gdacoYlSi9VPirEakd7SmNvN88eMMN2UvKWMJqKwIJ0iP7KZ2AQQAVGHFevn9Ba1TLgGRs56xoyRokSjAMsVQE4ryBn9wid3fYCWsWaWAEn71Ni9Hpf6-gCcVWThofRVYhkJqrvGEzLPyH7fVFfSyDb94AQOzQKIIdP1SxzDs2HLfEBBvCodq7YIUCFfRaV3uSIaIXccbI6u1QhvQVPajuU5kjfnVpU7HJSb1HPMI5nGYq2IuCqPVJgiMiuGTn3UZV2DWCSaCZMstpABCLegqRRVX5H1JuZ9je6Q_VCUC4NAHOeIBszaD_5ml9pVhnJ9QtFooc2odyvlhw7Qvk9ojLi2SNIvMlwtMiyy-Tdqq_ln0OuV_t9WljT3KlZHbJzzludQs_0py-UBcKwcqJejNg-clhyD978kYX4fYdq6fYwzI5Bb5KlFKPYwW2Wb0HIkvK5WG83sXVu1fQXVfnvofSLWz_lu7SjX3pcqJQvyuL4vPtxImVDVitMhOy47LffqLjz3yeH9p0BRMaYM3labnOKviCOLlyaOuQbN5iKZkeOgZBMC8dcvc_ziWfomJwIIjJuSIT8yQibDC12Lg7ApJvjOYpyG0pnhSj35Q8gAHyHqrhh_0dyl5tEJhrNooTfsOFSHxw8bi2M206Xwy8z66ADR7k3yBeJra29LrtoESogpA7xv78Ccf1u1mAytkjs6fQWhLFZex2coGCnQh8t72ksBisfmNXhRTsVbfw8m7p_7eCRexsC_M1-dMoM2Yf3oB3EHAYBGLcvbZ8yeEt7R7JQxgFNHhtKd_SY3nWVwB1aVwjL1zQPKGjUzH9Si9fqCOVnR-LwTluuVwKzsHm8o6FORj_R5_5MMvK5oxf3AEoCEomNWuTPThUIlo28wvJmG3q2TDfaOsOVeYPQ0mcNdS07vSI0adtel7OVaNgY9DYOJomMxT7IIh3GIsYbjWuzd8lb3JePiUjj8Lda1C63Ic8_HCqx_C83FvD9zErhEfmIVJmsxmnO_eAwRgUmLajZji5voUbyf7BJZTmjZnGg77b0lgkCCMp_7HgkXl_90QXFR6iNeM17_qm2nOJmZbCEBm758zZC3pnyMdQMU8l4x4XYHtH7AoIPYo0u6zmXbVopjFUHMfVWmuAVx4t8Jf2vzyMK5zb3ogu_hEkCUSgF7PAywvdhrOqxCNenFrQ0cexKE55YDIUoAPCL6mOI7iwqDCuyuZPmazBhP9HFmjakmUSC9QTKGB1I73xHnmh9JewBedIS9qT5pEgSQriJsrfkq77_kjm1fk0lLX-xR8A7FldyCjOh13MCptjKZa-DeaIaSzXBMp-Tkt0gQOSLWcVb0Dz2qwOm5CEgFt8o2_3KSNxzu1SbBp-I1d6OqIdd8z824XPNXcxhCe6mJL-290xa6sNalRur2KexgHHavt28N9h1uVSTeQ5dGcIYjfHD79z-XaRTHEZz7zdckMSAM385O3EbjNTDGQkljfRnDZ_BvMVczhxMl5Ry9irbPtaU7LZSH1HRMA-WvJdu4D3oucvX1C4rA1kQ-OY03vns7xocAYpIicx0PkLKE2eovnZTPKSyfW39KrSqP7RRc76hnWrOVIqboj1DnKn7XaFZ5mfj0NvKPXMoSuOPjgL0KKM4RFdH9zUxvuXMk8FKsyH0mB5gSjySe6tGDhYiOCHMvf3KkU9jKjmbCaQny2J9jdR0-8T0CP4ElwzwoOuvp9He-iKnij3quGxpeT1BhdpcvxmCGnsQZ2Lsvglmxmk_hn1KvnunBpRRjJkRkjkHwMtwLLXH6Dq0WHmiKEKsGkQZGSpC91bchpMcXZAyG16bkRBRXkiUlfl5vjRWk6udfAEoO_m7RZ_rpixpy0" alt="uml diagram">
+<h3 id="corporation"><a class="toc-anchor" href="#corporation" >§</a> Corporation</h3>
+<p>A <code>Corporation</code> is the VPR-level entity that extends a Cosmos SDK <a class="term-reference" href="#term:group">group</a> with a DID, a governance framework, and lifecycle attributes. A Corporation may control <a class="term-reference" href="#term:participants">participants</a> in zero or more <a class="term-reference" href="#term:ecosystems">ecosystems</a> and may itself be the controller of zero or more <a class="term-reference" href="#term:ecosystems">ecosystems</a>.</p>
+<p><code>Corporation</code>:</p>
 <ul>
-<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the trust registry.</li>
+<li><code>did</code> (string) (<em>mandatory</em>): the DID of the Corporation.</li>
+<li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this Corporation has been created.</li>
+<li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this Corporation has been modified.</li>
+<li><code>archived</code> (timestamp) (<em>optional</em>): timestamp this Corporation has been archived.</li>
+<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of this Corporation.</li>
+<li><code>active_version</code> (int) (<em>mandatory</em>): active <a class="term-reference" href="#term:cgf">CGF</a> version.</li>
+</ul>
+<blockquote>
+<p>Note: a Corporation entry has no <code>id</code> of its own. Its primary key is the underlying Cosmos SDK <a class="term-reference" href="#term:group">group</a> (1:1, see the <code>group --- corp</code> link in the diagram above): a Corporation entry is created, looked up, and referenced by the id of the group it extends. Members and policies of a Corporation are managed by the underlying Cosmos SDK group module; the Corporation entry adds VPR-level attributes only (DID, governance framework, lifecycle).</p>
+</blockquote>
+<h3 id="ecosystem"><a class="toc-anchor" href="#ecosystem" >§</a> Ecosystem</h3>
+<p><code>Ecosystem</code>:</p>
+<ul>
+<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the ecosystem.</li>
 <li><code>did</code> (string) (<em>mandatory</em>): the did of the ecosystem.</li>
-<li><code>corporation</code> (group) (<em>mandatory</em>): <a class="term-reference" href="#term:group">group</a> that controls this entry.</li>
-<li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this TrustRegistry has been created.</li>
-<li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this TrustRegistry has been modified.</li>
-<li><code>archived</code> (timestamp) (<em>mandatory</em>): timestamp this TrustRegistry has been archived.</li>
-<li><code>aka</code> (string) (<em>optional</em>): optional additional URI of this trust registry.</li>
-<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of this trust registry.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): <a class="term-reference" href="#term:corporation">corporation</a> that controls this entry.</li>
+<li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this Ecosystem has been created.</li>
+<li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this Ecosystem has been modified.</li>
+<li><code>archived</code> (timestamp) (<em>mandatory</em>): timestamp this Ecosystem has been archived.</li>
+<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of this ecosystem.</li>
 <li><code>active_version</code> (int): (<em>mandatory</em>) active governance framework version.</li>
 </ul>
 <h3 id="governanceframeworkversion"><a class="toc-anchor" href="#governanceframeworkversion" >§</a> GovernanceFrameworkVersion</h3>
+<p>A <code>GovernanceFrameworkVersion</code> represents a single version of either an <a class="term-reference" href="#term:egf">EGF</a> or a <a class="term-reference" href="#term:cgf">CGF</a>. Its owning subject is identified by exactly one of <code>ecosystem_id</code> or <code>corporation_id</code> (XOR).</p>
 <p><code>GovernanceFrameworkVersion</code>:</p>
 <ul>
-<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the schema.</li>
-<li><code>tr_id</code> (uint64) (<em>mandatory</em>): the id of the trust registry that controls this <code>GovernanceFrameworkVersion</code> entry.</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the GFV.</li>
+<li><code>ecosystem_id</code> (uint64) (<em>conditional</em>): the id of the <a class="term-reference" href="#term:ecosystem">ecosystem</a> that controls this <code>GovernanceFrameworkVersion</code> entry. MUST be set if <code>corporation_id</code> is null.</li>
+<li><code>corporation_id</code> (uint64) (<em>conditional</em>): the id of the <a class="term-reference" href="#term:corporation">corporation</a> that controls this <code>GovernanceFrameworkVersion</code> entry. MUST be set if <code>ecosystem_id</code> is null.</li>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this GovernanceFrameworkVersion has been created.</li>
 <li><code>version</code> (int) (<em>mandatory</em>): version of this GF. MUST Starts with 1.</li>
 </ul>
+<blockquote>
+<p>Constraint: exactly one of <code>ecosystem_id</code> and <code>corporation_id</code> MUST be set.</p>
+</blockquote>
 <h3 id="governanceframeworkdocument"><a class="toc-anchor" href="#governanceframeworkdocument" >§</a> GovernanceFrameworkDocument</h3>
 <p><code>GovernanceFrameworkDocument</code></p>
 <ul>
-<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the schema.</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the GFD.</li>
 <li><code>gfv_id</code> (uint64) (<em>mandatory</em>): the id of the <code>GovernanceFrameworkVersion</code> entry.</li>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this GovernanceFrameworkDocument has been created.</li>
-<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of this trust registry.</li>
+<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of this governance framework document.</li>
 <li><code>url</code> (string) (<em>mandatory</em>): URL where the document is published.</li>
 <li><code>digest_sri</code> (string) (<em>mandatory</em>): digest_sri of the document.</li>
 </ul>
@@ -584,19 +601,19 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 <p><strong>General Info</strong>:</p>
 <ul>
 <li><code>id</code> (uint64) (<em>mandatory</em>): the id of the schema.</li>
-<li><code>tr_id</code> (uint64) (<em>mandatory</em>): the id of the trust registry that controls this <code>CredentialSchema</code> entry.</li>
+<li><code>ecosystem_id</code> (uint64) (<em>mandatory</em>): the id of the ecosystem that controls this <code>CredentialSchema</code> entry.</li>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this CredentialSchema has been created.</li>
 <li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this CredentialSchema has been modified.</li>
 <li><code>archived</code> (timestamp) (<em>mandatory</em>): timestamp this CredentialSchema has been archived.</li>
 <li><code>json_schema</code> (string) (<em>mandatory</em>): Json Schema used for issuing credentials based on this schema.</li>
-<li><code>issuer_grantor_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which an issuer grantor validation process expires and must be renewed.</li>
-<li><code>verifier_grantor_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which a verifier grantor validation process expires and must be renewed.</li>
-<li><code>issuer_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which an issuer validation process expires and must be renewed.</li>
-<li><code>verifier_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which a verifier validation process expires and must be renewed.</li>
-<li><code>holder_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which an holder validation process expires and must be renewed.</li>
-<li><code>issuer_onboarding_mode</code> (IssuerOnboardingMode) (<em>mandatory</em>): defines how permissions are managed for issuers of this <code>CredentialSchema</code>. OPEN means anyone can issue credential of this schema; GRANTOR_VALIDATION_PROCESS means a validation process MUST be run between a candidate ISSUER and an ISSUER_GRANTOR in order to create an ISSUER permission; ECOSYSTEM_VALIDATION_PROCESS means a validation process MUST be run between a candidate ISSUER and the trust registry owner (ecosystem) of the <code>CredentialSchema</code> entry in order to create an ISSUER permission;</li>
-<li><code>verifier_onboarding_mode</code> (VerifierOnboardingMode) (<em>mandatory</em>): defines how permissions are managed for verifiers of this <code>CredentialSchema</code>. OPEN means anyone can verify credentials of this schema (does not implies that a payment is not necessary); GRANTOR_VALIDATION_PROCESS means a validation process MUST be run between a candidate VERIFIER and a VERIFIER_GRANTOR in order to create a VERIFIER permission; ECOSYSTEM_VALIDATION_PROCESS means a validation process MUST be run between a candidate VERIFIER and the trust registry owner (ecosystem) of the <code>CredentialSchema</code> entry in order to create a VERIFIER permission;</li>
-<li><code>holder_onboarding_mode</code> (HolderOnboardingMode) (<em>mandatory</em>): defines how permissions are managed for holders of this <code>CredentialSchema</code>. ISSUER_VALIDATION_PROCESS means a validation process MUST be run between a candidate HOLDER and an ISSUER in order to create a HOLDER permission. HOLDER permission is used to check credential revocation status; PERMISSIONLESS means no onboarding is required to take place on the VPR (and thus an ISSUER cannot use the VPR to charge validation fees to candidate holders);</li>
+<li><code>issuer_grantor_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which an issuer grantor onboarding process expires and must be renewed.</li>
+<li><code>verifier_grantor_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which a verifier grantor onboarding process expires and must be renewed.</li>
+<li><code>issuer_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which an issuer onboarding process expires and must be renewed.</li>
+<li><code>verifier_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which a verifier onboarding process expires and must be renewed.</li>
+<li><code>holder_validation_validity_period</code> (number) (<em>mandatory</em>): number of days after which an holder onboarding process expires and must be renewed.</li>
+<li><code>issuer_onboarding_mode</code> (IssuerOnboardingMode) (<em>mandatory</em>): defines how permissions are managed for issuers of this <code>CredentialSchema</code>. OPEN means anyone can issue credential of this schema; GRANTOR_ONBOARDING_PROCESS means an onboarding process MUST be run between a candidate ISSUER and an ISSUER_GRANTOR in order to create an ISSUER permission; ECOSYSTEM_ONBOARDING_PROCESS means an onboarding process MUST be run between a candidate ISSUER and the ecosystem owner (ecosystem) of the <code>CredentialSchema</code> entry in order to create an ISSUER permission;</li>
+<li><code>verifier_onboarding_mode</code> (VerifierOnboardingMode) (<em>mandatory</em>): defines how permissions are managed for verifiers of this <code>CredentialSchema</code>. OPEN means anyone can verify credentials of this schema (does not implies that a payment is not necessary); GRANTOR_ONBOARDING_PROCESS means an onboarding process MUST be run between a candidate VERIFIER and a VERIFIER_GRANTOR in order to create a VERIFIER permission; ECOSYSTEM_ONBOARDING_PROCESS means an onboarding process MUST be run between a candidate VERIFIER and the ecosystem owner (ecosystem) of the <code>CredentialSchema</code> entry in order to create a VERIFIER permission;</li>
+<li><code>holder_onboarding_mode</code> (HolderOnboardingMode) (<em>mandatory</em>): defines how permissions are managed for holders of this <code>CredentialSchema</code>. ISSUER_ONBOARDING_PROCESS means an onboarding process MUST be run between a candidate HOLDER and an ISSUER in order to create a HOLDER permission. HOLDER permission is used to check credential revocation status; PERMISSIONLESS means no onboarding is required to take place on the VPR (and thus an ISSUER cannot use the VPR to charge validation fees to candidate holders);</li>
 <li><code>pricing_asset_type</code> (PricingAssetType) (<em>mandatory</em>): used asset for paying business fees. Can be TU (<a class="term-reference" href="#term:trust-unit">trust unit</a>),  COIN (a token available on the VPR chain), FIAT (means chain is used for settlement only and payment is done off-chain). Not that in all cases, trust deposits are always handled in <code>denom</code>.</li>
 <li><code>pricing_asset</code> (string) (<em>mandatory</em>): <code>&quot;tu&quot;</code> if <code>pricing_asset_type</code> is set to TU, else examples: COIN: <code>denom</code> <code>&quot;uvna&quot;</code>, <code>&quot;ufoo&quot;</code>, <code>&quot;ibc/3A0F9C2E4E2A9B7D6F...&quot;</code>, <code>&quot;factory/verana1.../ueurv&quot;</code>, FIAT: <code>&quot;USD&quot;</code>, <code>&quot;GBP&quot;</code>,…</li>
 <li><code>digest_algorithm</code> (string) (<em>mandatory</em>): algorithm used to compute the <code>digestSRI</code> for credentials issued under this schema. Valid values are defined in the <a path-0="verana-labs.github.io"path-1="verifiable-trust-spec"path-2=""href="https://verana-labs.github.io/verifiable-trust-spec/" >Verifiable Trust spec</a>.</li>
@@ -615,73 +632,73 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 <li><code>effective_until</code> (timestamp) (<em>optional</em>): timestamp until which this policy version is in force, if time-limited.</li>
 <li><code>revoked</code> (boolean) (<em>mandatory</em>): indicates whether this policy version has been revoked and must no longer be used.</li>
 </ul>
-<h3 id="permission"><a class="toc-anchor" href="#permission" >§</a> Permission</h3>
-<p><code>Permission</code>:</p>
+<h3 id="participant"><a class="toc-anchor" href="#participant" >§</a> Participant</h3>
+<p><code>Participant</code>:</p>
 <ul>
-<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the perm.</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the participant.</li>
 <li><code>schema_id</code> (uint64) (<em>mandatory</em>): the id of the related <code>CredentialSchema</code> entry.</li>
-<li><code>type</code> (PermissionType): ISSUER, VERIFIER, ISSUER_GRANTOR, VERIFIER_GRANTOR, ECOSYSTEM, HOLDER</li>
+<li><code>role</code> (ParticipantRole): ISSUER, VERIFIER, ISSUER_GRANTOR, VERIFIER_GRANTOR, ECOSYSTEM, HOLDER</li>
 <li><code>did</code> (string) (<em>optional</em>): <a class="term-reference" href="#term:did">DID</a> this permission refers to. MUST conform to [<a class="spec-reference" href="#ref:RFC3986">RFC3986</a>].</li>
-<li><code>corporation</code> (group) (<em>mandatory</em>): <a class="term-reference" href="#term:group">group</a> that owns this permission.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): <a class="term-reference" href="#term:corporation">corporation</a> that owns this permission.</li>
 <li><code>vs_operator</code> (account) (<em>mandatory</em>): verifiable service agent account. This is the account that will have the right to create or update permission sessions.</li>
-<li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this <code>Permission</code> has been created.</li>
-<li><code>adjusted</code> (timestamp) (<em>mandatory</em>): timestamp this <code>Permission</code> has been adjusted.</li>
-<li><code>slashed</code> (timestamp) (<em>mandatory</em>): timestamp this <code>Permission</code> has been slashed.</li>
-<li><code>repaid</code> (timestamp) (<em>mandatory</em>): timestamp this <code>Permission</code> has been repaid.</li>
-<li><code>effective_from</code> (timestamp) (<em>optional</em>): timestamp from which (inclusive) this <code>Permission</code> is effective.</li>
-<li><code>effective_until</code> (timestamp) (<em>optional</em>): timestamp until when (exclusive) this <code>Permission</code> is effective, null if no time limit has been set for this permission.</li>
-<li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this Permission has been modified.</li>
-<li><code>validation_fees</code> (number) (<em>mandatory</em>): price to pay by an applicant to a validator (<code>corporation</code> grantee of this perm) for running a validation process for a given validation period. Must be an integer. Default to 0. Considered unit depends on <code>pricing_asset_type</code> and <code>pricing_asset</code> configuration of related schema.</li>
+<li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this <code>Participant</code> has been created.</li>
+<li><code>adjusted</code> (timestamp) (<em>mandatory</em>): timestamp this <code>Participant</code> has been adjusted.</li>
+<li><code>slashed</code> (timestamp) (<em>mandatory</em>): timestamp this <code>Participant</code> has been slashed.</li>
+<li><code>repaid</code> (timestamp) (<em>mandatory</em>): timestamp this <code>Participant</code> has been repaid.</li>
+<li><code>effective_from</code> (timestamp) (<em>optional</em>): timestamp from which (inclusive) this <code>Participant</code> is effective.</li>
+<li><code>effective_until</code> (timestamp) (<em>optional</em>): timestamp until when (exclusive) this <code>Participant</code> is effective, null if no time limit has been set for this permission.</li>
+<li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this Participant has been modified.</li>
+<li><code>validation_fees</code> (number) (<em>mandatory</em>): price to pay by an applicant to a validator (<code>corporation</code> grantee of this perm) for running an onboarding process for a given validation period. Must be an integer. Default to 0. Considered unit depends on <code>pricing_asset_type</code> and <code>pricing_asset</code> configuration of related schema.</li>
 <li><code>issuance_fees</code> (number) (<em>mandatory</em>): fees requested by grantee <code>corporation</code> of this perm when a credential is issued. Must be an integer. Default to 0. Considered unit depends on <code>pricing_asset_type</code> and <code>pricing_asset</code> configuration of related schema.</li>
 <li><code>verification_fees</code> (number) (<em>mandatory</em>): fees requested by grantee <code>corporation</code> of this perm when a credential is verified. Must be an integer. Default to 0. Considered unit depends on <code>pricing_asset_type</code> and <code>pricing_asset</code> configuration of related schema.</li>
-<li><code>deposit</code> (number) (<em>mandatory</em>): accumulated <em>grantee</em> deposit in the context of the <em>use</em> of this permission (including the validation process), in <a class="term-reference" href="#term:native-denom">native denom</a>. Usually, it is incremented when for example, for a ISSUER type <code>Permission</code> <code>perm</code>, issuer issues credentials that require paying issuance fees: an additional % of the fees is charged to issuer and sent to its deposit, corresponding deposit amount increases this <code>perm.deposit</code> value as well. If <code>perm</code> is, let’s say revoked, then corresponding <code>perm.deposit</code> value is freed from <code>perm.grantee</code> Trust Deposit.</li>
+<li><code>deposit</code> (number) (<em>mandatory</em>): accumulated <em>grantee</em> deposit in the context of the <em>use</em> of this permission (including the onboarding process), in <a class="term-reference" href="#term:native-denom">native denom</a>. Usually, it is incremented when for example, for a ISSUER type <code>Participant</code> <code>perm</code>, issuer issues credentials that require paying issuance fees: an additional % of the fees is charged to issuer and sent to its deposit, corresponding deposit amount increases this <code>participant.deposit</code> value as well. If <code>perm</code> is, let’s say revoked, then corresponding <code>participant.deposit</code> value is freed from <code>participant.grantee</code> Trust Deposit.</li>
 <li><code>slashed_deposit</code> (number) (<em>mandatory</em>): part of the deposit in <a class="term-reference" href="#term:native-denom">native denom</a> that has been slashed.</li>
 <li><code>repaid_deposit</code> (number) (<em>mandatory</em>): part of the slashed deposit in <a class="term-reference" href="#term:native-denom">native denom</a> that has been repaid.</li>
 <li><code>revoked</code> (timestamp) (<em>optional</em>): manual revocation timestamp of this Perm.</li>
-<li><code>validator_perm_id</code> (uint64) (<em>optional</em>): permission of the validator assigned to the validation process of this permission, ie <em>parent node</em> in the <code>Permission</code> tree.</li>
-<li><code>vp_state</code> (enum) (<em>mandatory</em>): one of PENDING, VALIDATED, TERMINATED.</li>
-<li><code>vp_exp</code> (timestamp) (<em>optional</em>): validation expiration timestamp. This expiration timestamp is for the validation process itself, not for the issued credential or <code>Permission</code> expiration timestamp.</li>
-<li><code>vp_last_state_change</code> (timestamp) (<em>mandatory</em>)</li>
-<li><code>vp_validator_deposit</code>: number (<em>optional</em>): accumulated validator trust deposit, in <a class="term-reference" href="#term:denom">denom</a>.</li>
-<li><code>vp_current_fees</code> (number) (<em>mandatory</em>): current action escrowed fees that will be paid to <a class="term-reference" href="#term:validator">validator</a> upon validation process completion, in <a class="term-reference" href="#term:denom">denom</a>.</li>
-<li><code>vp_current_deposit</code> (number) (<em>mandatory</em>): current action trust deposit, in <a class="term-reference" href="#term:denom">denom</a>.</li>
-<li><code>vp_summary_digest</code> (string) (<em>optional</em>): an optional digest SRI, set by <a class="term-reference" href="#term:validator">validator</a>, of a summary of the information, proofs… provided by the <a class="term-reference" href="#term:applicant">applicant</a>.</li>
-<li><code>issuance_fee_discount</code>: (number) (<em>mandatory</em>): default to 0 (no discount). Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_VALIDATION_PROCESS mode) or an ISSUER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
-<li><code>verification_fee_discount</code>: (number) (<em>mandatory</em>): default to 0 (no discount). Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_VALIDATION_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
+<li><code>validator_participant_id</code> (uint64) (<em>optional</em>): permission of the validator assigned to the onboarding process of this permission, ie <em>parent node</em> in the <code>Participant</code> tree.</li>
+<li><code>op_state</code> (enum) (<em>mandatory</em>): one of PENDING, VALIDATED, TERMINATED.</li>
+<li><code>op_exp</code> (timestamp) (<em>optional</em>): validation expiration timestamp. This expiration timestamp is for the onboarding process itself, not for the issued credential or <code>Participant</code> expiration timestamp.</li>
+<li><code>op_last_state_change</code> (timestamp) (<em>mandatory</em>)</li>
+<li><code>op_validator_deposit</code>: number (<em>optional</em>): accumulated validator trust deposit, in <a class="term-reference" href="#term:denom">denom</a>.</li>
+<li><code>op_current_fees</code> (number) (<em>mandatory</em>): current action escrowed fees that will be paid to <a class="term-reference" href="#term:validator">validator</a> upon onboarding process completion, in <a class="term-reference" href="#term:denom">denom</a>.</li>
+<li><code>op_current_deposit</code> (number) (<em>mandatory</em>): current action trust deposit, in <a class="term-reference" href="#term:denom">denom</a>.</li>
+<li><code>op_summary_digest</code> (string) (<em>optional</em>): an optional digest SRI, set by <a class="term-reference" href="#term:validator">validator</a>, of a summary of the information, proofs… provided by the <a class="term-reference" href="#term:applicant">applicant</a>.</li>
+<li><code>issuance_fee_discount</code>: (number) (<em>mandatory</em>): default to 0 (no discount). Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR or ISSUER <code>Participant</code> entry (if GRANTOR_ONBOARDING_PROCESS mode) or to an ISSUER <code>Participant</code> entry (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated issuance fees for the subtree of <code>Participant</code> entries. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
+<li><code>verification_fee_discount</code>: (number) (<em>mandatory</em>): default to 0 (no discount). Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR or VERIFIER <code>Participant</code> entry (if GRANTOR_ONBOARDING_PROCESS mode) and/or to a VERIFIER <code>Participant</code> entry (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated fees for the subtree of <code>Participant</code> entries. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
 </ul>
 <blockquote>
-<p>Note: VS operator authorization settings (spend limits, feegrant, expiration, authorized message types) are no longer stored on <code>Permission</code>. They live in <code>PermissionAuthorizationRecord</code> entries inside <a href="#vsoperatorauthorization" >VSOperatorAuthorization</a>, keyed by <code>Permission.id</code>. See <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a> and <a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a>.</p>
+<p>Note: VS operator authorization settings (spend limits, feegrant, expiration, authorized message types) are no longer stored on <code>Participant</code>. They live in <code>ParticipantAuthorizationRecord</code> entries inside <a href="#vsoperatorauthorization" >VSOperatorAuthorization</a>, keyed by <code>Participant.id</code>. See <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a> and <a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a>.</p>
 </blockquote>
-<h3 id="permissionsession"><a class="toc-anchor" href="#permissionsession" >§</a> PermissionSession</h3>
-<p><code>PermissionSession</code>:</p>
+<h3 id="participantsession"><a class="toc-anchor" href="#participantsession" >§</a> ParticipantSession</h3>
+<p><code>ParticipantSession</code>:</p>
 <ul>
 <li><code>id</code> (uuid) (<em>mandatory</em>): session uuid.</li>
 <li><code>corporation</code> (group) (<em>mandatory</em>): corporation that controls the entry.</li>
 <li><code>vs_operator</code> (account) (<em>mandatory</em>): verifiable service agent account that controls the entry (agent crypto account).</li>
-<li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this PermissionSession has been created.</li>
-<li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this PermissionSession has been modified.</li>
-<li><code>session_records</code> (PermissionSessionRecord[]) (<em>mandatory</em>): session records, for this session.</li>
+<li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this ParticipantSession has been created.</li>
+<li><code>modified</code> (timestamp) (<em>mandatory</em>): timestamp this ParticipantSession has been modified.</li>
+<li><code>session_records</code> (ParticipantSessionRecord[]) (<em>mandatory</em>): session records, for this session.</li>
 </ul>
-<h3 id="permissionsessionrecord"><a class="toc-anchor" href="#permissionsessionrecord" >§</a> PermissionSessionRecord</h3>
-<p><code>PermissionSessionRecord</code>:</p>
+<h3 id="participantsessionrecord"><a class="toc-anchor" href="#participantsessionrecord" >§</a> ParticipantSessionRecord</h3>
+<p><code>ParticipantSessionRecord</code>:</p>
 <ul>
 <li><code>created</code> (timestamp) (<em>mandatory</em>): timestamp this record has been created.</li>
-<li><code>issuer_perm_id</code> (uint64) (<em>optional</em>): related issuer <code>Permission</code> id (if applicable).</li>
-<li><code>verifier_perm_id</code> (uint64) (<em>optional</em>): related verifier <code>Permission</code> id (if applicable).</li>
-<li><code>wallet_agent_perm_id</code> (uint64) (<em>optional</em>): related wallet agent <code>Permission</code> id (if applicable).</li>
-<li><code>agent_perm_id</code> (uint64) (<em>optional</em>): permission id of the agent <code>Permission</code> id (if applicable).</li>
+<li><code>issuer_participant_id</code> (uint64) (<em>optional</em>): related issuer <code>Participant</code> id (if applicable).</li>
+<li><code>verifier_participant_id</code> (uint64) (<em>optional</em>): related verifier <code>Participant</code> id (if applicable).</li>
+<li><code>wallet_agent_participant_id</code> (uint64) (<em>optional</em>): related wallet agent <code>Participant</code> id (if applicable).</li>
+<li><code>agent_participant_id</code> (uint64) (<em>optional</em>): permission id of the agent <code>Participant</code> id (if applicable).</li>
 </ul>
 <h3 id="trustdeposit"><a class="toc-anchor" href="#trustdeposit" >§</a> TrustDeposit</h3>
 <p><code>TrustDeposit</code>:</p>
 <ul>
 <li><code>share</code> (number) (<em>mandatory</em>): share of the module total deposit.</li>
-<li><code>corporation</code> (group) (<em>mandatory</em>) (key): the <a class="term-reference" href="#term:group">group</a></li>
+<li><code>corporation</code> (group) (<em>mandatory</em>) (key): the <a class="term-reference" href="#term:corporation">corporation</a></li>
 <li><code>deposit</code> (number) (<em>mandatory</em>): amount of deposit in <code>denom</code>.</li>
-<li><code>claimable</code> (number) (<em>mandatory</em>): amount of claimable deposit in <code>denom</code>.</li>
+<li><code>refunded</code> (number) (<em>mandatory</em>): amount of refunded trust deposit, in <code>denom</code>. Refunded trust deposit is reused as funding for the next trust deposit spending before drawing additional funds from the corporation account.</li>
 <li><code>slashed_deposit</code> (number) (<em>optional</em>): amount of slashed deposit in <code>denom</code>.</li>
-<li><code>repaid_deposit</code> (number) (<em>optional</em>): amount of slashed deposit in <code>denom</code>.</li>
+<li><code>repaid_deposit</code> (number) (<em>optional</em>): part of the slashed trust deposit, in <code>denom</code>, that has been repaid.</li>
 <li><code>last_slashed</code> (timestamp) (<em>optional</em>): last time this trust deposit has been slashed.</li>
-<li><code>last_repaid</code> (timestamp) (<em>optional</em>): last time this trust deposit has been slashed.</li>
+<li><code>last_repaid</code> (timestamp) (<em>optional</em>): last time this trust deposit has been repaid.</li>
 <li><code>slash_count</code> (number) (<em>optional</em>): number of times this account has been slashed.</li>
 </ul>
 <h3 id="denomamount"><a class="toc-anchor" href="#denomamount" >§</a> DenomAmount</h3>
@@ -696,42 +713,47 @@ For example, a <strong>key-value store</strong> may be more appropriate for a <s
 </ul>
 <h3 id="operatorauthorization"><a class="toc-anchor" href="#operatorauthorization" >§</a> OperatorAuthorization</h3>
 <ul>
-<li><code>corporation</code> (group) (<em>mandatory</em>): the corporation group granting the authorization.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): the <a class="term-reference" href="#term:corporation">corporation</a> granting the authorization.</li>
 <li><code>operator</code> (account) (<em>mandatory</em>): the operator account receiving the authorization.</li>
 <li><code>msg_types</code> (msg_type[]) (<em>mandatory</em>): list of module message types this authorization applies to.</li>
 <li><code>spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds that the grantee is allowed to spend
 as a direct consequence of executing authorized messages.</li>
+<li><code>remaining_spend</code> (DenomAmount[]) (<em>conditional</em>): runtime balance for <code>spend_limit</code>. Present iff <code>spend_limit</code> is set. Initialized to <code>spend_limit</code> at create time. Decremented per matching <code>denom</code> after each authorized operation. Reset to <code>spend_limit</code> when the current cycle ends (see <code>expiration</code> and <code>period</code> below).</li>
 <li><code>fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of fees that can be paid using this authorization.</li>
-<li><code>expiration</code> (timestamp) (<em>optional</em>): timestamp after which the authorization is no longer valid.</li>
-<li><code>period</code> (duration) (<em>optional</em>): reset period for spend_limit and fee_spend_limit.</li>
+<li><code>remaining_fee_spend</code> (DenomAmount[]) (<em>conditional</em>): runtime balance for <code>fee_spend_limit</code>. Present iff <code>fee_spend_limit</code> is set. Initialized, decremented and reset following the same rules as <code>remaining_spend</code>.</li>
+<li><code>expiration</code> (timestamp) (<em>optional</em>): authorization window boundary. If <code>period</code> is unset, this is the absolute end-of-life: when <code>now() &gt;= expiration</code>, the authorization is dead. If <code>period</code> is set, this is the end of the current cycle: when <code>now() &gt;= expiration</code>, the runtime balances are reset to their original limits and <code>expiration</code> is advanced to <code>now() + period</code> (the authorization auto-renews until the corporation revokes it).</li>
+<li><code>period</code> (duration) (<em>optional</em>): reset period for <code>spend_limit</code> and <code>fee_spend_limit</code>. If set, <code>expiration</code> MUST also be set.</li>
 </ul>
 <h3 id="feegrant"><a class="toc-anchor" href="#feegrant" >§</a> FeeGrant</h3>
 <p><code>FeeGrant</code>:</p>
 <ul>
-<li><code>grantor</code> (group) (<em>mandatory</em>): the corporation group granting the fee allowance.</li>
+<li><code>grantor</code> (group) (<em>mandatory</em>): the <a class="term-reference" href="#term:corporation">corporation</a> granting the fee allowance.</li>
 <li><code>grantee</code> (account) (<em>mandatory</em>): the account that receives the fee grant from <code>grantor</code>.</li>
 <li><code>msg_types</code> (msg_type[]) (<em>mandatory</em>): list of VPR delegable message types for which the fee allowance applies.</li>
 <li><code>spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of fees that can be spent using this grant.</li>
-<li><code>expiration</code> (timestamp) (<em>optional</em>): timestamp after which the fee grant is no longer valid.</li>
-<li><code>period</code> (duration) (<em>optional</em>): reset period for spend_limit.</li>
+<li><code>remaining_spend</code> (DenomAmount[]) (<em>conditional</em>): runtime balance for <code>spend_limit</code>. Present iff <code>spend_limit</code> is set. Initialized to <code>spend_limit</code> at create time. Decremented per matching <code>denom</code> after each authorized operation. Reset to <code>spend_limit</code> when the current cycle ends (see <code>expiration</code> and <code>period</code> below).</li>
+<li><code>expiration</code> (timestamp) (<em>optional</em>): grant window boundary. If <code>period</code> is unset, this is the absolute end-of-life: when <code>now() &gt;= expiration</code>, the grant is dead. If <code>period</code> is set, this is the end of the current cycle: when <code>now() &gt;= expiration</code>, <code>remaining_spend</code> is reset to <code>spend_limit</code> and <code>expiration</code> is advanced to <code>now() + period</code> (the grant auto-renews until the grantor revokes it).</li>
+<li><code>period</code> (duration) (<em>optional</em>): reset period for <code>spend_limit</code>. If set, <code>expiration</code> MUST also be set.</li>
 </ul>
 <h3 id="vsoperatorauthorization"><a class="toc-anchor" href="#vsoperatorauthorization" >§</a> VSOperatorAuthorization</h3>
-<p>A <code>VSOperatorAuthorization</code> groups all <code>PermissionAuthorizationRecord</code> entries delegated by one <code>corporation</code> to one <code>vs_operator</code>. It is keyed by the <code>(corporation, vs_operator)</code> pair. The entry exists if, and only if, it has at least one record.</p>
+<p>A <code>VSOperatorAuthorization</code> groups all <code>ParticipantAuthorizationRecord</code> entries delegated by one <code>corporation</code> to one <code>vs_operator</code>. It is keyed by the <code>(corporation, vs_operator)</code> pair. The entry exists if, and only if, it has at least one record.</p>
 <ul>
-<li><code>corporation</code> (group) (<em>mandatory</em>): the corporation group granting the authorization.</li>
+<li><code>corporation</code> (group) (<em>mandatory</em>): the <a class="term-reference" href="#term:corporation">corporation</a> granting the authorization.</li>
 <li><code>vs_operator</code> (account) (<em>mandatory</em>): the operator account receiving the authorization.</li>
-<li><code>records</code> (PermissionAuthorizationRecord[]) (<em>mandatory</em>): per-permission authorization records granted to <code>vs_operator</code> by <code>corporation</code>.</li>
+<li><code>records</code> (ParticipantAuthorizationRecord[]) (<em>mandatory</em>): per-permission authorization records granted to <code>vs_operator</code> by <code>corporation</code>.</li>
 </ul>
-<h3 id="permissionauthorizationrecord"><a class="toc-anchor" href="#permissionauthorizationrecord" >§</a> PermissionAuthorizationRecord</h3>
-<p>A <code>PermissionAuthorizationRecord</code> carries the per-permission authorization configuration that was previously stored on <code>Permission.vs_operator_authz_*</code> fields. Each record is globally unique by <code>perm_id</code>: for any <code>Permission.id</code>, at most one record exists system-wide, so <code>(corporation, vs_operator)</code> can be derived from <code>perm_id</code> via a direct lookup.</p>
+<h3 id="participantauthorizationrecord"><a class="toc-anchor" href="#participantauthorizationrecord" >§</a> ParticipantAuthorizationRecord</h3>
+<p>A <code>ParticipantAuthorizationRecord</code> carries the per-permission authorization configuration that was previously stored on <code>Participant.vs_operator_authz_*</code> fields. Each record is globally unique by <code>participant_id</code>: for any <code>Participant.id</code>, at most one record exists system-wide, so <code>(corporation, vs_operator)</code> can be derived from <code>participant_id</code> via a direct lookup.</p>
 <ul>
-<li><code>perm_id</code> (uint64) (<em>mandatory</em>): id of the <code>Permission</code> this authorization record applies to. Globally unique across all <code>PermissionAuthorizationRecord</code> entries.</li>
-<li><code>msg_types</code> (msg_type[]) (<em>mandatory</em>): list of delegable message types for which the <code>vs_operator</code> is authorized on behalf of <code>corporation</code> when acting in the context of <code>perm_id</code>. Declared by the applicant at record creation time (see <a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a> and <a href="#mod-perm-msg-14-self-create-permission" >[MOD-PERM-MSG-14]</a>). Frozen after creation.</li>
-<li><code>spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount the <code>vs_operator</code> is allowed to spend, in the context of this permission, as a direct consequence of executing authorized messages.</li>
-<li><code>fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of transaction fees that can be spent by <code>vs_operator</code> (paid by <code>corporation</code> via fee grant) in the context of this permission.</li>
-<li><code>with_feegrant</code> (bool) (<em>mandatory</em>): if true, <code>corporation</code> pays the transaction fees for <code>vs_operator</code> when executing authorized messages in the context of this permission, through an on-chain <code>FeeGrant</code>.</li>
-<li><code>expiration</code> (timestamp) (<em>mandatory</em>): timestamp after which this authorization is no longer valid. Written to <code>now</code> at <a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a> (disabled until validation) and to <code>Permission.effective_until</code> at <a href="#mod-perm-msg-3-set-permission-vp-to-validated" >[MOD-PERM-MSG-3]</a> / <a href="#mod-perm-msg-8-adjust-permission" >[MOD-PERM-MSG-8]</a> / <a href="#mod-perm-msg-14-self-create-permission" >[MOD-PERM-MSG-14]</a>.</li>
-<li><code>period</code> (duration) (<em>optional</em>): reset period for <code>spend_limit</code> and <code>fee_spend_limit</code> in the context of this permission.</li>
+<li><code>participant_id</code> (uint64) (<em>mandatory</em>): id of the <code>Participant</code> this authorization record applies to. Globally unique across all <code>ParticipantAuthorizationRecord</code> entries.</li>
+<li><code>msg_types</code> (msg_type[]) (<em>mandatory</em>): list of delegable message types for which the <code>vs_operator</code> is authorized on behalf of <code>corporation</code> when acting in the context of <code>participant_id</code>. Declared by the applicant at record creation time (see <a href="#mod-pp-msg-1-start-participant-op" >[MOD-PP-MSG-1]</a> and <a href="#mod-pp-msg-14-self-create-participant" >[MOD-PP-MSG-14]</a>). Frozen after creation.</li>
+<li><code>spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount the <code>vs_operator</code> is allowed to spend, in the context of this <code>Participant</code> entry, as a direct consequence of executing authorized messages.</li>
+<li><code>remaining_spend</code> (DenomAmount[]) (<em>conditional</em>): runtime balance for <code>spend_limit</code>. Present iff <code>spend_limit</code> is set. Initialized to <code>spend_limit</code> at create time. Decremented per matching <code>denom</code> after each authorized operation. Reset to <code>spend_limit</code> when the current cycle ends (see <code>expiration</code> and <code>period</code> below).</li>
+<li><code>fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of transaction fees that can be spent by <code>vs_operator</code> (paid by <code>corporation</code> via fee grant) in the context of this <code>Participant</code> entry.</li>
+<li><code>remaining_fee_spend</code> (DenomAmount[]) (<em>conditional</em>): runtime balance for <code>fee_spend_limit</code>. Present iff <code>fee_spend_limit</code> is set. Initialized, decremented and reset following the same rules as <code>remaining_spend</code>.</li>
+<li><code>with_feegrant</code> (bool) (<em>mandatory</em>): if true, <code>corporation</code> pays the transaction fees for <code>vs_operator</code> when executing authorized messages in the context of this <code>Participant</code> entry, through an on-chain <code>FeeGrant</code>.</li>
+<li><code>expiration</code> (timestamp) (<em>mandatory</em>): authorization window boundary. If <code>period</code> is unset, this is the absolute end-of-life: when <code>now() &gt;= expiration</code>, the record is dead. If <code>period</code> is set, this is the end of the current cycle: when <code>now() &gt;= expiration</code>, the runtime balances are reset to their original limits and <code>expiration</code> is advanced to <code>now() + period</code> (the record auto-renews until removed via <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a>). Initially written to <code>now</code> at <a href="#mod-pp-msg-1-start-participant-op" >[MOD-PP-MSG-1]</a> (disabled until validation) and to <code>Participant.effective_until</code> at <a href="#mod-pp-msg-3-set-participant-op-to-validated" >[MOD-PP-MSG-3]</a> / <a href="#mod-pp-msg-8-set-participant-effective-until" >[MOD-PP-MSG-8]</a> / <a href="#mod-pp-msg-14-self-create-participant" >[MOD-PP-MSG-14]</a>.</li>
+<li><code>period</code> (duration) (<em>optional</em>): reset period for <code>spend_limit</code> and <code>fee_spend_limit</code> in the context of this <code>Participant</code> entry.</li>
 </ul>
 <h3 id="exchangerate"><a class="toc-anchor" href="#exchangerate" >§</a> ExchangeRate</h3>
 <p>Represents an on-chain exchange rate between two assets.</p>
@@ -747,6 +769,17 @@ as a direct consequence of executing authorized messages.</li>
 <li><code>updated</code> (timestamp, mandatory): Timestamp of the last exchange rate update.</li>
 <li><code>expires</code> (timestamp, mandatory): Timestamp after which the exchange rate is considered invalid.</li>
 <li><code>state</code> (boolean, mandatory): true means enabled, false means disabled.</li>
+</ul>
+<h3 id="exchangerateauthorization"><a class="toc-anchor" href="#exchangerateauthorization" >§</a> ExchangeRateAuthorization</h3>
+<p>Represents the authorization granted by network governance to a specific operator account to execute <a href="#mod-xr-msg-2-update-exchange-rate" >[MOD-XR-MSG-2]</a> Update Exchange Rate on a given <code>ExchangeRate</code> entry.</p>
+<p>Exchange rates are a <em>protocol-level oracle</em>: they are consumed by <a href="#mod-xr-qry-3-get-price" >[MOD-XR-QRY-3]</a> Get Price and used across the protocol (trust deposit pricing, fees). Therefore, ownership and update permission of an <code>ExchangeRate</code> is scoped to the network (governance), not to a corporation. <code>ExchangeRateAuthorization</code> is the on-chain record that designates which operator account is authorized to push fresh values for a given <code>ExchangeRate</code>, and under what runtime constraints.</p>
+<p><code>ExchangeRateAuthorization</code>:</p>
+<ul>
+<li><code>xr_id</code> (uint64, <em>mandatory</em>): id of the <code>ExchangeRate</code> this authorization applies to. Together with <code>operator</code>, forms the composite key.</li>
+<li><code>operator</code> (account, <em>mandatory</em>): account authorized to execute <a href="#mod-xr-msg-2-update-exchange-rate" >[MOD-XR-MSG-2]</a> on <code>xr_id</code>. Together with <code>xr_id</code>, forms the composite key.</li>
+<li><code>expiration</code> (timestamp, <em>mandatory</em>): authorization end-of-life. When <code>now() &gt;= expiration</code>, the authorization is dead and <a href="#mod-xr-msg-2-update-exchange-rate" >[MOD-XR-MSG-2]</a> MUST be rejected.</li>
+<li><code>min_interval</code> (duration, <em>optional</em>): anti-spam guard. If set, two successive successful <a href="#mod-xr-msg-2-update-exchange-rate" >[MOD-XR-MSG-2]</a> calls under this authorization MUST be separated by at least <code>min_interval</code>.</li>
+<li><code>max_deviation_bps</code> (uint32, <em>optional</em>): circuit breaker, expressed in basis points (1 bps = 0.01%). If set, <a href="#mod-xr-msg-2-update-exchange-rate" >[MOD-XR-MSG-2]</a> MUST be rejected if the relative change between the new <code>rate</code> and the current <code>xr.rate</code> exceeds <code>max_deviation_bps / 10000</code>. A larger move requires a fresh governance proposal (typically a new <a href="#mod-xr-msg-1-create-exchange-rate" >[MOD-XR-MSG-1]</a> or an updated authorization).</li>
 </ul>
 <h3 id="globalvariables"><a class="toc-anchor" href="#globalvariables" >§</a> GlobalVariables</h3>
 <p><code>GlobalVariables</code>:</p>
@@ -779,15 +812,14 @@ as a direct consequence of executing authorized messages.</li>
 <p>Note about Query REST API:</p>
 <ul>
 <li>all query methods MUST return valid JSON.</li>
-<li>objects MUST be nested when needed, such as when returning a trust registry.</li>
-<li>JSON formatting MUST obey to data model regarding attribute names. A method that returns a <code>TrustRegistry</code> entry MUST return an entry called “trust_registry”. A method that returns a list of Trust Registries MUST return an entry called “trustRegistries” that contain a list of <code>TrustRegistry</code> entries.</li>
+<li>objects MUST be nested when needed, such as when returning an ecosystem.</li>
+<li>JSON formatting MUST obey to data model regarding attribute names. A method that returns a <code>Ecosystem</code> entry MUST return an entry called “ecosystem”. A method that returns a list of Ecosystems MUST return an entry called “ecosystems” that contain a list of <code>Ecosystem</code> entries.</li>
 </ul>
 <p>Examples:</p>
-<p>Get a <code>TrustRegistry</code></p>
-<pre class="language-json"><code class="language-json"><span class="token property">"trust_registry"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
+<p>Get an <code>Ecosystem</code></p>
+<pre class="language-json"><code class="language-json"><span class="token property">"ecosystem"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
   <span class="token punctuation">{</span>
     <span class="token property">"active_version"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span>
-    <span class="token property">"aka"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
     <span class="token property">"corporation"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
     <span class="token property">"created"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span><span class="token punctuation">,</span>
     <span class="token property">"deposit"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
@@ -800,7 +832,7 @@ as a direct consequence of executing authorized messages.</li>
         <span class="token property">"active_since"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span><span class="token punctuation">,</span>
         <span class="token property">"created"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span><span class="token punctuation">,</span>
         <span class="token property">"id"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
-        <span class="token property">"tr_id"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
+        <span class="token property">"ecosystem_id"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
         <span class="token property">"version"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span>
         <span class="token property">"documents"</span><span class="token operator">:</span> <span class="token punctuation">[</span>
           <span class="token punctuation">{</span>
@@ -816,10 +848,9 @@ as a direct consequence of executing authorized messages.</li>
     <span class="token punctuation">]</span>  
   <span class="token punctuation">}</span>
 </code></pre>
-<pre class="language-json"><code class="language-json"><span class="token property">"trustRegistries"</span><span class="token operator">:</span> <span class="token punctuation">[</span> <span class="token punctuation">{</span>
+<pre class="language-json"><code class="language-json"><span class="token property">"ecosystems"</span><span class="token operator">:</span> <span class="token punctuation">[</span> <span class="token punctuation">{</span>
   <span class="token punctuation">{</span>
     <span class="token property">"active_version"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span>
-    <span class="token property">"aka"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
     <span class="token property">"corporation"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
     <span class="token property">"created"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span><span class="token punctuation">,</span>
     <span class="token property">"deposit"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
@@ -832,7 +863,7 @@ as a direct consequence of executing authorized messages.</li>
         <span class="token property">"active_since"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span><span class="token punctuation">,</span>
         <span class="token property">"created"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span><span class="token punctuation">,</span>
         <span class="token property">"id"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
-        <span class="token property">"tr_id"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
+        <span class="token property">"ecosystem_id"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
         <span class="token property">"version"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span>
         <span class="token property">"documents"</span><span class="token operator">:</span> <span class="token punctuation">[</span>
           <span class="token punctuation">{</span>
@@ -848,7 +879,6 @@ as a direct consequence of executing authorized messages.</li>
     <span class="token punctuation">]</span>  
   <span class="token punctuation">}</span><span class="token punctuation">,</span> <span class="token punctuation">{</span>
     <span class="token property">"active_version"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span>
-    <span class="token property">"aka"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
     <span class="token property">"corporation"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
     <span class="token property">"created"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span><span class="token punctuation">,</span>
     <span class="token property">"deposit"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
@@ -861,7 +891,7 @@ as a direct consequence of executing authorized messages.</li>
         <span class="token property">"active_since"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span><span class="token punctuation">,</span>
         <span class="token property">"created"</span><span class="token operator">:</span> <span class="token string">"2025-01-14T19:40:37.967Z"</span><span class="token punctuation">,</span>
         <span class="token property">"id"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
-        <span class="token property">"tr_id"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
+        <span class="token property">"ecosystem_id"</span><span class="token operator">:</span> <span class="token string">"string"</span><span class="token punctuation">,</span>
         <span class="token property">"version"</span><span class="token operator">:</span> <span class="token number">0</span><span class="token punctuation">,</span>
         <span class="token property">"documents"</span><span class="token operator">:</span> <span class="token punctuation">[</span>
           <span class="token punctuation">{</span>
@@ -881,7 +911,7 @@ as a direct consequence of executing authorized messages.</li>
 <div id="warning-46" class="notice warning"><a class="notice-link" href="#warning-46">WARNING</a><p>For Msg methods, all precondition checks MUST be verified first for accepting the Msg, and MUST be verified <strong>again</strong> upon method execution</p>
 </div>
 <p>A VPR implementation MUST implement all the following requirements.</p>
-<div id="note-79" class="notice note"><a class="notice-link" href="#note-79">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="tr"path-3="v1"path-4="get"href="https://example/verana/tr/v1/get" ><span>https://example/verana/tr/v1/get</span></a>.</p>
+<div id="note-79" class="notice note"><a class="notice-link" href="#note-79">NOTE</a><p>The relative REST path is the path suffix. Implementer can set any prefix, like <a path-0="example"path-1="verana"path-2="ec"path-3="v1"path-4="get"href="https://example/verana/ec/v1/get" ><span>https://example/verana/ec/v1/get</span></a>.</p>
 </div>
 <h3 id="authorization-and-fee-grants"><a class="toc-anchor" href="#authorization-and-fee-grants" >§</a> Authorization and Fee Grants</h3>
 <h4 id="delegable-module-messages"><a class="toc-anchor" href="#delegable-module-messages" >§</a> Delegable Module Messages</h4>
@@ -922,12 +952,12 @@ It is entirely up to the <code>corporation</code> group to decide <strong>which 
 <li><code>corporation</code> (group):<br>
 The <code>group</code> that owns the manipulated resource.</li>
 </ul>
-<p>Such messages <strong>cannot be delegated</strong> and MUST be executed exclusively through a <strong>group proposal</strong>.</p>
+<p>Such messages <strong>cannot be delegated</strong> and MUST be executed exclusively through a <strong>corporation proposal</strong>.</p>
 <h4 id="governance-signed-module-messages"><a class="toc-anchor" href="#governance-signed-module-messages" >§</a> Governance-Signed Module Messages</h4>
-<p>Some module messages can be executed <strong>only through a governance proposal</strong>.</p>
+<p>Some module messages can be executed <strong>only through a VPR council governance proposal</strong>.</p>
 <p>These messages do not support delegation and are not executable by accounts, whether directly or via group authorization.</p>
 <h4 id="fee-grants"><a class="toc-anchor" href="#fee-grants" >§</a> Fee Grants</h4>
-<p>A <code>corporation</code> group MAY allow its <code>operator</code>s to pay <strong>network transaction fees</strong> using the <code>corporation</code>’s funds.</p>
+<p>A <code>corporation</code> MAY allow its <code>operator</code>s to pay <strong>network transaction fees</strong> using the <code>corporation</code>’s funds.</p>
 <p>Fee grants are <strong>not created directly</strong>.<br>
 They are created, updated, and revoked <strong>exclusively by Authorization module messages</strong>.<br>
 When an authorization is created or updated, it MAY optionally include an associated fee grant.</p>
@@ -936,52 +966,87 @@ When an authorization is created or updated, it MAY optionally include an associ
 <h5 id="authz-check-1-operator-authorization-checks"><a class="toc-anchor" href="#authz-check-1-operator-authorization-checks" >§</a> [AUTHZ-CHECK-1] Operator Authorization checks</h5>
 <ol>
 <li>An <code>OperatorAuthorization</code> <code>oauthz</code> MUST exist where <code>oauthz.corporation</code> = <code>corporation</code>, <code>oauthz.operator</code> = <code>operator</code>, and <code>oauthz.msg_types</code> includes the current message type.</li>
-<li>If <code>oauthz.expiration</code> is set, it MUST be in the future.</li>
-<li>If <code>oauthz.spend_limit</code> is set, the remaining balance MUST be sufficient for the operation. After successful execution, the consumed amount MUST be deducted from the remaining balance.</li>
-<li>If <code>oauthz.period</code> is set and the current period has elapsed since the last reset, the remaining balance MUST be reset to <code>oauthz.spend_limit</code> before evaluating the check above.</li>
+<li>If <code>oauthz.expiration</code> is set:
+<ul>
+<li>if <code>oauthz.period</code> is set and <code>now() &gt;= oauthz.expiration</code>:
+<ul>
+<li>if <code>oauthz.spend_limit</code> is set, set <code>oauthz.remaining_spend := oauthz.spend_limit</code>.</li>
+<li>if <code>oauthz.fee_spend_limit</code> is set, set <code>oauthz.remaining_fee_spend := oauthz.fee_spend_limit</code>.</li>
+<li>set <code>oauthz.expiration := now() + oauthz.period</code>.</li>
+</ul>
+</li>
+<li>else, <code>oauthz.expiration</code> MUST be strictly greater than <code>now()</code>. Abort otherwise.</li>
+</ul>
+</li>
+<li>If <code>oauthz.spend_limit</code> is set, <code>oauthz.remaining_spend</code> MUST be sufficient for the operation. After successful execution, the consumed amount MUST be deducted from <code>oauthz.remaining_spend</code> (per matching <code>denom</code> entry).</li>
 </ol>
 <h5 id="authz-check-2-fee-grant-checks"><a class="toc-anchor" href="#authz-check-2-fee-grant-checks" >§</a> [AUTHZ-CHECK-2] Fee Grant checks</h5>
 <p>If the transaction fees are paid by the <code>corporation</code> account (via fee grant) instead of the <code>operator</code> account:</p>
 <ol>
 <li>A <code>FeeGrant</code> <code>fg</code> MUST exist where <code>fg.grantor</code> = <code>corporation</code>, <code>fg.grantee</code> = <code>operator</code>, and <code>fg.msg_types</code> includes the current message type.</li>
-<li>If <code>fg.expiration</code> is set, it MUST be in the future.</li>
-<li>If <code>fg.spend_limit</code> is set, the remaining balance MUST be sufficient for the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>. After successful execution, the consumed fee amount MUST be deducted from the remaining balance.</li>
-<li>If <code>fg.period</code> is set and the current period has elapsed since the last reset, the remaining balance MUST be reset to <code>fg.spend_limit</code> before evaluating the check above.</li>
+<li>If <code>fg.expiration</code> is set:
+<ul>
+<li>if <code>fg.period</code> is set and <code>now() &gt;= fg.expiration</code>:
+<ul>
+<li>if <code>fg.spend_limit</code> is set, set <code>fg.remaining_spend := fg.spend_limit</code>.</li>
+<li>set <code>fg.expiration := now() + fg.period</code>.</li>
+</ul>
+</li>
+<li>else, <code>fg.expiration</code> MUST be strictly greater than <code>now()</code>. Abort otherwise.</li>
+</ul>
+</li>
+<li>If <code>fg.spend_limit</code> is set, <code>fg.remaining_spend</code> MUST be sufficient for the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>. After successful execution, the consumed fee amount MUST be deducted from <code>fg.remaining_spend</code> (per matching <code>denom</code> entry).</li>
 </ol>
 <h5 id="authz-check-3-vs-operator-authorization-checks"><a class="toc-anchor" href="#authz-check-3-vs-operator-authorization-checks" >§</a> [AUTHZ-CHECK-3] VS Operator Authorization checks</h5>
-<p>A second authorization grant mode exists for vs-agents. It is used when a corporation delegates a specific permission (and a specific set of message types, scoped to that permission) to a <code>vs_operator</code> account. The authorization model differs from other delegable messages: it relies on <a href="#vsoperatorauthorization" >VSOperatorAuthorization</a> / <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> instead of <code>OperatorAuthorization</code>.</p>
+<p>A second authorization grant mode exists for vs-agents. It is used when a corporation delegates a specific permission (and a specific set of message types, scoped to that permission) to a <code>vs_operator</code> account. The authorization model differs from other delegable messages: it relies on <a href="#vsoperatorauthorization" >VSOperatorAuthorization</a> / <a href="#participantauthorizationrecord" >ParticipantAuthorizationRecord</a> instead of <code>OperatorAuthorization</code>.</p>
 <blockquote>
-<p>Note: the set of messages a <code>vs_operator</code> is authorized to execute in the context of a permission is declared by the applicant at permission creation time (see <a href="#mod-perm-msg-1-1-start-permission-vp-parameters" >[MOD-PERM-MSG-1-1]</a> and <a href="#mod-perm-msg-14-1-self-create-permission-parameters" >[MOD-PERM-MSG-14-1]</a>) and stored in <code>record.msg_types</code>. It is frozen for the lifetime of the record and can only be changed by revoking the permission and starting a new one.</p>
+<p>Note: the set of messages a <code>vs_operator</code> is authorized to execute in the context of a permission is declared by the applicant at permission creation time (see <a href="#mod-pp-msg-1-1-start-participant-op-parameters" >[MOD-PP-MSG-1-1]</a> and <a href="#mod-pp-msg-14-1-self-create-participant-parameters" >[MOD-PP-MSG-14-1]</a>) and stored in <code>record.msg_types</code>. It is frozen for the lifetime of the record and can only be changed by revoking the permission and starting a new one.</p>
 </blockquote>
-<p>Given a <code>corporation</code>, an <code>operator</code> (the <code>vs_operator</code>), a <strong>primary permission id</strong> <code>perm_id</code> (determined by the calling method), and the current message type <code>msg_type</code>:</p>
+<p>Given a <code>corporation</code>, an <code>operator</code> (the <code>vs_operator</code>), a <strong>primary permission id</strong> <code>participant_id</code> (determined by the calling method), and the current message type <code>msg_type</code>:</p>
 <ol>
-<li>A <code>PermissionAuthorizationRecord</code> <code>record</code> MUST exist for <code>perm_id</code>. Abort if not found.</li>
+<li>A <code>ParticipantAuthorizationRecord</code> <code>record</code> MUST exist for <code>participant_id</code>. Abort if not found.</li>
 <li><code>record</code> MUST belong to <code>VSOperatorAuthorization[corporation, operator]</code>, that is: the containing <code>VSOperatorAuthorization</code> MUST have <code>corporation</code> as its <code>corporation</code> and <code>operator</code> as its <code>vs_operator</code>. Abort otherwise.</li>
 <li><code>msg_type</code> MUST be in <code>record.msg_types</code>. Abort otherwise.</li>
-<li><code>record.expiration</code> MUST be strictly greater than now(). Abort otherwise.</li>
-<li>If <code>record.period</code> is set and the current period has elapsed since the last reset, the remaining balances for <code>record.spend_limit</code> and <code>record.fee_spend_limit</code> MUST be reset to their original values before evaluating the check below.</li>
-<li>If <code>record.spend_limit</code> is set, the remaining balance MUST be sufficient for the operation. After successful execution, the consumed amount MUST be deducted from the remaining balance.</li>
+<li>Cycle / expiration check:
+<ul>
+<li>if <code>record.period</code> is set and <code>now() &gt;= record.expiration</code>:
+<ul>
+<li>if <code>record.spend_limit</code> is set, set <code>record.remaining_spend := record.spend_limit</code>.</li>
+<li>if <code>record.fee_spend_limit</code> is set, set <code>record.remaining_fee_spend := record.fee_spend_limit</code>.</li>
+<li>set <code>record.expiration := now() + record.period</code>.</li>
+</ul>
+</li>
+<li>else, <code>record.expiration</code> MUST be strictly greater than <code>now()</code>. Abort otherwise.</li>
+</ul>
+</li>
+<li>If <code>record.spend_limit</code> is set, <code>record.remaining_spend</code> MUST be sufficient for the operation. After successful execution, the consumed amount MUST be deducted from <code>record.remaining_spend</code> (per matching <code>denom</code> entry).</li>
 </ol>
 <h5 id="authz-check-4-vs-operator-fee-grant-checks"><a class="toc-anchor" href="#authz-check-4-vs-operator-fee-grant-checks" >§</a> [AUTHZ-CHECK-4] VS Operator Fee Grant checks</h5>
-<p>If the <a class="term-reference" href="#term:transaction">transaction</a> fees are paid by the <code>corporation</code> account (via fee grant) instead of the <code>operator</code> account, using the same <code>PermissionAuthorizationRecord</code> <code>record</code> looked up in <a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a>:</p>
+<p>If the <a class="term-reference" href="#term:transaction">transaction</a> fees are paid by the <code>corporation</code> account (via fee grant) instead of the <code>operator</code> account, using the same <code>ParticipantAuthorizationRecord</code> <code>record</code> looked up in <a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a>:</p>
 <ol>
 <li><code>record.with_feegrant</code> MUST be true, else abort.</li>
-<li>If <code>record.period</code> is set and the current period has elapsed since the last reset, the remaining balance for <code>record.fee_spend_limit</code> MUST be reset to its original value before evaluating the check below.</li>
-<li>If <code>record.fee_spend_limit</code> is set, the remaining balance MUST be sufficient for the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>. After successful execution, the consumed fee amount MUST be deducted from the remaining balance.</li>
+<li>The cycle / expiration check from <a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a> step 4 has already been performed against the same <code>record</code>; <code>record.remaining_fee_spend</code> is therefore current.</li>
+<li>If <code>record.fee_spend_limit</code> is set, <code>record.remaining_fee_spend</code> MUST be sufficient for the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>. After successful execution, the consumed fee amount MUST be deducted from <code>record.remaining_fee_spend</code> (per matching <code>denom</code> entry).</li>
 </ol>
+<h5 id="authz-check-5-corporation-registration-check"><a class="toc-anchor" href="#authz-check-5-corporation-registration-check" >§</a> [AUTHZ-CHECK-5] Corporation Registration check</h5>
+<p>A <code>Corporation</code> entry MUST exist for the signing <code>corporation</code> (i.e., keyed by its underlying Cosmos SDK <a class="term-reference" href="#term:group">group</a>). If none exists, the <a class="term-reference" href="#term:transaction">transaction</a> MUST abort with an error indicating that the underlying <a class="term-reference" href="#term:group">group</a> has not yet been registered as a <a class="term-reference" href="#term:corporation">corporation</a> (see <a href="#mod-co-msg-1-create-new-corporation" >[MOD-CO-MSG-1]</a>).</p>
+<blockquote>
+<p>Exception: this check MUST NOT be applied for <a href="#mod-co-msg-1-create-new-corporation" >[MOD-CO-MSG-1]</a>, whose explicit purpose is to register a Cosmos SDK <a class="term-reference" href="#term:group">group</a> as a new <code>Corporation</code>. That method enforces the inverse precondition (the entry MUST NOT yet exist) in its own basic checks.</p>
+</blockquote>
+<p>This check applies to every delegable message that invokes <a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a>. As a result, all Create-* methods (and every other delegable Msg) implicitly require the signing <code>corporation</code> to be a registered <code>Corporation</code>.</p>
 <h4 id="example"><a class="toc-anchor" href="#example" >§</a> Example</h4>
 <p>A corporation group <code>corporationABC</code> wants to authorize an operator account <code>accountABC</code> to execute the<br>
-<a href="#mod-perm-msg-10-create-or-update-permission-session" ><code>mod-perm-msg-10-create-or-update-permission-session</code></a>,
-<a href="#mod-perm-msg-3-set-permission-vp-to-validated" ><code>mod-perm-msg-3-set-permission-vp-to-validated</code></a>, and
-<a href="#mod-perm-msg-15-trigger-resolver" ><code>mod-perm-msg-15-trigger-resolver</code></a>
+<a href="#mod-pp-msg-10-create-or-update-participant-session" ><code>mod-pp-msg-10-create-or-update-participant-session</code></a>,
+<a href="#mod-pp-msg-3-set-participant-op-to-validated" ><code>mod-pp-msg-3-set-participant-op-to-validated</code></a>, and
+<a href="#mod-pp-msg-15-trigger-resolver" ><code>mod-pp-msg-15-trigger-resolver</code></a>
 messages.</p>
 <p>Additionally, the corporation wants <code>accountABC</code> to pay the transaction fees for this message using the corporation’s funds.</p>
 <p>To achieve this, <code>corporationABC</code> MUST:</p>
 <ul>
 <li>create an <strong>authorization</strong> from <code>corporationABC</code> to <code>accountABC</code> for the<br>
-<a href="#mod-perm-msg-10-create-or-update-permission-session" ><code>mod-perm-msg-10-create-or-update-permission-session</code></a>,
-<a href="#mod-perm-msg-3-set-permission-vp-to-validated" ><code>mod-perm-msg-3-set-permission-vp-to-validated</code></a>, and
-<a href="#mod-perm-msg-15-trigger-resolver" ><code>mod-perm-msg-15-trigger-resolver</code></a> message types, optionally enabling an associated fee grant.</li>
+<a href="#mod-pp-msg-10-create-or-update-participant-session" ><code>mod-pp-msg-10-create-or-update-participant-session</code></a>,
+<a href="#mod-pp-msg-3-set-participant-op-to-validated" ><code>mod-pp-msg-3-set-participant-op-to-validated</code></a>, and
+<a href="#mod-pp-msg-15-trigger-resolver" ><code>mod-pp-msg-15-trigger-resolver</code></a> message types, optionally enabling an associated fee grant.</li>
 </ul>
 <p>As a result, <code>accountABC</code> is authorized to:</p>
 <ul>
@@ -1002,19 +1067,123 @@ messages.</p>
 </thead>
 <tbody>
 <tr>
-<td>Trust Registry</td>
-<td>Create a Trust Registry</td>
+<td>Corporation</td>
+<td>Create New Corporation</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-tr-msg-1-create-new-trust-registry" >[MOD-TR-MSG-1]</a></td>
+<td><a href="#mod-co-msg-1-create-new-corporation" >[MOD-CO-MSG-1]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
+<td>Update Corporation</td>
+<td>N/A (Tx)</td>
+<td>Msg</td>
+<td><a href="#mod-co-msg-2-update-corporation" >[MOD-CO-MSG-2]</a></td>
+<td>corporation + operator</td>
+</tr>
+<tr>
+<td></td>
+<td>Archive Corporation</td>
+<td>N/A (Tx)</td>
+<td>Msg</td>
+<td><a href="#mod-co-msg-3-archive-corporation" >[MOD-CO-MSG-3]</a></td>
+<td>corporation + operator</td>
+</tr>
+<tr>
+<td></td>
+<td>Update Corporation Module Parameters</td>
+<td>N/A (Tx)</td>
+<td>Msg</td>
+<td><a href="#mod-co-msg-4-update-module-parameters" >[MOD-CO-MSG-4]</a></td>
+<td>governance proposal</td>
+</tr>
+<tr>
+<td></td>
+<td>Get Corporation</td>
+<td>/co/v1/get</td>
+<td>Query</td>
+<td><a href="#mod-co-qry-1-get-corporation" >[MOD-CO-QRY-1]</a></td>
+<td>N/A</td>
+</tr>
+<tr>
+<td></td>
+<td>List Corporations</td>
+<td>/co/v1/list</td>
+<td>Query</td>
+<td><a href="#mod-co-qry-2-list-corporations" >[MOD-CO-QRY-2]</a></td>
+<td>N/A</td>
+</tr>
+<tr>
+<td></td>
+<td>List Corporation Module Parameters</td>
+<td>/co/v1/params</td>
+<td>Query</td>
+<td><a href="#mod-co-qry-3-list-module-parameters" >[MOD-CO-QRY-3]</a></td>
+<td>N/A</td>
+</tr>
+<tr>
+<td>Ecosystem</td>
+<td>Create an Ecosystem</td>
+<td>N/A (Tx)</td>
+<td>Msg</td>
+<td><a href="#mod-es-msg-1-create-new-ecosystem" >[MOD-ES-MSG-1]</a></td>
+<td>corporation + operator</td>
+</tr>
+<tr>
+<td></td>
+<td>Update Ecosystem</td>
+<td>N/A (Tx)</td>
+<td>Msg</td>
+<td><a href="#mod-es-msg-2-update-ecosystem" >[MOD-ES-MSG-2]</a></td>
+<td>corporation + operator</td>
+</tr>
+<tr>
+<td></td>
+<td>Archive Ecosystem</td>
+<td>N/A (Tx)</td>
+<td>Msg</td>
+<td><a href="#mod-es-msg-3-archive-ecosystem" >[MOD-ES-MSG-3]</a></td>
+<td>corporation + operator</td>
+</tr>
+<tr>
+<td></td>
+<td>Update Ecosystem Module Parameters</td>
+<td>N/A (Tx)</td>
+<td>Msg</td>
+<td><a href="#mod-es-msg-4-update-module-parameters" >[MOD-ES-MSG-4]</a></td>
+<td>governance proposal</td>
+</tr>
+<tr>
+<td></td>
+<td>Get Ecosystem</td>
+<td>/ec/v1/get</td>
+<td>Query</td>
+<td><a href="#mod-es-qry-1-get-ecosystem" >[MOD-ES-QRY-1]</a></td>
+<td>N/A</td>
+</tr>
+<tr>
+<td></td>
+<td>List Ecosystems</td>
+<td>/ec/v1/list</td>
+<td>Query</td>
+<td><a href="#mod-es-qry-2-list-ecosystems" >[MOD-ES-QRY-2]</a></td>
+<td>N/A</td>
+</tr>
+<tr>
+<td></td>
+<td>List Ecosystem Module Parameters</td>
+<td>/ec/v1/params</td>
+<td>Query</td>
+<td><a href="#mod-es-qry-3-list-module-parameters" >[MOD-ES-QRY-3]</a></td>
+<td>N/A</td>
+</tr>
+<tr>
+<td>Governance Framework</td>
 <td>Add Governance Framework Document</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-tr-msg-2-add-governance-framework-document" >[MOD-TR-MSG-2]</a></td>
+<td><a href="#mod-gf-msg-1-add-governance-framework-document" >[MOD-GF-MSG-1]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
@@ -1022,55 +1191,23 @@ messages.</p>
 <td>Increase Active Governance Framework Version</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-tr-msg-3-increase-active-governance-framework-version" >[MOD-TR-MSG-3]</a></td>
+<td><a href="#mod-gf-msg-2-increase-active-governance-framework-version" >[MOD-GF-MSG-2]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
-<td>Update Trust Registry</td>
-<td>N/A (Tx)</td>
-<td>Msg</td>
-<td><a href="#mod-tr-msg-4-update-trust-registry" >[MOD-TR-MSG-4]</a></td>
-<td>corporation + operator</td>
-</tr>
-<tr>
-<td></td>
-<td>Archive Trust Registry</td>
-<td>N/A (Tx)</td>
-<td>Msg</td>
-<td><a href="#mod-tr-msg-5-archive-trust-registry" >[MOD-TR-MSG-5]</a></td>
-<td>corporation + operator</td>
-</tr>
-<tr>
-<td></td>
-<td>Update TR Module Parameters</td>
-<td>N/A (Tx)</td>
-<td>Msg</td>
-<td><a href="#mod-tr-msg-6-update-module-parameters" >[MOD-TR-MSG-6]</a></td>
-<td>governance proposal</td>
-</tr>
-<tr>
-<td></td>
-<td>Get Trust Registry</td>
-<td>/tr/v1/get</td>
+<td>Get Governance Framework Version</td>
+<td>/gf/v1/get</td>
 <td>Query</td>
-<td><a href="#mod-tr-qry-1-get-trust-registry" >[MOD-TR-QRY-1]</a></td>
+<td><a href="#mod-gf-qry-1-get-governance-framework-version" >[MOD-GF-QRY-1]</a></td>
 <td>N/A</td>
 </tr>
 <tr>
 <td></td>
-<td>List Trust Registries</td>
-<td>/tr/v1/list</td>
+<td>List Governance Framework Versions</td>
+<td>/gf/v1/list</td>
 <td>Query</td>
-<td><a href="#mod-tr-qry-2-list-trust-registries" >[MOD-TR-QRY-2]</a></td>
-<td>N/A</td>
-</tr>
-<tr>
-<td></td>
-<td>List TR Module Parameters</td>
-<td>/tr/v1/params</td>
-<td>Query</td>
-<td><a href="#mod-tr-qry-3-list-module-parameters" >[MOD-TR-QRY-3]</a></td>
+<td><a href="#mod-gf-qry-2-list-governance-framework-versions" >[MOD-GF-QRY-2]</a></td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -1178,99 +1315,99 @@ messages.</p>
 <td>N/A</td>
 </tr>
 <tr>
-<td>Permission</td>
-<td>Start Permission VP</td>
+<td>Participant</td>
+<td>Start Participant OP</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a></td>
+<td><a href="#mod-pp-msg-1-start-participant-op" >[MOD-PP-MSG-1]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
-<td>Renew a Permission VP</td>
+<td>Renew a Participant OP</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-2-renew-permission-vp" >[MOD-PERM-MSG-2]</a></td>
+<td><a href="#mod-pp-msg-2-renew-participant-op" >[MOD-PP-MSG-2]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
-<td>Set Permission VP to Validated</td>
+<td>Set Participant OP to Validated</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-3-set-permission-vp-to-validated" >[MOD-PERM-MSG-3]</a></td>
+<td><a href="#mod-pp-msg-3-set-participant-op-to-validated" >[MOD-PP-MSG-3]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
-<td>Cancel Permission VP Last Request</td>
+<td>Cancel Participant OP Last Request</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-6-cancel-permission-vp-last-request" >[MOD-PERM-MSG-6]</a></td>
+<td><a href="#mod-pp-msg-6-cancel-participant-op-last-request" >[MOD-PP-MSG-6]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
-<td>Create Root Permission</td>
+<td>Create Root Participant</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-7-create-root-permission" >[MOD-PERM-MSG-7]</a></td>
+<td><a href="#mod-pp-msg-7-create-root-participant" >[MOD-PP-MSG-7]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
-<td>Adjust Permission</td>
+<td>Set Participant Effective Until</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-8-adjust-permission" >[MOD-PERM-MSG-8]</a></td>
+<td><a href="#mod-pp-msg-8-set-participant-effective-until" >[MOD-PP-MSG-8]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
-<td>Revoke Permission</td>
+<td>Revoke Participant</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-9-revoke-permission" >[MOD-PERM-MSG-9]</a></td>
+<td><a href="#mod-pp-msg-9-revoke-participant" >[MOD-PP-MSG-9]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
-<td>Create or update Permission Session</td>
+<td>Create or update Participant Session</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-10-create-or-update-permission-session" >[MOD-PERM-MSG-10]</a></td>
+<td><a href="#mod-pp-msg-10-create-or-update-participant-session" >[MOD-PP-MSG-10]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
-<td>Update Permission Module Parameters</td>
+<td>Update Participant Module Parameters</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-11-update-permission-module-parameters" >[MOD-PERM-MSG-11]</a></td>
+<td><a href="#mod-pp-msg-11-update-participant-module-parameters" >[MOD-PP-MSG-11]</a></td>
 <td>governance proposal</td>
 </tr>
 <tr>
 <td></td>
-<td>Slash Permission Trust Deposit</td>
+<td>Slash Participant Trust Deposit</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-12-slash-permission-trust-deposit" >[MOD-PERM-MSG-12]</a></td>
+<td><a href="#mod-pp-msg-12-slash-participant-trust-deposit" >[MOD-PP-MSG-12]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
-<td>Repay Permission Slashed Trust Deposit</td>
+<td>Repay Participant Slashed Trust Deposit</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-13-repay-permission-slashed-trust-deposit" >[MOD-PERM-MSG-13]</a></td>
+<td><a href="#mod-pp-msg-13-repay-participant-slashed-trust-deposit" >[MOD-PP-MSG-13]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
-<td>Self Create Permission (OPEN mode)</td>
+<td>Self Create Participant (OPEN mode)</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-14-self-create-permission" >[MOD-PERM-MSG-14]</a></td>
+<td><a href="#mod-pp-msg-14-self-create-participant" >[MOD-PP-MSG-14]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
@@ -1278,47 +1415,47 @@ messages.</p>
 <td>Trigger Resolver</td>
 <td>N/A (Tx)</td>
 <td>Msg</td>
-<td><a href="#mod-perm-msg-15-trigger-resolver" >[MOD-PERM-MSG-15]</a></td>
+<td><a href="#mod-pp-msg-15-trigger-resolver" >[MOD-PP-MSG-15]</a></td>
 <td>corporation + operator</td>
 </tr>
 <tr>
 <td></td>
-<td>List Permissions</td>
-<td>/perm/v1/list</td>
+<td>List Participants</td>
+<td>/pp/v1/list</td>
 <td>Query</td>
-<td><a href="#mod-perm-qry-1-list-permissions" >[MOD-PERM-QRY-1]</a></td>
+<td><a href="#mod-pp-qry-1-list-participants" >[MOD-PP-QRY-1]</a></td>
 <td>N/A</td>
 </tr>
 <tr>
 <td></td>
-<td>Get a Permission</td>
-<td>/perm/v1/get</td>
+<td>Get a Participant</td>
+<td>/pp/v1/get</td>
 <td>Query</td>
-<td><a href="#mod-perm-qry-2-get-permission" >[MOD-PERM-QRY-2]</a></td>
+<td><a href="#mod-pp-qry-2-get-participant" >[MOD-PP-QRY-2]</a></td>
 <td>N/A</td>
 </tr>
 <tr>
 <td></td>
 <td>Find Beneficiaries</td>
-<td>/perm/v1/beneficiaries</td>
+<td>/pp/v1/beneficiaries</td>
 <td>Query</td>
-<td><a href="#mod-perm-qry-4-find-beneficiaries" >[MOD-PERM-QRY-4]</a></td>
+<td><a href="#mod-pp-qry-4-find-beneficiaries" >[MOD-PP-QRY-4]</a></td>
 <td>N/A</td>
 </tr>
 <tr>
 <td></td>
-<td>Get Permission Session</td>
-<td>/perm/v1/session/get</td>
+<td>Get Participant Session</td>
+<td>/pp/v1/session/get</td>
 <td>Query</td>
-<td><a href="#mod-perm-qry-5-get-permissionsession" >[MOD-PERM-QRY-5]</a></td>
+<td><a href="#mod-pp-qry-5-get-participantsession" >[MOD-PP-QRY-5]</a></td>
 <td>N/A</td>
 </tr>
 <tr>
 <td></td>
-<td>List Permission Module Parameters</td>
-<td>/perm/v1/params</td>
+<td>List Participant Module Parameters</td>
+<td>/pp/v1/params</td>
 <td>Query</td>
-<td><a href="#mod-perm-qry-6-list-permission-module-parameters" >[MOD-PERM-QRY-6]</a></td>
+<td><a href="#mod-pp-qry-6-list-participant-module-parameters" >[MOD-PP-QRY-6]</a></td>
 <td>N/A</td>
 </tr>
 <tr>
@@ -1435,30 +1572,6 @@ messages.</p>
 </tr>
 <tr>
 <td></td>
-<td>Grant Exchange Rate Authorization</td>
-<td>N/A (Tx)</td>
-<td>Msg</td>
-<td><a href="#mod-de-msg-7-grant-exchange-rate-authorization" >[MOD-DE-MSG-7]</a></td>
-<td>governance proposal</td>
-</tr>
-<tr>
-<td></td>
-<td>Revoke Exchange Rate Authorization</td>
-<td>N/A (Tx)</td>
-<td>Msg</td>
-<td><a href="#mod-de-msg-8-revoke-exchange-rate-authorization" >[MOD-DE-MSG-8]</a></td>
-<td>governance proposal</td>
-</tr>
-<tr>
-<td></td>
-<td>Update VS Operator Authorization Expiration</td>
-<td>N/A (Tx)</td>
-<td>Msg</td>
-<td><a href="#mod-de-msg-9-update-vs-operator-authorization-expiration" >[MOD-DE-MSG-9]</a></td>
-<td>module call</td>
-</tr>
-<tr>
-<td></td>
 <td>List Operator Authorizations</td>
 <td>/de/v1/authz/list</td>
 <td>Query</td>
@@ -1515,6 +1628,22 @@ messages.</p>
 </tr>
 <tr>
 <td></td>
+<td>Grant Exchange Rate Authorization</td>
+<td>N/A (Tx)</td>
+<td>Msg</td>
+<td><a href="#mod-xr-msg-4-grant-exchange-rate-authorization" >[MOD-XR-MSG-4]</a></td>
+<td>governance proposal</td>
+</tr>
+<tr>
+<td></td>
+<td>Revoke Exchange Rate Authorization</td>
+<td>N/A (Tx)</td>
+<td>Msg</td>
+<td><a href="#mod-xr-msg-5-revoke-exchange-rate-authorization" >[MOD-XR-MSG-5]</a></td>
+<td>governance proposal</td>
+</tr>
+<tr>
+<td></td>
 <td>Get Exchange Rate</td>
 <td>/xr/v1/get</td>
 <td>Query</td>
@@ -1541,24 +1670,24 @@ messages.</p>
 </table>
 <div id="note-80" class="notice note"><a class="notice-link" href="#note-80">NOTE</a><p>Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.</p>
 </div>
-<h3 id="trust-registry-module"><a class="toc-anchor" href="#trust-registry-module" >§</a> Trust Registry Module</h3>
-<h4 id="mod-tr-msg-1-create-new-trust-registry"><a class="toc-anchor" href="#mod-tr-msg-1-create-new-trust-registry" >§</a> [MOD-TR-MSG-1] Create New Trust Registry</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
-<h5 id="mod-tr-msg-1-1-create-new-trust-registry-parameters"><a class="toc-anchor" href="#mod-tr-msg-1-1-create-new-trust-registry-parameters" >§</a> [MOD-TR-MSG-1-1] Create New Trust Registry parameters</h5>
-<p>An authorized <code>operator</code> that would like to create a <a class="term-reference" href="#term:trust-registry">trust registry</a> MUST call this method by specifying:</p>
+<h3 id="corporation-module"><a class="toc-anchor" href="#corporation-module" >§</a> Corporation Module</h3>
+<p>This module manages <a class="term-reference" href="#term:corporation">corporation</a> entries — the VPR-level entity that extends a Cosmos SDK <a class="term-reference" href="#term:group">group</a> with a DID, a governance framework, and lifecycle attributes. A <code>Corporation</code> entry MUST exist before its underlying group can be referenced as the <code>corporation</code> (group) in any other VPR Create-* method (see <a href="#mod-co-msg-1-create-new-corporation" >[MOD-CO-MSG-1]</a>).</p>
+<h4 id="mod-co-msg-1-create-new-corporation"><a class="toc-anchor" href="#mod-co-msg-1-create-new-corporation" >§</a> [MOD-CO-MSG-1] Create New Corporation</h4>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a Cosmos SDK <a class="term-reference" href="#term:group">group</a> to register a new <code>Corporation</code> entry for that group.</p>
+<h5 id="mod-co-msg-1-1-create-new-corporation-parameters"><a class="toc-anchor" href="#mod-co-msg-1-1-create-new-corporation-parameters" >§</a> [MOD-CO-MSG-1-1] Create New Corporation parameters</h5>
+<p>An authorized <code>operator</code> that would like to register a Cosmos SDK <a class="term-reference" href="#term:group">group</a> as a <code>Corporation</code> MUST call this method by specifying:</p>
 <ul>
-<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed. For this method specifically, the underlying Cosmos SDK <a class="term-reference" href="#term:group">group</a> of <code>corporation</code> is the group that wants to register itself — no <code>Corporation</code> entry exists for that group yet.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>did</code> (string) (<em>mandatory</em>): the did of the ecosystem that is creating the trust registry.</li>
-<li><code>aka</code> (string) (<em>optional</em>): optional additional URI of this trust registry.</li>
-<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of this trust registry.</li>
-<li><code>doc_url</code> (string) (<em>mandatory</em>): URL where the document is published.</li>
-<li><code>doc_digest_sri</code> (string) (<em>mandatory</em>): digest_sri of the document.</li>
+<li><code>did</code> (string) (<em>mandatory</em>): the DID of the Corporation.</li>
+<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of this Corporation.</li>
+<li><code>doc_url</code> (string) (<em>mandatory</em>): URL where the v1 <a class="term-reference" href="#term:cgf">CGF</a> document is published.</li>
+<li><code>doc_digest_sri</code> (string) (<em>mandatory</em>): digest_sri of the v1 <a class="term-reference" href="#term:cgf">CGF</a> document.</li>
 </ul>
-<p>Provided document must be of the same language that the primary language of the trust registry.</p>
-<h5 id="mod-tr-msg-1-2-create-new-trust-registry-precondition-checks"><a class="toc-anchor" href="#mod-tr-msg-1-2-create-new-trust-registry-precondition-checks" >§</a> [MOD-TR-MSG-1-2] Create New Trust Registry precondition checks</h5>
+<p>Provided document MUST be of the same language as the primary <code>language</code> of the Corporation.</p>
+<h5 id="mod-co-msg-1-2-create-new-corporation-precondition-checks"><a class="toc-anchor" href="#mod-co-msg-1-2-create-new-corporation-precondition-checks" >§</a> [MOD-CO-MSG-1-2] Create New Corporation precondition checks</h5>
 <p>If any of these precondition checks fail, method MUST abort.</p>
-<h6 id="mod-tr-msg-1-2-1-create-new-trust-registry-basic-checks"><a class="toc-anchor" href="#mod-tr-msg-1-2-1-create-new-trust-registry-basic-checks" >§</a> [MOD-TR-MSG-1-2-1] Create New Trust Registry basic checks</h6>
+<h6 id="mod-co-msg-1-2-1-create-new-corporation-basic-checks"><a class="toc-anchor" href="#mod-co-msg-1-2-1-create-new-corporation-basic-checks" >§</a> [MOD-CO-MSG-1-2-1] Create New Corporation basic checks</h6>
 <ul>
 <li>
 <p>if a mandatory parameter is not present, method MUST abort.</p>
@@ -1573,55 +1702,47 @@ messages.</p>
 <p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
 </li>
 <li>
-<p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
+<p>A <code>Corporation</code> entry for the signing <a class="term-reference" href="#term:group">group</a> MUST NOT exist; if one exists, method MUST abort (a group MAY register itself as a <code>Corporation</code> at most once).</p>
 </li>
 <li>
-<p><code>aka</code> (string) (<em>optional</em>): optional additional URI of this trust registry. MUST be an <a class="term-reference" href="#term:uri">URI</a>.</p>
+<p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
 </li>
 <li>
 <p><code>language</code> (string(17)) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>).</p>
 </li>
 <li>
-<p><code>doc_url</code> (string) (<em>mandatory</em>): MUST be a valid URL .</p>
+<p><code>doc_url</code> (string) (<em>mandatory</em>): MUST be a valid URL.</p>
 </li>
 <li>
 <p><code>doc_digest_sri</code> (string) (<em>mandatory</em>): MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</p>
 </li>
 </ul>
-<div id="note-81" class="notice note"><a class="notice-link" href="#note-81">NOTE</a><p>It is not a problem if several trust registries are created with the same ecosystem DID. Identifier of a <code>TrustRegistry</code> is its id, and the Verifiable Trust Spec includes the id of the <code>TrustRegistry</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
-</div>
-<h6 id="mod-tr-msg-1-2-2-create-new-trust-registry-fee-checks"><a class="toc-anchor" href="#mod-tr-msg-1-2-2-create-new-trust-registry-fee-checks" >§</a> [MOD-TR-MSG-1-2-2] Create New Trust Registry fee checks</h6>
-<p>Fee payer MUST have an available balance to cover the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</p>
-<h5 id="mod-tr-msg-1-3-create-new-trust-registry-execution"><a class="toc-anchor" href="#mod-tr-msg-1-3-create-new-trust-registry-execution" >§</a> [MOD-TR-MSG-1-3] Create New Trust Registry execution</h5>
+<h6 id="mod-co-msg-1-2-2-create-new-corporation-fee-checks"><a class="toc-anchor" href="#mod-co-msg-1-2-2-create-new-corporation-fee-checks" >§</a> [MOD-CO-MSG-1-2-2] Create New Corporation fee checks</h6>
+<p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>.</p>
+<h5 id="mod-co-msg-1-3-create-new-corporation-execution"><a class="toc-anchor" href="#mod-co-msg-1-3-create-new-corporation-execution" >§</a> [MOD-CO-MSG-1-3] Create New Corporation execution</h5>
 <p>If all precondition checks passed, method is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>
-<p>create and persist a new <code>TrustRegistry</code> entry <code>tr</code>:</p>
+<p>create and persist a new <code>Corporation</code> entry <code>co</code> keyed by the signing Cosmos SDK <a class="term-reference" href="#term:group">group</a> (1:1):</p>
 </li>
 <li>
-<p><code>tr.id</code> : auto-incremented uint64</p>
+<p><code>co.did</code>: <code>did</code></p>
 </li>
 <li>
-<p><code>tr.did</code>: <code>did</code></p>
+<p><code>co.created</code>: current timestamp</p>
 </li>
 <li>
-<p><code>tr.corporation</code>: <code>corporation</code></p>
+<p><code>co.modified</code>: <code>co.created</code></p>
 </li>
 <li>
-<p><code>tr.created</code>: current timestamp</p>
+<p><code>co.archived</code>: null</p>
 </li>
 <li>
-<p><code>tr.modified</code>: <code>tr.created</code></p>
+<p><code>co.language</code>: <code>language</code></p>
 </li>
 <li>
-<p><code>tr.aka</code>: <code>aka</code></p>
-</li>
-<li>
-<p><code>tr.language</code>: <code>language</code></p>
-</li>
-<li>
-<p><code>tr.active_version</code>: 1</p>
+<p><code>co.active_version</code>: 1</p>
 </li>
 <li>
 <p>create and persist a new <code>GovernanceFrameworkVersion</code> entry <code>gfv</code>:</p>
@@ -1630,7 +1751,10 @@ messages.</p>
 <p><code>gfv.id</code>: auto-incremented uint64</p>
 </li>
 <li>
-<p><code>gfv.tr_id</code>: <code>tr.id</code></p>
+<p><code>gfv.ecosystem_id</code>: null</p>
+</li>
+<li>
+<p><code>gfv.corporation_id</code>: id of the signing <a class="term-reference" href="#term:group">group</a> (i.e., the key of <code>co</code>)</p>
 </li>
 <li>
 <p><code>gfv.created</code>: current timestamp</p>
@@ -1663,57 +1787,273 @@ messages.</p>
 <p><code>gfd.digest_sri</code>: <code>doc_digest_sri</code></p>
 </li>
 </ul>
-<h4 id="mod-tr-msg-2-add-governance-framework-document"><a class="toc-anchor" href="#mod-tr-msg-2-add-governance-framework-document" >§</a> [MOD-TR-MSG-2] Add Governance Framework Document</h4>
+<blockquote>
+<p>Subsequent governance framework documents and version activations for this <code>Corporation</code> MUST be managed through <a href="#mod-gf-msg-1-add-governance-framework-document" >[MOD-GF-MSG-1]</a> and <a href="#mod-gf-msg-2-increase-active-governance-framework-version" >[MOD-GF-MSG-2]</a>.</p>
+</blockquote>
+<h4 id="mod-co-msg-2-update-corporation"><a class="toc-anchor" href="#mod-co-msg-2-update-corporation" >§</a> [MOD-CO-MSG-2] Update Corporation</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
-<h5 id="mod-tr-msg-2-1-add-governance-framework-document-parameters"><a class="toc-anchor" href="#mod-tr-msg-2-1-add-governance-framework-document-parameters" >§</a> [MOD-TR-MSG-2-1] Add Governance Framework Document parameters</h5>
+<h5 id="mod-co-msg-2-1-update-corporation-parameters"><a class="toc-anchor" href="#mod-co-msg-2-1-update-corporation-parameters" >§</a> [MOD-CO-MSG-2-1] Update Corporation parameters</h5>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the trust registry.</li>
-<li><code>doc_language</code> (string) (<em>mandatory</em>): language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of the <a class="term-reference" href="#term:egf">EGF</a> document, provided by the <a class="term-reference" href="#term:ega">EGA</a>.</li>
-<li><code>doc_url</code> (string) (<em>mandatory</em>): URL where the document is published.</li>
-<li><code>doc_digest_sri</code> (string) (<em>mandatory</em>): digest_sri of the document.</li>
-<li><code>version</code> (int) (<em>mandatory</em>): targeted version.</li>
+<li><code>did</code> (string) (<em>mandatory</em>): the new DID of the Corporation.</li>
+<li><code>language</code> (string) (<em>mandatory</em>): primary language tag of this Corporation.</li>
 </ul>
-<p>If for a given language, a document already exists, the execution of this transaction will replace the corresponding entry. Else, a new entry is created. It is only possible to edit future versions. Active version cannot be modified.</p>
-<h5 id="mod-tr-msg-2-2-add-governance-framework-document-precondition-checks"><a class="toc-anchor" href="#mod-tr-msg-2-2-add-governance-framework-document-precondition-checks" >§</a> [MOD-TR-MSG-2-2] Add Governance Framework Document precondition checks</h5>
+<h5 id="mod-co-msg-2-2-update-corporation-precondition-checks"><a class="toc-anchor" href="#mod-co-msg-2-2-update-corporation-precondition-checks" >§</a> [MOD-CO-MSG-2-2] Update Corporation precondition checks</h5>
 <p>If any of these precondition checks fail, method MUST abort.</p>
-<h6 id="mod-tr-msg-2-2-1-add-governance-framework-document-basic-checks"><a class="toc-anchor" href="#mod-tr-msg-2-2-1-add-governance-framework-document-basic-checks" >§</a> [MOD-TR-MSG-2-2-1] Add Governance Framework Document basic checks</h6>
-<p>if a mandatory parameter is not present, method MUST abort.</p>
+<h6 id="mod-co-msg-2-2-1-update-corporation-basic-checks"><a class="toc-anchor" href="#mod-co-msg-2-2-1-update-corporation-basic-checks" >§</a> [MOD-CO-MSG-2-2-1] Update Corporation basic checks</h6>
 <ul>
-<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
-<li><code>operator</code> (account): (Signer) signature must be verified.</li>
-<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): a <code>TrustRegistry</code> entry with this id MUST exist and <code>corporation</code> executing the method MUST be the <code>corporation</code> of the <code>TrustRegistry</code> entry.</li>
-<li><code>version</code>: there MUST exist a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> where <code>gfv.tr_id</code> is equal to <code>id</code> and <code>gfv.version</code> = <code>version</code>, or <code>version</code> MUST be exactly equal to the biggest found <code>gfv.version</code> + 1 of all <code>GovernanceFrameworkVersion</code> entries found for this <code>gfv.tr_id</code> equal to <code>id</code>. <code>version</code> MUST be greater than the <code>tr.active_version</code>.</li>
-<li><code>doc_language</code> (string) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>).</li>
-<li><code>doc_url</code> (string) (<em>mandatory</em>): MUST be a valid URL.</li>
-<li><code>doc_digest_sri</code> (string) (<em>mandatory</em>): MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</li>
+<li>
+<p>if a mandatory parameter is not present, method MUST abort.</p>
+</li>
+<li>
+<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
+</li>
+<li>
+<p><code>operator</code> (account): (Signer) signature must be verified.</p>
+</li>
+<li>
+<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
+</li>
+<li>
+<p>A <code>Corporation</code> entry <code>co</code> for the signing <code>corporation</code> MUST exist; if none exists, method MUST abort.</p>
+</li>
+<li>
+<p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
+</li>
+<li>
+<p><code>language</code> (string(17)) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>).</p>
+</li>
 </ul>
-<h6 id="mod-tr-msg-2-2-2-add-governance-framework-document-fee-checks"><a class="toc-anchor" href="#mod-tr-msg-2-2-2-add-governance-framework-document-fee-checks" >§</a> [MOD-TR-MSG-2-2-2] Add Governance Framework Document fee checks</h6>
-<p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>.</p>
-<h5 id="mod-tr-msg-2-3-add-governance-framework-document-execution"><a class="toc-anchor" href="#mod-tr-msg-2-3-add-governance-framework-document-execution" >§</a> [MOD-TR-MSG-2-3] Add Governance Framework Document execution</h5>
+<h6 id="mod-co-msg-2-2-2-update-corporation-fee-checks"><a class="toc-anchor" href="#mod-co-msg-2-2-2-update-corporation-fee-checks" >§</a> [MOD-CO-MSG-2-2-2] Update Corporation fee checks</h6>
+<p>Fee payer MUST have available balance in its <a class="term-reference" href="#term:account">account</a> to cover the required <a class="term-reference" href="#term:transaction-fees">transaction fees</a>.</p>
+<h5 id="mod-co-msg-2-3-update-corporation-execution"><a class="toc-anchor" href="#mod-co-msg-2-3-update-corporation-execution" >§</a> [MOD-CO-MSG-2-3] Update Corporation execution</h5>
 <p>If all precondition checks passed, method is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
-<p>load <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> for the requested version, or create a new <code>GovernanceFrameworkVersion</code> <code>gfv</code> if required:</p>
 <ul>
+<li>
+<p>load <code>Corporation</code> entry <code>co</code> for the signing <code>corporation</code> and set:</p>
+</li>
+<li>
+<p><code>co.did</code>: <code>did</code></p>
+</li>
+<li>
+<p><code>co.language</code>: <code>language</code></p>
+</li>
+<li>
+<p><code>co.modified</code>: current timestamp</p>
+</li>
+</ul>
+<h4 id="mod-co-msg-3-archive-corporation"><a class="toc-anchor" href="#mod-co-msg-3-archive-corporation" >§</a> [MOD-CO-MSG-3] Archive Corporation</h4>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
+<h5 id="mod-co-msg-3-1-archive-corporation-parameters"><a class="toc-anchor" href="#mod-co-msg-3-1-archive-corporation-parameters" >§</a> [MOD-CO-MSG-3-1] Archive Corporation parameters</h5>
+<ul>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
+<li><code>archive</code> (boolean) (<em>mandatory</em>): true means archive, false means unarchive.</li>
+</ul>
+<h5 id="mod-co-msg-3-2-archive-corporation-precondition-checks"><a class="toc-anchor" href="#mod-co-msg-3-2-archive-corporation-precondition-checks" >§</a> [MOD-CO-MSG-3-2] Archive Corporation precondition checks</h5>
+<p>If any of these precondition checks fail, method MUST abort.</p>
+<h6 id="mod-co-msg-3-2-1-archive-corporation-basic-checks"><a class="toc-anchor" href="#mod-co-msg-3-2-1-archive-corporation-basic-checks" >§</a> [MOD-CO-MSG-3-2-1] Archive Corporation basic checks</h6>
+<ul>
+<li>
+<p>if a mandatory parameter is not present, method MUST abort.</p>
+</li>
+<li>
+<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
+</li>
+<li>
+<p><code>operator</code> (account): (Signer) signature must be verified.</p>
+</li>
+<li>
+<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
+</li>
+<li>
+<p>load <code>Corporation</code> <code>co</code> from the id of the signing <code>corporation</code>. If none exists, MUST abort.</p>
+</li>
+<li>
+<p><code>archive</code> (boolean) (<em>mandatory</em>) MUST be a boolean.</p>
+<ul>
+<li>If <code>archive</code> is true and <code>co.archived</code> is not null, MUST abort as <code>Corporation</code> is already archived.</li>
+<li>If <code>archive</code> is false and <code>co.archived</code> is null, MUST abort as <code>Corporation</code> is already not archived.</li>
+</ul>
+</li>
+</ul>
+<h6 id="mod-co-msg-3-2-2-archive-corporation-fee-checks"><a class="toc-anchor" href="#mod-co-msg-3-2-2-archive-corporation-fee-checks" >§</a> [MOD-CO-MSG-3-2-2] Archive Corporation fee checks</h6>
+<p>Fee payer MUST have an available balance in its <a class="term-reference" href="#term:account">account</a> to cover the required <a class="term-reference" href="#term:transaction-fees">transaction fees</a>.</p>
+<h5 id="mod-co-msg-3-3-archive-corporation-execution"><a class="toc-anchor" href="#mod-co-msg-3-3-archive-corporation-execution" >§</a> [MOD-CO-MSG-3-3] Archive Corporation execution</h5>
+<p>If all precondition checks passed, method is executed.</p>
+<p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
+<ul>
+<li>update <code>Corporation</code> entry <code>co</code>:</li>
+<li>if <code>archive</code> is true: set <code>co.archived</code> to current timestamp.</li>
+<li>if <code>archive</code> is false: set <code>co.archived</code> to null.</li>
+<li><code>co.modified</code>: current timestamp</li>
+</ul>
+<h4 id="mod-co-msg-4-update-module-parameters"><a class="toc-anchor" href="#mod-co-msg-4-update-module-parameters" >§</a> [MOD-CO-MSG-4] Update Module Parameters</h4>
+<p>Update Module Parameters.</p>
+<p>Can only be executed through a governance proposal.</p>
+<h5 id="mod-co-msg-4-1-update-module-parameters-parameters"><a class="toc-anchor" href="#mod-co-msg-4-1-update-module-parameters-parameters" >§</a> [MOD-CO-MSG-4-1] Update Module Parameters parameters</h5>
+<ul>
+<li><code>params</code> (KeySet&lt;String, String&gt;): the parameters to update and their values.</li>
+</ul>
+<h5 id="mod-co-msg-4-2-update-module-parameters-precondition-checks"><a class="toc-anchor" href="#mod-co-msg-4-2-update-module-parameters-precondition-checks" >§</a> [MOD-CO-MSG-4-2] Update Module Parameters precondition checks</h5>
+<p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<h6 id="mod-co-msg-4-2-1-update-module-parameters-basic-checks"><a class="toc-anchor" href="#mod-co-msg-4-2-1-update-module-parameters-basic-checks" >§</a> [MOD-CO-MSG-4-2-1] Update Module Parameters basic checks</h6>
+<ul>
+<li><code>params</code>: size of <code>params</code> MUST be greater than 0. For each <code>param</code> &lt;<code>key</code>, <code>value</code>&gt;, <code>key</code> MUST exist, else abort.</li>
+</ul>
+<h6 id="mod-co-msg-4-2-2-update-module-parameters-fee-checks"><a class="toc-anchor" href="#mod-co-msg-4-2-2-update-module-parameters-fee-checks" >§</a> [MOD-CO-MSG-4-2-2] Update Module Parameters fee checks</h6>
+<p>provided transaction fees MUST be sufficient for execution.</p>
+<h5 id="mod-co-msg-4-3-update-module-parameters-execution"><a class="toc-anchor" href="#mod-co-msg-4-3-update-module-parameters-execution" >§</a> [MOD-CO-MSG-4-3] Update Module Parameters execution</h5>
+<p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
+<p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
+<p>for each parameter <code>param</code> &lt;<code>key</code>, <code>value</code>&gt; in <code>parameters</code>:</p>
+<ul>
+<li>update parameter set value = <code>value</code> where key = <code>key</code>.</li>
+</ul>
+<h4 id="mod-co-qry-1-get-corporation"><a class="toc-anchor" href="#mod-co-qry-1-get-corporation" >§</a> [MOD-CO-QRY-1] Get Corporation</h4>
+<p>Anyone CAN execute this method.</p>
+<h5 id="mod-co-qry-1-1-get-corporation-query-parameters"><a class="toc-anchor" href="#mod-co-qry-1-1-get-corporation-query-parameters" >§</a> [MOD-CO-QRY-1-1] Get Corporation query parameters</h5>
+<ul>
+<li><code>corporation</code> (group) (<em>mandatory</em>): the <a class="term-reference" href="#term:corporation">corporation</a> to fetch (i.e., the underlying Cosmos SDK <a class="term-reference" href="#term:group">group</a> whose <code>Corporation</code> entry is keyed by it).</li>
+<li><code>active_gf_only</code> (boolean) (<em>optional</em>): if true, include only current governance framework data. If false or null, returns everything.</li>
+<li><code>preferred_language</code> (string) (<em>optional</em>): if set, return only one document per version, preferring <code>preferred_language</code>.</li>
+</ul>
+<h5 id="mod-co-qry-1-2-get-corporation-query-checks"><a class="toc-anchor" href="#mod-co-qry-1-2-get-corporation-query-checks" >§</a> [MOD-CO-QRY-1-2] Get Corporation query checks</h5>
+<p>If any of these checks fail, <a class="term-reference" href="#term:query">query</a> MUST fail.</p>
+<ul>
+<li><code>corporation</code> (group) (<em>mandatory</em>): MUST be a valid group id.</li>
+</ul>
+<h5 id="mod-co-qry-1-3-get-corporation-execution"><a class="toc-anchor" href="#mod-co-qry-1-3-get-corporation-execution" >§</a> [MOD-CO-QRY-1-3] Get Corporation execution</h5>
+<p>Return the <code>Corporation</code> entry keyed by <code>corporation</code> (if any), as well as <em>all its nested</em> <code>GovernanceFrameworkVersion</code> and <code>GovernanceFrameworkDocument</code> entries. If <code>active_gf_only</code> is true, return only nested <code>GovernanceFrameworkVersion</code> and <code>GovernanceFrameworkDocument</code> entries for the active version.</p>
+<h4 id="mod-co-qry-2-list-corporations"><a class="toc-anchor" href="#mod-co-qry-2-list-corporations" >§</a> [MOD-CO-QRY-2] List Corporations</h4>
+<h5 id="mod-co-qry-2-1-list-corporations-query-parameters"><a class="toc-anchor" href="#mod-co-qry-2-1-list-corporations-query-parameters" >§</a> [MOD-CO-QRY-2-1] List Corporations query parameters</h5>
+<p>The following parameters are optional:</p>
+<ul>
+<li><code>modified_after</code> (timestamp) (<em>optional</em>): if specified, returns only <code>Corporation</code> entries with <code>Corporation.modified</code> greater than <code>modified_after</code>.</li>
+<li><code>active_gf_only</code> (boolean) (<em>optional</em>): if true, include only current governance framework data. If false or null, returns everything.</li>
+<li><code>preferred_language</code> (string) (<em>optional</em>): if set, return only one document per version, preferring <code>preferred_language</code>.</li>
+<li><code>response_max_size</code> (small number) (<em>optional</em>): default to 64. Max 1,024.</li>
+</ul>
+<h5 id="mod-co-qry-2-2-list-corporations-query-checks"><a class="toc-anchor" href="#mod-co-qry-2-2-list-corporations-query-checks" >§</a> [MOD-CO-QRY-2-2] List Corporations query checks</h5>
+<p>If any of these checks fail, <a class="term-reference" href="#term:query">query</a> MUST fail.</p>
+<ul>
+<li><code>response_max_size</code> must be between 1 and 1,024. Default to 64 if unspecified.</li>
+</ul>
+<h5 id="mod-co-qry-2-3-list-corporations-execution"><a class="toc-anchor" href="#mod-co-qry-2-3-list-corporations-execution" >§</a> [MOD-CO-QRY-2-3] List Corporations execution</h5>
+<p>If all precondition checks passed, <a class="term-reference" href="#term:query">query</a> is executed and result (may be empty) returned. If <code>modified_after</code> is specified, order by <code>modified</code> desc.</p>
+<h4 id="mod-co-qry-3-list-module-parameters"><a class="toc-anchor" href="#mod-co-qry-3-list-module-parameters" >§</a> [MOD-CO-QRY-3] List Module Parameters</h4>
+<p>Anyone CAN run this <a class="term-reference" href="#term:query">query</a>.</p>
+<h5 id="mod-co-qry-3-3-list-module-parameters-execution"><a class="toc-anchor" href="#mod-co-qry-3-3-list-module-parameters-execution" >§</a> [MOD-CO-QRY-3-3] List Module Parameters execution</h5>
+<p>Return the list of parameters of this module as a json file:</p>
+<pre class="language-json"><code class="language-json"><span class="token punctuation">{</span>
+  <span class="token property">"params"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
+    <span class="token property">"key1"</span><span class="token operator">:</span> <span class="token string">"value1"</span><span class="token punctuation">,</span>
+    <span class="token property">"key2"</span><span class="token operator">:</span> <span class="token string">"value2"</span><span class="token punctuation">,</span>
+    ...
+    ...
+  <span class="token punctuation">}</span>
+<span class="token punctuation">}</span>
+</code></pre>
+<h3 id="ecosystem-module"><a class="toc-anchor" href="#ecosystem-module" >§</a> Ecosystem Module</h3>
+<h4 id="mod-es-msg-1-create-new-ecosystem"><a class="toc-anchor" href="#mod-es-msg-1-create-new-ecosystem" >§</a> [MOD-ES-MSG-1] Create New Ecosystem</h4>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
+<h5 id="mod-es-msg-1-1-create-new-ecosystem-parameters"><a class="toc-anchor" href="#mod-es-msg-1-1-create-new-ecosystem-parameters" >§</a> [MOD-ES-MSG-1-1] Create New Ecosystem parameters</h5>
+<p>An authorized <code>operator</code> that would like to create a <a class="term-reference" href="#term:ecosystem">ecosystem</a> MUST call this method by specifying:</p>
+<ul>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
+<li><code>did</code> (string) (<em>mandatory</em>): the did of the ecosystem that is creating the ecosystem.</li>
+<li><code>language</code> (string) (<em>mandatory</em>): primary language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of this ecosystem.</li>
+<li><code>doc_url</code> (string) (<em>mandatory</em>): URL where the document is published.</li>
+<li><code>doc_digest_sri</code> (string) (<em>mandatory</em>): digest_sri of the document.</li>
+</ul>
+<p>Provided document must be of the same language that the primary language of the ecosystem.</p>
+<h5 id="mod-es-msg-1-2-create-new-ecosystem-precondition-checks"><a class="toc-anchor" href="#mod-es-msg-1-2-create-new-ecosystem-precondition-checks" >§</a> [MOD-ES-MSG-1-2] Create New Ecosystem precondition checks</h5>
+<p>If any of these precondition checks fail, method MUST abort.</p>
+<h6 id="mod-es-msg-1-2-1-create-new-ecosystem-basic-checks"><a class="toc-anchor" href="#mod-es-msg-1-2-1-create-new-ecosystem-basic-checks" >§</a> [MOD-ES-MSG-1-2-1] Create New Ecosystem basic checks</h6>
+<ul>
+<li>
+<p>if a mandatory parameter is not present, method MUST abort.</p>
+</li>
+<li>
+<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
+</li>
+<li>
+<p><code>operator</code> (account): (Signer) signature must be verified.</p>
+</li>
+<li>
+<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
+</li>
+<li>
+<p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
+</li>
+<li>
+<p><code>language</code> (string(17)) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>).</p>
+</li>
+<li>
+<p><code>doc_url</code> (string) (<em>mandatory</em>): MUST be a valid URL .</p>
+</li>
+<li>
+<p><code>doc_digest_sri</code> (string) (<em>mandatory</em>): MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</p>
+</li>
+</ul>
+<div id="note-81" class="notice note"><a class="notice-link" href="#note-81">NOTE</a><p>It is not a problem if several ecosystems are created with the same ecosystem DID. Identifier of a <code>Ecosystem</code> is its id, and the Verifiable Trust Spec includes the id of the <code>Ecosystem</code> in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.</p>
+</div>
+<h6 id="mod-es-msg-1-2-2-create-new-ecosystem-fee-checks"><a class="toc-anchor" href="#mod-es-msg-1-2-2-create-new-ecosystem-fee-checks" >§</a> [MOD-ES-MSG-1-2-2] Create New Ecosystem fee checks</h6>
+<p>Fee payer MUST have an available balance to cover the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</p>
+<h5 id="mod-es-msg-1-3-create-new-ecosystem-execution"><a class="toc-anchor" href="#mod-es-msg-1-3-create-new-ecosystem-execution" >§</a> [MOD-ES-MSG-1-3] Create New Ecosystem execution</h5>
+<p>If all precondition checks passed, method is executed.</p>
+<p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
+<ul>
+<li>
+<p>create and persist a new <code>Ecosystem</code> entry <code>tr</code>:</p>
+</li>
+<li>
+<p><code>ecosystem.id</code> : auto-incremented uint64</p>
+</li>
+<li>
+<p><code>ecosystem.did</code>: <code>did</code></p>
+</li>
+<li>
+<p><code>ecosystem.corporation</code>: <code>corporation</code></p>
+</li>
+<li>
+<p><code>ecosystem.created</code>: current timestamp</p>
+</li>
+<li>
+<p><code>ecosystem.modified</code>: <code>ecosystem.created</code></p>
+</li>
+<li>
+<p><code>ecosystem.language</code>: <code>language</code></p>
+</li>
+<li>
+<p><code>ecosystem.active_version</code>: 1</p>
+</li>
+<li>
+<p>create and persist a new <code>GovernanceFrameworkVersion</code> entry <code>gfv</code>:</p>
+</li>
 <li>
 <p><code>gfv.id</code>: auto-incremented uint64</p>
 </li>
 <li>
-<p><code>gfv.tr_id</code>: <code>id</code></p>
+<p><code>gfv.ecosystem_id</code>: <code>ecosystem.id</code></p>
+</li>
+<li>
+<p><code>gfv.corporation_id</code>: null</p>
 </li>
 <li>
 <p><code>gfv.created</code>: current timestamp</p>
 </li>
 <li>
-<p><code>gfv.version</code>: <code>version</code></p>
+<p><code>gfv.version</code>: 1</p>
 </li>
 <li>
-<p><code>gfv.active_since</code>: null</p>
+<p><code>gfv.active_since</code>: current timestamp</p>
 </li>
 <li>
-<p>create and persist or (replace if already exist) a <code>GovernanceFrameworkDocument</code> entry <code>gfd</code>:</p>
+<p>create and persist a new <code>GovernanceFrameworkDocument</code> entry <code>gfd</code>:</p>
 </li>
 <li>
 <p><code>gfd.id</code>: auto-incremented uint64</p>
@@ -1725,7 +2065,7 @@ messages.</p>
 <p><code>gfd.created</code>: current timestamp</p>
 </li>
 <li>
-<p><code>gfd.language</code>: <code>doc_language</code></p>
+<p><code>gfd.language</code>: <code>language</code></p>
 </li>
 <li>
 <p><code>gfd.url</code>: <code>doc_url</code></p>
@@ -1734,17 +2074,21 @@ messages.</p>
 <p><code>gfd.digest_sri</code>: <code>doc_digest_sri</code></p>
 </li>
 </ul>
-<h4 id="mod-tr-msg-3-increase-active-governance-framework-version"><a class="toc-anchor" href="#mod-tr-msg-3-increase-active-governance-framework-version" >§</a> [MOD-TR-MSG-3] Increase Active Governance Framework Version</h4>
+<blockquote>
+<p>Subsequent governance framework documents and version activations for this ecosystem MUST be managed through <a href="#mod-gf-msg-1-add-governance-framework-document" >[MOD-GF-MSG-1]</a> and <a href="#mod-gf-msg-2-increase-active-governance-framework-version" >[MOD-GF-MSG-2]</a>.</p>
+</blockquote>
+<h4 id="mod-es-msg-2-update-ecosystem"><a class="toc-anchor" href="#mod-es-msg-2-update-ecosystem" >§</a> [MOD-ES-MSG-2] Update Ecosystem</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
-<h5 id="mod-tr-msg-3-1-increase-active-governance-framework-version-parameters"><a class="toc-anchor" href="#mod-tr-msg-3-1-increase-active-governance-framework-version-parameters" >§</a> [MOD-TR-MSG-3-1] Increase Active Governance Framework Version parameters</h5>
+<h5 id="mod-es-msg-2-1-update-ecosystem-parameters"><a class="toc-anchor" href="#mod-es-msg-2-1-update-ecosystem-parameters" >§</a> [MOD-ES-MSG-2-1] Update Ecosystem parameters</h5>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the trust registry.</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the ecosystem.</li>
+<li><code>did</code> (string) (<em>mandatory</em>): the did of the ecosystem.</li>
 </ul>
-<h5 id="mod-tr-msg-3-2-increase-active-governance-framework-version-precondition-checks"><a class="toc-anchor" href="#mod-tr-msg-3-2-increase-active-governance-framework-version-precondition-checks" >§</a> [MOD-TR-MSG-3-2] Increase Active Governance Framework Version precondition checks</h5>
+<h5 id="mod-es-msg-2-2-update-ecosystem-precondition-checks"><a class="toc-anchor" href="#mod-es-msg-2-2-update-ecosystem-precondition-checks" >§</a> [MOD-ES-MSG-2-2] Update Ecosystem precondition checks</h5>
 <p>If any of these precondition checks fail, method MUST abort.</p>
-<h6 id="mod-tr-msg-3-2-1-increase-active-governance-framework-version-basic-checks"><a class="toc-anchor" href="#mod-tr-msg-3-2-1-increase-active-governance-framework-version-basic-checks" >§</a> [MOD-TR-MSG-3-2-1] Increase Active Governance Framework Version basic checks</h6>
+<h6 id="mod-es-msg-2-2-1-update-ecosystem-basic-checks"><a class="toc-anchor" href="#mod-es-msg-2-2-1-update-ecosystem-basic-checks" >§</a> [MOD-ES-MSG-2-2-1] Update Ecosystem basic checks</h6>
 <ul>
 <li>
 <p>if a mandatory parameter is not present, method MUST abort.</p>
@@ -1759,90 +2103,40 @@ messages.</p>
 <p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
 </li>
 <li>
-<p><code>id</code> (uint64) (<em>mandatory</em>): a <code>TrustRegistry</code> entry with this id MUST exist and <code>corporation</code> executing the method MUST be the <code>corporation</code> of the <code>TrustRegistry</code> entry.</p>
-</li>
-<li>
-<p>load <code>TrustRegistry</code> entry <code>tr</code> from its <code>id</code>. Find a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> where version is equal to <code>tr.active_version</code> + 1. If none is found, transaction MUST abort.</p>
-</li>
-<li>
-<p>find <code>GovernanceFrameworkDocument</code> <code>gfd</code> for <code>gfd.gfv_id</code> = <code>gfv.id</code> and <code>gfd.language</code> = <code>tr.language</code>. If no document is found (and thus no document exist for the default language of this version for this trust registry), transaction MUST abort.</p>
-</li>
-</ul>
-<h6 id="mod-tr-msg-3-2-2-increase-active-governance-framework-version-fee-checks"><a class="toc-anchor" href="#mod-tr-msg-3-2-2-increase-active-governance-framework-version-fee-checks" >§</a> [MOD-TR-MSG-3-2-2] Increase Active Governance Framework Version fee checks</h6>
-<p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>.</p>
-<h5 id="mod-tr-msg-3-3-increase-active-governance-framework-version-execution"><a class="toc-anchor" href="#mod-tr-msg-3-3-increase-active-governance-framework-version-execution" >§</a> [MOD-TR-MSG-3-3] Increase Active Governance Framework Version execution</h5>
-<p>If all precondition checks passed, method is executed.</p>
-<p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
-<ul>
-<li>load <code>TrustRegistry</code> entry <code>tr</code> from its <code>id</code>. Find a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> where version is equal to <code>tr.active_version</code> + 1. If none is found, transaction MUST abort. Else, update <code>tr.active_version</code> to <code>tr.active_version</code> + 1. Set <code>tr.modified</code> to current timestamp, and set <code>gfv.active_since</code> to current timestamp and persist changes.</li>
-</ul>
-<h4 id="mod-tr-msg-4-update-trust-registry"><a class="toc-anchor" href="#mod-tr-msg-4-update-trust-registry" >§</a> [MOD-TR-MSG-4] Update Trust Registry</h4>
-<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
-<h5 id="mod-tr-msg-4-1-update-trust-registry-parameters"><a class="toc-anchor" href="#mod-tr-msg-4-1-update-trust-registry-parameters" >§</a> [MOD-TR-MSG-4-1] Update Trust Registry parameters</h5>
-<ul>
-<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
-<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the trust registry.</li>
-<li><code>did</code> (string) (<em>mandatory</em>): the did of the trust registry.</li>
-<li><code>aka</code> (string) (<em>optional</em>): optional additional URI of this trust registry. If null, it means replace existing value with null.</li>
-</ul>
-<h5 id="mod-tr-msg-4-2-update-trust-registry-precondition-checks"><a class="toc-anchor" href="#mod-tr-msg-4-2-update-trust-registry-precondition-checks" >§</a> [MOD-TR-MSG-4-2] Update Trust Registry precondition checks</h5>
-<p>If any of these precondition checks fail, method MUST abort.</p>
-<h6 id="mod-tr-msg-4-2-1-update-trust-registry-basic-checks"><a class="toc-anchor" href="#mod-tr-msg-4-2-1-update-trust-registry-basic-checks" >§</a> [MOD-TR-MSG-4-2-1] Update Trust Registry basic checks</h6>
-<ul>
-<li>
-<p>if a mandatory parameter is not present, method MUST abort.</p>
-</li>
-<li>
-<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
-</li>
-<li>
-<p><code>operator</code> (account): (Signer) signature must be verified.</p>
-</li>
-<li>
-<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
-</li>
-<li>
-<p><code>id</code> (uint64) (<em>mandatory</em>): a <code>TrustRegistry</code> entry <code>tr</code> with id <code>id</code> MUST exist and <code>corporation</code> executing the method MUST be the <code>corporation</code> of the <code>TrustRegistry</code> entry <code>tr</code>.</p>
+<p><code>id</code> (uint64) (<em>mandatory</em>): a <code>Ecosystem</code> entry <code>tr</code> with id <code>id</code> MUST exist and <code>corporation</code> executing the method MUST be the <code>corporation</code> of the <code>Ecosystem</code> entry <code>tr</code>.</p>
 </li>
 <li>
 <p><code>did</code> (string) (<em>mandatory</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</p>
 </li>
-<li>
-<p><code>aka</code> (string) (<em>optional</em>): optional additional URI of this trust registry. MUST be an <a class="term-reference" href="#term:uri">URI</a> or null.</p>
-</li>
 </ul>
-<h6 id="mod-tr-msg-4-2-2-update-trust-registry-fee-checks"><a class="toc-anchor" href="#mod-tr-msg-4-2-2-update-trust-registry-fee-checks" >§</a> [MOD-TR-MSG-4-2-2] Update Trust Registry fee checks</h6>
+<h6 id="mod-es-msg-2-2-2-update-ecosystem-fee-checks"><a class="toc-anchor" href="#mod-es-msg-2-2-2-update-ecosystem-fee-checks" >§</a> [MOD-ES-MSG-2-2-2] Update Ecosystem fee checks</h6>
 <p>Fee payer must have available balance in its <a class="term-reference" href="#term:account">account</a> to cover the required <a class="term-reference" href="#term:transaction-fees">transaction fees</a>.</p>
-<h5 id="mod-tr-msg-4-3-update-trust-registry-execution"><a class="toc-anchor" href="#mod-tr-msg-4-3-update-trust-registry-execution" >§</a> [MOD-TR-MSG-4-3] Update Trust Registry execution</h5>
+<h5 id="mod-es-msg-2-3-update-ecosystem-execution"><a class="toc-anchor" href="#mod-es-msg-2-3-update-ecosystem-execution" >§</a> [MOD-ES-MSG-2-3] Update Ecosystem execution</h5>
 <p>If all precondition checks passed, method is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>
-<p>load <code>TrustRegistry</code> entry <code>tr</code> from <code>id</code> and set:</p>
+<p>load <code>Ecosystem</code> entry <code>tr</code> from <code>id</code> and set:</p>
 </li>
 <li>
-<p><code>tr.did</code>: <code>did</code></p>
+<p><code>ecosystem.did</code>: <code>did</code></p>
 </li>
 <li>
-<p><code>tr.aka</code>: <code>aka</code></p>
-</li>
-<li>
-<p><code>tr.modified</code>: current timestamp</p>
+<p><code>ecosystem.modified</code>: current timestamp</p>
 </li>
 </ul>
-<h4 id="mod-tr-msg-5-archive-trust-registry"><a class="toc-anchor" href="#mod-tr-msg-5-archive-trust-registry" >§</a> [MOD-TR-MSG-5] Archive Trust Registry</h4>
+<h4 id="mod-es-msg-3-archive-ecosystem"><a class="toc-anchor" href="#mod-es-msg-3-archive-ecosystem" >§</a> [MOD-ES-MSG-3] Archive Ecosystem</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
-<h5 id="mod-tr-msg-5-1-archive-trust-registry-parameters"><a class="toc-anchor" href="#mod-tr-msg-5-1-archive-trust-registry-parameters" >§</a> [MOD-TR-MSG-5-1] Archive Trust Registry parameters</h5>
+<h5 id="mod-es-msg-3-1-archive-ecosystem-parameters"><a class="toc-anchor" href="#mod-es-msg-3-1-archive-ecosystem-parameters" >§</a> [MOD-ES-MSG-3-1] Archive Ecosystem parameters</h5>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>) id of the trust registry (<em>mandatory</em>);</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>) id of the ecosystem (<em>mandatory</em>);</li>
 <li><code>archive</code> (boolean) (<em>mandatory</em>), true means archive, false means unarchive.</li>
 </ul>
-<h5 id="mod-tr-msg-5-2-archive-trust-registry-precondition-checks"><a class="toc-anchor" href="#mod-tr-msg-5-2-archive-trust-registry-precondition-checks" >§</a> [MOD-TR-MSG-5-2] Archive Trust Registry precondition checks</h5>
+<h5 id="mod-es-msg-3-2-archive-ecosystem-precondition-checks"><a class="toc-anchor" href="#mod-es-msg-3-2-archive-ecosystem-precondition-checks" >§</a> [MOD-ES-MSG-3-2] Archive Ecosystem precondition checks</h5>
 <p>If any of these precondition checks fail, method MUST abort.</p>
-<h6 id="mod-tr-msg-5-2-1-archive-trust-registry-basic-checks"><a class="toc-anchor" href="#mod-tr-msg-5-2-1-archive-trust-registry-basic-checks" >§</a> [MOD-TR-MSG-5-2-1] Archive Trust Registry basic checks</h6>
+<h6 id="mod-es-msg-3-2-1-archive-ecosystem-basic-checks"><a class="toc-anchor" href="#mod-es-msg-3-2-1-archive-ecosystem-basic-checks" >§</a> [MOD-ES-MSG-3-2-1] Archive Ecosystem basic checks</h6>
 <ul>
 <li>
 <p>if a mandatory parameter is not present, method MUST abort.</p>
@@ -1857,84 +2151,84 @@ messages.</p>
 <p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
 </li>
 <li>
-<p>load <code>TrustRegistry</code> <code>tr</code> from <code>id</code>. <code>tr.corporation</code> MUST be the corporation executing the method, else MUST abort.</p>
+<p>load <code>Ecosystem</code> <code>tr</code> from <code>id</code>. <code>ecosystem.corporation</code> MUST be the corporation executing the method, else MUST abort.</p>
 </li>
 <li>
 <p><code>archive</code> (boolean) (<em>mandatory</em>) MUST be a boolean.</p>
 <ul>
-<li>If <code>archive</code> is true and <code>tr.archived</code> is not null, MUST abort as <code>TrustRegistry</code> is already archived.</li>
-<li>If <code>archive</code> is false and <code>tr.archived</code> is null, MUST abort as <code>TrustRegistry</code> is already not archived.</li>
+<li>If <code>archive</code> is true and <code>ecosystem.archived</code> is not null, MUST abort as <code>Ecosystem</code> is already archived.</li>
+<li>If <code>archive</code> is false and <code>ecosystem.archived</code> is null, MUST abort as <code>Ecosystem</code> is already not archived.</li>
 </ul>
 </li>
 </ul>
-<h6 id="mod-tr-msg-5-2-2-archive-trust-registry-fee-checks"><a class="toc-anchor" href="#mod-tr-msg-5-2-2-archive-trust-registry-fee-checks" >§</a> [MOD-TR-MSG-5-2-2] Archive Trust Registry fee checks</h6>
+<h6 id="mod-es-msg-3-2-2-archive-ecosystem-fee-checks"><a class="toc-anchor" href="#mod-es-msg-3-2-2-archive-ecosystem-fee-checks" >§</a> [MOD-ES-MSG-3-2-2] Archive Ecosystem fee checks</h6>
 <p>Fee payer MUST have an available balance in its <a class="term-reference" href="#term:account">account</a> to cover the required <a class="term-reference" href="#term:transaction-fees">transaction fees</a>.</p>
-<h5 id="mod-tr-msg-5-3-archive-trust-registry-execution"><a class="toc-anchor" href="#mod-tr-msg-5-3-archive-trust-registry-execution" >§</a> [MOD-TR-MSG-5-3] Archive Trust Registry execution</h5>
+<h5 id="mod-es-msg-3-3-archive-ecosystem-execution"><a class="toc-anchor" href="#mod-es-msg-3-3-archive-ecosystem-execution" >§</a> [MOD-ES-MSG-3-3] Archive Ecosystem execution</h5>
 <p>If all precondition checks passed, method is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
-<li>update <code>TrustRegistry</code> entry <code>tr</code> with <code>tr.id</code> equal to <code>id</code>:</li>
-<li>if <code>archived</code> is true: set <code>tr.archived</code> to current timestamp.</li>
-<li>if <code>archived</code> is false: set <code>tr.archived</code> to null.</li>
-<li><code>tr.modified</code>: current timestamp</li>
+<li>update <code>Ecosystem</code> entry <code>tr</code> with <code>ecosystem.id</code> equal to <code>id</code>:</li>
+<li>if <code>archived</code> is true: set <code>ecosystem.archived</code> to current timestamp.</li>
+<li>if <code>archived</code> is false: set <code>ecosystem.archived</code> to null.</li>
+<li><code>ecosystem.modified</code>: current timestamp</li>
 </ul>
-<h4 id="mod-tr-msg-6-update-module-parameters"><a class="toc-anchor" href="#mod-tr-msg-6-update-module-parameters" >§</a> [MOD-TR-MSG-6] Update Module Parameters</h4>
+<h4 id="mod-es-msg-4-update-module-parameters"><a class="toc-anchor" href="#mod-es-msg-4-update-module-parameters" >§</a> [MOD-ES-MSG-4] Update Module Parameters</h4>
 <p>Update Module Parameters.</p>
 <p>Can only be executed through a governance proposal.</p>
-<h5 id="mod-tr-msg-6-1-update-module-parameters-parameters"><a class="toc-anchor" href="#mod-tr-msg-6-1-update-module-parameters-parameters" >§</a> [MOD-TR-MSG-6-1] Update Module Parameters parameters</h5>
+<h5 id="mod-es-msg-4-1-update-module-parameters-parameters"><a class="toc-anchor" href="#mod-es-msg-4-1-update-module-parameters-parameters" >§</a> [MOD-ES-MSG-4-1] Update Module Parameters parameters</h5>
 <ul>
 <li><code>params</code> (KeySet&lt;String, String&gt;): the parameters to update and their values.</li>
 </ul>
-<h5 id="mod-tr-msg-6-2-update-module-parameters-precondition-checks"><a class="toc-anchor" href="#mod-tr-msg-6-2-update-module-parameters-precondition-checks" >§</a> [MOD-TR-MSG-6-2] Update Module Parameters precondition checks</h5>
+<h5 id="mod-es-msg-4-2-update-module-parameters-precondition-checks"><a class="toc-anchor" href="#mod-es-msg-4-2-update-module-parameters-precondition-checks" >§</a> [MOD-ES-MSG-4-2] Update Module Parameters precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-tr-msg-6-2-1-update-module-parameters-basic-checks"><a class="toc-anchor" href="#mod-tr-msg-6-2-1-update-module-parameters-basic-checks" >§</a> [MOD-TR-MSG-6-2-1] Update Module Parameters basic checks</h6>
+<h6 id="mod-es-msg-4-2-1-update-module-parameters-basic-checks"><a class="toc-anchor" href="#mod-es-msg-4-2-1-update-module-parameters-basic-checks" >§</a> [MOD-ES-MSG-4-2-1] Update Module Parameters basic checks</h6>
 <ul>
 <li><code>params</code>: size of <code>params</code> MUST be greater than 0. For each <code>param</code> &lt;<code>key</code>, <code>value</code>&gt; <code>key</code> MUST exist, else abort.</li>
 </ul>
-<h6 id="mod-tr-msg-6-2-2-update-module-parameters-fee-checks"><a class="toc-anchor" href="#mod-tr-msg-6-2-2-update-module-parameters-fee-checks" >§</a> [MOD-TR-MSG-6-2-2] Update Module Parameters fee checks</h6>
+<h6 id="mod-es-msg-4-2-2-update-module-parameters-fee-checks"><a class="toc-anchor" href="#mod-es-msg-4-2-2-update-module-parameters-fee-checks" >§</a> [MOD-ES-MSG-4-2-2] Update Module Parameters fee checks</h6>
 <p>provided transaction fees MUST be sufficient for execution</p>
-<h5 id="mod-tr-msg-6-3-update-module-parameters-execution"><a class="toc-anchor" href="#mod-tr-msg-6-3-update-module-parameters-execution" >§</a> [MOD-TR-MSG-6-3] Update Module Parameters execution</h5>
+<h5 id="mod-es-msg-4-3-update-module-parameters-execution"><a class="toc-anchor" href="#mod-es-msg-4-3-update-module-parameters-execution" >§</a> [MOD-ES-MSG-4-3] Update Module Parameters execution</h5>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <p>for each parameter <code>param</code> &lt;<code>key</code>, <code>value</code>&gt; in <code>parameters</code>:</p>
 <ul>
 <li>update parameter set value = <code>value</code> where key = <code>key</code>.</li>
 </ul>
-<h4 id="mod-tr-qry-1-get-trust-registry"><a class="toc-anchor" href="#mod-tr-qry-1-get-trust-registry" >§</a> [MOD-TR-QRY-1] Get Trust Registry</h4>
+<h4 id="mod-es-qry-1-get-ecosystem"><a class="toc-anchor" href="#mod-es-qry-1-get-ecosystem" >§</a> [MOD-ES-QRY-1] Get Ecosystem</h4>
 <p>Anyone CAN execute this method.</p>
-<h5 id="mod-tr-qry-1-1-get-trust-registry-parameters"><a class="toc-anchor" href="#mod-tr-qry-1-1-get-trust-registry-parameters" >§</a> [MOD-TR-QRY-1-1] Get Trust Registry parameters</h5>
+<h5 id="mod-es-qry-1-1-get-ecosystem-parameters"><a class="toc-anchor" href="#mod-es-qry-1-1-get-ecosystem-parameters" >§</a> [MOD-ES-QRY-1-1] Get Ecosystem parameters</h5>
 <ul>
-<li><code>id</code> (uint64) (<em>mandatory</em>): id of the <a class="term-reference" href="#term:trust-registry">trust registry</a>.</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): id of the <a class="term-reference" href="#term:ecosystem">ecosystem</a>.</li>
 <li><code>active_gf_only</code> (boolean) (<em>optional</em>): if true, include only current governance framework data. If false or null, returns everything.</li>
 <li><code>preferred_language</code> (string) (<em>optional</em>): if set, return only one document per version, with language=<code>preferred_language</code> when possible, else if no document exist with this language, return language. If not set, return all documents of all languages.</li>
 </ul>
-<h5 id="mod-tr-qry-1-2-get-trust-registry-checks"><a class="toc-anchor" href="#mod-tr-qry-1-2-get-trust-registry-checks" >§</a> [MOD-TR-QRY-1-2] Get Trust Registry checks</h5>
-<h5 id="mod-tr-qry-1-3-get-trust-registry-execution"><a class="toc-anchor" href="#mod-tr-qry-1-3-get-trust-registry-execution" >§</a> [MOD-TR-QRY-1-3] Get Trust Registry execution</h5>
-<p>return found <code>TrustRegistry</code> entry (if any), as well as <em>all its nested</em> <code>GovernanceFrameworkVersion</code> and <code>GovernanceFrameworkDocument</code> entries. If <code>active_gf_only</code> is true, return only nested <code>GovernanceFrameworkVersion</code> and <code>GovernanceFrameworkDocument</code> entries for the active version.</p>
-<h4 id="mod-tr-qry-2-list-trust-registries"><a class="toc-anchor" href="#mod-tr-qry-2-list-trust-registries" >§</a> [MOD-TR-QRY-2] List Trust Registries</h4>
-<h5 id="mod-tr-qry-2-1-list-trust-registries-query-parameters"><a class="toc-anchor" href="#mod-tr-qry-2-1-list-trust-registries-query-parameters" >§</a> [MOD-TR-QRY-2-1] List Trust Registries query parameters</h5>
+<h5 id="mod-es-qry-1-2-get-ecosystem-checks"><a class="toc-anchor" href="#mod-es-qry-1-2-get-ecosystem-checks" >§</a> [MOD-ES-QRY-1-2] Get Ecosystem checks</h5>
+<h5 id="mod-es-qry-1-3-get-ecosystem-execution"><a class="toc-anchor" href="#mod-es-qry-1-3-get-ecosystem-execution" >§</a> [MOD-ES-QRY-1-3] Get Ecosystem execution</h5>
+<p>return found <code>Ecosystem</code> entry (if any), as well as <em>all its nested</em> <code>GovernanceFrameworkVersion</code> and <code>GovernanceFrameworkDocument</code> entries. If <code>active_gf_only</code> is true, return only nested <code>GovernanceFrameworkVersion</code> and <code>GovernanceFrameworkDocument</code> entries for the active version.</p>
+<h4 id="mod-es-qry-2-list-ecosystems"><a class="toc-anchor" href="#mod-es-qry-2-list-ecosystems" >§</a> [MOD-ES-QRY-2] List Ecosystems</h4>
+<h5 id="mod-es-qry-2-1-list-ecosystems-query-parameters"><a class="toc-anchor" href="#mod-es-qry-2-1-list-ecosystems-query-parameters" >§</a> [MOD-ES-QRY-2-1] List Ecosystems query parameters</h5>
 <p>The following parameters are optional:</p>
 <ul>
 <li><code>corporation</code> (group) (<em>optional</em>): if specified, filter by corporation.</li>
-<li><code>modified_after</code> (timestamp) (<em>optional</em>): if specified, returns only <code>TrustRegistry</code> entries with <code>TrustRegistry.modified</code> greater than <code>modified</code>.</li>
+<li><code>modified_after</code> (timestamp) (<em>optional</em>): if specified, returns only <code>Ecosystem</code> entries with <code>Ecosystem.modified</code> greater than <code>modified</code>.</li>
 <li><code>active_gf_only</code> (boolean) (<em>optional</em>): if true, include only current governance framework data. If false or null, returns everything.</li>
 <li><code>preferred_language</code> (string) (<em>optional</em>): if set, return only one document per version, with language=<code>preferred_language</code> when possible, else if no document exist with this language, return language. If not set, return all documents of all languages.</li>
 <li><code>response_max_size</code> (small number) (<em>optional</em>): default to 64. Max 1,024.</li>
 </ul>
-<h5 id="mod-tr-qry-2-2-list-trust-registries-query-checks"><a class="toc-anchor" href="#mod-tr-qry-2-2-list-trust-registries-query-checks" >§</a> [MOD-TR-QRY-2-2] List Trust Registries query checks</h5>
+<h5 id="mod-es-qry-2-2-list-ecosystems-query-checks"><a class="toc-anchor" href="#mod-es-qry-2-2-list-ecosystems-query-checks" >§</a> [MOD-ES-QRY-2-2] List Ecosystems query checks</h5>
 <p>If any of these checks fail, <a class="term-reference" href="#term:query">query</a> MUST fail.</p>
 <ul>
 <li><code>response_max_size</code> must be between 1 and 1,024. Default to 64 if unspecified.</li>
 </ul>
-<h5 id="mod-tr-qry-2-3-list-trust-registries-execution-of-the-query"><a class="toc-anchor" href="#mod-tr-qry-2-3-list-trust-registries-execution-of-the-query" >§</a> [MOD-TR-QRY-2-3] List Trust Registries execution of the query</h5>
+<h5 id="mod-es-qry-2-3-list-ecosystems-execution-of-the-query"><a class="toc-anchor" href="#mod-es-qry-2-3-list-ecosystems-execution-of-the-query" >§</a> [MOD-ES-QRY-2-3] List Ecosystems execution of the query</h5>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:query">query</a> is executed and result (may be empty) returned. If <code>modified_after</code> is specified, order by <code>modified</code> desc.</p>
-<h4 id="mod-tr-qry-3-list-module-parameters"><a class="toc-anchor" href="#mod-tr-qry-3-list-module-parameters" >§</a> [MOD-TR-QRY-3] List Module Parameters</h4>
+<h4 id="mod-es-qry-3-list-module-parameters"><a class="toc-anchor" href="#mod-es-qry-3-list-module-parameters" >§</a> [MOD-ES-QRY-3] List Module Parameters</h4>
 <p>Anyone CAN run this <a class="term-reference" href="#term:query">query</a>.</p>
-<h5 id="mod-tr-qry-3-2-list-module-parameters-parameters"><a class="toc-anchor" href="#mod-tr-qry-3-2-list-module-parameters-parameters" >§</a> [MOD-TR-QRY-3-2] List Module Parameters parameters</h5>
-<h5 id="mod-tr-qry-3-2-list-module-parameters-query-checks"><a class="toc-anchor" href="#mod-tr-qry-3-2-list-module-parameters-query-checks" >§</a> [MOD-TR-QRY-3-2] List Module Parameters query checks</h5>
-<h5 id="mod-tr-qry-3-3-list-module-parameters-execution-of-the-query"><a class="toc-anchor" href="#mod-tr-qry-3-3-list-module-parameters-execution-of-the-query" >§</a> [MOD-TR-QRY-3-3] List Module Parameters execution of the query</h5>
+<h5 id="mod-es-qry-3-2-list-module-parameters-parameters"><a class="toc-anchor" href="#mod-es-qry-3-2-list-module-parameters-parameters" >§</a> [MOD-ES-QRY-3-2] List Module Parameters parameters</h5>
+<h5 id="mod-es-qry-3-2-list-module-parameters-query-checks"><a class="toc-anchor" href="#mod-es-qry-3-2-list-module-parameters-query-checks" >§</a> [MOD-ES-QRY-3-2] List Module Parameters query checks</h5>
+<h5 id="mod-es-qry-3-3-list-module-parameters-execution-of-the-query"><a class="toc-anchor" href="#mod-es-qry-3-3-list-module-parameters-execution-of-the-query" >§</a> [MOD-ES-QRY-3-3] List Module Parameters execution of the query</h5>
 <p>Return the list of the existing parameters and their values.</p>
-<h5 id="mod-tr-qry-3-4-list-module-parameters-api-result-example"><a class="toc-anchor" href="#mod-tr-qry-3-4-list-module-parameters-api-result-example" >§</a> [MOD-TR-QRY-3-4] List Module Parameters API result example</h5>
+<h5 id="mod-es-qry-3-4-list-module-parameters-api-result-example"><a class="toc-anchor" href="#mod-es-qry-3-4-list-module-parameters-api-result-example" >§</a> [MOD-ES-QRY-3-4] List Module Parameters API result example</h5>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span>
   <span class="token property">"params"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
     <span class="token property">"key1"</span><span class="token operator">:</span> <span class="token string">"value1"</span><span class="token punctuation">,</span>
@@ -1944,6 +2238,166 @@ messages.</p>
   <span class="token punctuation">}</span>
 <span class="token punctuation">}</span>
 </code></pre>
+<h3 id="governance-framework-module"><a class="toc-anchor" href="#governance-framework-module" >§</a> Governance Framework Module</h3>
+<p>This module handles <a class="term-reference" href="#term:governance-framework">governance framework</a> documents and version activation for both <a class="term-reference" href="#term:ecosystems">ecosystems</a> and <a class="term-reference" href="#term:corporations">corporations</a>. Methods are polymorphic over the owning subject: every message specifies exactly one of <code>ecosystem_id</code> or <code>corporation_id</code> to designate whose governance framework is being modified.</p>
+<p>The initial <code>GovernanceFrameworkVersion</code> and its first <code>GovernanceFrameworkDocument</code> are created atomically by <a href="#mod-es-msg-1-create-new-ecosystem" >Create New Ecosystem</a> (and, by parallel construction, by <a href="#mod-co-msg-1-create-new-corporation" >Create New Corporation</a>). After that, subsequent versions and documents are added through this module.</p>
+<h4 id="mod-gf-msg-1-add-governance-framework-document"><a class="toc-anchor" href="#mod-gf-msg-1-add-governance-framework-document" >§</a> [MOD-GF-MSG-1] Add Governance Framework Document</h4>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
+<h5 id="mod-gf-msg-1-1-add-governance-framework-document-parameters"><a class="toc-anchor" href="#mod-gf-msg-1-1-add-governance-framework-document-parameters" >§</a> [MOD-GF-MSG-1-1] Add Governance Framework Document parameters</h5>
+<ul>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
+<li><code>ecosystem_id</code> (uint64) (<em>conditional</em>): id of the target <a class="term-reference" href="#term:ecosystem">ecosystem</a> whose governance framework will be modified. MUST be set if <code>corporation_id</code> is null.</li>
+<li><code>corporation_id</code> (uint64) (<em>conditional</em>): id of the target <a class="term-reference" href="#term:corporation">corporation</a> whose governance framework will be modified. MUST be set if <code>ecosystem_id</code> is null.</li>
+<li><code>doc_language</code> (string) (<em>mandatory</em>): language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>) of the governance framework document.</li>
+<li><code>doc_url</code> (string) (<em>mandatory</em>): URL where the document is published.</li>
+<li><code>doc_digest_sri</code> (string) (<em>mandatory</em>): digest_sri of the document.</li>
+<li><code>version</code> (int) (<em>mandatory</em>): targeted version.</li>
+</ul>
+<p>If for a given language, a document already exists, the execution of this transaction will replace the corresponding entry. Else, a new entry is created. It is only possible to edit future versions. Active version cannot be modified.</p>
+<h5 id="mod-gf-msg-1-2-add-governance-framework-document-precondition-checks"><a class="toc-anchor" href="#mod-gf-msg-1-2-add-governance-framework-document-precondition-checks" >§</a> [MOD-GF-MSG-1-2] Add Governance Framework Document precondition checks</h5>
+<p>If any of these precondition checks fail, method MUST abort.</p>
+<h6 id="mod-gf-msg-1-2-1-add-governance-framework-document-basic-checks"><a class="toc-anchor" href="#mod-gf-msg-1-2-1-add-governance-framework-document-basic-checks" >§</a> [MOD-GF-MSG-1-2-1] Add Governance Framework Document basic checks</h6>
+<p>if a mandatory parameter is not present, method MUST abort.</p>
+<ul>
+<li><code>corporation</code> (group): (Signer) signature must be verified.</li>
+<li><code>operator</code> (account): (Signer) signature must be verified.</li>
+<li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
+<li>Exactly one of <code>ecosystem_id</code> and <code>corporation_id</code> MUST be set; if both are set or both are null, method MUST abort.</li>
+<li>Define <code>subject</code> as:
+<ul>
+<li>if <code>ecosystem_id</code> is set: the <code>Ecosystem</code> entry with this id. The entry MUST exist and <code>subject.corporation</code> MUST be equal to the <code>corporation</code> executing the method.</li>
+<li>if <code>corporation_id</code> is set: the <code>Corporation</code> entry keyed by <code>corporation_id</code> (i.e., the Corporation whose underlying <a class="term-reference" href="#term:group">group</a> has id <code>corporation_id</code>). The entry MUST exist, and <code>corporation_id</code> MUST equal the <a class="term-reference" href="#term:group">group</a> id of the signing <code>corporation</code> (a Corporation may only edit its own governance framework).</li>
+</ul>
+</li>
+<li><code>version</code>: there MUST exist a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> whose owner matches <code>subject</code> (i.e., <code>gfv.ecosystem_id = ecosystem_id</code> if subject is an Ecosystem, else <code>gfv.corporation_id = corporation_id</code>) and <code>gfv.version = version</code>, OR <code>version</code> MUST be exactly equal to the biggest <code>gfv.version</code> + 1 of all <code>GovernanceFrameworkVersion</code> entries owned by <code>subject</code>. <code>version</code> MUST be greater than <code>subject.active_version</code>.</li>
+<li><code>doc_language</code> (string) (<em>mandatory</em>): MUST be a language tag (<a path-0="www.rfc-editor.org"path-1="info"path-2="bcp47"href="https://www.rfc-editor.org/info/bcp47" >BCP 47</a>).</li>
+<li><code>doc_url</code> (string) (<em>mandatory</em>): MUST be a valid URL.</li>
+<li><code>doc_digest_sri</code> (string) (<em>mandatory</em>): MUST be a valid digest_sri as specified in <a path-0="www.w3.org"path-1="TR"path-2="vc-data-model-2.0"path-3="#integrity-of-related-resources"href="https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources" >integrity of related resources spec</a>. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</li>
+</ul>
+<h6 id="mod-gf-msg-1-2-2-add-governance-framework-document-fee-checks"><a class="toc-anchor" href="#mod-gf-msg-1-2-2-add-governance-framework-document-fee-checks" >§</a> [MOD-GF-MSG-1-2-2] Add Governance Framework Document fee checks</h6>
+<p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>.</p>
+<h5 id="mod-gf-msg-1-3-add-governance-framework-document-execution"><a class="toc-anchor" href="#mod-gf-msg-1-3-add-governance-framework-document-execution" >§</a> [MOD-GF-MSG-1-3] Add Governance Framework Document execution</h5>
+<p>If all precondition checks passed, method is executed.</p>
+<p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
+<ul>
+<li>
+<p>if a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> matching <code>subject</code> and <code>version</code> does not exist, create and persist a new one:</p>
+<ul>
+<li><code>gfv.id</code>: auto-incremented uint64</li>
+<li><code>gfv.ecosystem_id</code>: <code>ecosystem_id</code> (or null if subject is a Corporation)</li>
+<li><code>gfv.corporation_id</code>: <code>corporation_id</code> (or null if subject is an Ecosystem)</li>
+<li><code>gfv.created</code>: current timestamp</li>
+<li><code>gfv.version</code>: <code>version</code></li>
+</ul>
+</li>
+<li>
+<p>if a <code>GovernanceFrameworkDocument</code> entry <code>gfd</code> exists with <code>gfd.gfv_id = gfv.id</code> and <code>gfd.language = doc_language</code>, update it:</p>
+<ul>
+<li><code>gfd.url</code>: <code>doc_url</code></li>
+<li><code>gfd.digest_sri</code>: <code>doc_digest_sri</code></li>
+</ul>
+</li>
+<li>
+<p>else, create and persist a new <code>GovernanceFrameworkDocument</code> entry <code>gfd</code>:</p>
+<ul>
+<li><code>gfd.id</code>: auto-incremented uint64</li>
+<li><code>gfd.gfv_id</code>: <code>gfv.id</code></li>
+<li><code>gfd.created</code>: current timestamp</li>
+<li><code>gfd.language</code>: <code>doc_language</code></li>
+<li><code>gfd.url</code>: <code>doc_url</code></li>
+<li><code>gfd.digest_sri</code>: <code>doc_digest_sri</code></li>
+</ul>
+</li>
+</ul>
+<h4 id="mod-gf-msg-2-increase-active-governance-framework-version"><a class="toc-anchor" href="#mod-gf-msg-2-increase-active-governance-framework-version" >§</a> [MOD-GF-MSG-2] Increase Active Governance Framework Version</h4>
+<p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
+<h5 id="mod-gf-msg-2-1-increase-active-governance-framework-version-parameters"><a class="toc-anchor" href="#mod-gf-msg-2-1-increase-active-governance-framework-version-parameters" >§</a> [MOD-GF-MSG-2-1] Increase Active Governance Framework Version parameters</h5>
+<ul>
+<li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
+<li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
+<li><code>ecosystem_id</code> (uint64) (<em>conditional</em>): id of the target <a class="term-reference" href="#term:ecosystem">ecosystem</a>. MUST be set if <code>corporation_id</code> is null.</li>
+<li><code>corporation_id</code> (uint64) (<em>conditional</em>): id of the target <a class="term-reference" href="#term:corporation">corporation</a>. MUST be set if <code>ecosystem_id</code> is null.</li>
+</ul>
+<h5 id="mod-gf-msg-2-2-increase-active-governance-framework-version-precondition-checks"><a class="toc-anchor" href="#mod-gf-msg-2-2-increase-active-governance-framework-version-precondition-checks" >§</a> [MOD-GF-MSG-2-2] Increase Active Governance Framework Version precondition checks</h5>
+<p>If any of these precondition checks fail, method MUST abort.</p>
+<h6 id="mod-gf-msg-2-2-1-increase-active-governance-framework-version-basic-checks"><a class="toc-anchor" href="#mod-gf-msg-2-2-1-increase-active-governance-framework-version-basic-checks" >§</a> [MOD-GF-MSG-2-2-1] Increase Active Governance Framework Version basic checks</h6>
+<ul>
+<li>
+<p>if a mandatory parameter is not present, method MUST abort.</p>
+</li>
+<li>
+<p><code>corporation</code> (group): (Signer) signature must be verified.</p>
+</li>
+<li>
+<p><code>operator</code> (account): (Signer) signature must be verified.</p>
+</li>
+<li>
+<p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
+</li>
+<li>
+<p>Exactly one of <code>ecosystem_id</code> and <code>corporation_id</code> MUST be set; if both are set or both are null, method MUST abort.</p>
+</li>
+<li>
+<p>Define <code>subject</code> as:</p>
+<ul>
+<li>if <code>ecosystem_id</code> is set: the <code>Ecosystem</code> entry with this id. The entry MUST exist and <code>subject.corporation</code> MUST be equal to the <code>corporation</code> executing the method.</li>
+<li>if <code>corporation_id</code> is set: the <code>Corporation</code> entry keyed by <code>corporation_id</code> (i.e., the Corporation whose underlying <a class="term-reference" href="#term:group">group</a> has id <code>corporation_id</code>). The entry MUST exist, and <code>corporation_id</code> MUST equal the <a class="term-reference" href="#term:group">group</a> id of the signing <code>corporation</code>.</li>
+</ul>
+</li>
+<li>
+<p>Find a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> owned by <code>subject</code> (matching <code>gfv.ecosystem_id</code> or <code>gfv.corporation_id</code> as appropriate) whose <code>gfv.version</code> is equal to <code>subject.active_version</code> + 1. If none is found, transaction MUST abort.</p>
+</li>
+<li>
+<p>Find a <code>GovernanceFrameworkDocument</code> <code>gfd</code> for <code>gfd.gfv_id</code> = <code>gfv.id</code> and <code>gfd.language</code> = <code>subject.language</code>. If no document is found (and thus no document exists for the default language of this version for this subject), transaction MUST abort.</p>
+</li>
+</ul>
+<h6 id="mod-gf-msg-2-2-2-increase-active-governance-framework-version-fee-checks"><a class="toc-anchor" href="#mod-gf-msg-2-2-2-increase-active-governance-framework-version-fee-checks" >§</a> [MOD-GF-MSG-2-2-2] Increase Active Governance Framework Version fee checks</h6>
+<p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>.</p>
+<h5 id="mod-gf-msg-2-3-increase-active-governance-framework-version-execution"><a class="toc-anchor" href="#mod-gf-msg-2-3-increase-active-governance-framework-version-execution" >§</a> [MOD-GF-MSG-2-3] Increase Active Governance Framework Version execution</h5>
+<p>If all precondition checks passed, method is executed.</p>
+<p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
+<ul>
+<li>Load <code>subject</code> (<code>Ecosystem</code> or <code>Corporation</code> as identified above).</li>
+<li>Find a <code>GovernanceFrameworkVersion</code> entry <code>gfv</code> owned by <code>subject</code> whose <code>gfv.version</code> is equal to <code>subject.active_version</code> + 1.</li>
+<li>Update <code>subject.active_version</code> to <code>subject.active_version</code> + 1.</li>
+<li>Set <code>subject.modified</code> to current timestamp.</li>
+<li>Set <code>gfv.active_since</code> to current timestamp.</li>
+<li>Persist changes.</li>
+</ul>
+<h4 id="mod-gf-qry-1-get-governance-framework-version"><a class="toc-anchor" href="#mod-gf-qry-1-get-governance-framework-version" >§</a> [MOD-GF-QRY-1] Get Governance Framework Version</h4>
+<p>Anyone CAN execute this method.</p>
+<h5 id="mod-gf-qry-1-1-get-governance-framework-version-query-parameters"><a class="toc-anchor" href="#mod-gf-qry-1-1-get-governance-framework-version-query-parameters" >§</a> [MOD-GF-QRY-1-1] Get Governance Framework Version query parameters</h5>
+<ul>
+<li><code>id</code> (uint64) (<em>mandatory</em>): the id of the <code>GovernanceFrameworkVersion</code>.</li>
+<li><code>preferred_language</code> (string) (<em>optional</em>): if set, return only one document per version, preferring <code>preferred_language</code>. If not set, return all documents of all languages.</li>
+</ul>
+<h5 id="mod-gf-qry-1-2-get-governance-framework-version-query-checks"><a class="toc-anchor" href="#mod-gf-qry-1-2-get-governance-framework-version-query-checks" >§</a> [MOD-GF-QRY-1-2] Get Governance Framework Version query checks</h5>
+<p>If any of these checks fail, <a class="term-reference" href="#term:query">query</a> MUST fail.</p>
+<ul>
+<li><code>id</code> (uint64) (<em>mandatory</em>): MUST be a valid uint64.</li>
+</ul>
+<h5 id="mod-gf-qry-1-3-get-governance-framework-version-execution"><a class="toc-anchor" href="#mod-gf-qry-1-3-get-governance-framework-version-execution" >§</a> [MOD-GF-QRY-1-3] Get Governance Framework Version execution</h5>
+<p>Return the <code>GovernanceFrameworkVersion</code> entry with <code>id</code>, including its owning subject reference (<code>ecosystem_id</code> or <code>corporation_id</code>) and its nested <code>GovernanceFrameworkDocument</code> entries (filtered by <code>preferred_language</code> if set).</p>
+<h4 id="mod-gf-qry-2-list-governance-framework-versions"><a class="toc-anchor" href="#mod-gf-qry-2-list-governance-framework-versions" >§</a> [MOD-GF-QRY-2] List Governance Framework Versions</h4>
+<p>Anyone CAN execute this method.</p>
+<h5 id="mod-gf-qry-2-1-list-governance-framework-versions-query-parameters"><a class="toc-anchor" href="#mod-gf-qry-2-1-list-governance-framework-versions-query-parameters" >§</a> [MOD-GF-QRY-2-1] List Governance Framework Versions query parameters</h5>
+<p>Exactly one of <code>ecosystem_id</code> and <code>corporation_id</code> MUST be set:</p>
+<ul>
+<li><code>ecosystem_id</code> (uint64) (<em>conditional</em>): filter by ecosystem. MUST be set if <code>corporation_id</code> is null.</li>
+<li><code>corporation_id</code> (uint64) (<em>conditional</em>): filter by corporation. MUST be set if <code>ecosystem_id</code> is null.</li>
+<li><code>active_only</code> (boolean) (<em>optional</em>): if true, return only the entry corresponding to the subject’s <code>active_version</code>.</li>
+<li><code>preferred_language</code> (string) (<em>optional</em>): if set, return only one document per version, preferring <code>preferred_language</code>.</li>
+<li><code>response_max_size</code> (small number) (<em>optional</em>): default to 64. Max 1,024.</li>
+</ul>
+<h5 id="mod-gf-qry-2-2-list-governance-framework-versions-query-checks"><a class="toc-anchor" href="#mod-gf-qry-2-2-list-governance-framework-versions-query-checks" >§</a> [MOD-GF-QRY-2-2] List Governance Framework Versions query checks</h5>
+<p>If any of these checks fail, <a class="term-reference" href="#term:query">query</a> MUST fail.</p>
+<ul>
+<li>Exactly one of <code>ecosystem_id</code> and <code>corporation_id</code> MUST be set.</li>
+<li><code>response_max_size</code> must be between 1 and 1,024. Default to 64 if unspecified.</li>
+</ul>
+<h5 id="mod-gf-qry-2-3-list-governance-framework-versions-execution"><a class="toc-anchor" href="#mod-gf-qry-2-3-list-governance-framework-versions-execution" >§</a> [MOD-GF-QRY-2-3] List Governance Framework Versions execution</h5>
+<p>Return the list of <code>GovernanceFrameworkVersion</code> entries matching the filter, with their nested <code>GovernanceFrameworkDocument</code> entries (filtered as above). Entries MUST be ordered by ascending <code>version</code>.</p>
 <h3 id="credential-schema-module"><a class="toc-anchor" href="#credential-schema-module" >§</a> Credential Schema Module</h3>
 <h4 id="mod-cs-msg-1-create-new-credential-schema"><a class="toc-anchor" href="#mod-cs-msg-1-create-new-credential-schema" >§</a> [MOD-CS-MSG-1] Create New Credential Schema</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
@@ -1952,7 +2406,7 @@ messages.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>tr_id</code> id of the trust registry (<em>mandatory</em>);</li>
+<li><code>ecosystem_id</code> id of the ecosystem (<em>mandatory</em>);</li>
 <li><code>json_schema</code> the <a class="term-reference" href="#term:json-schema">Json Schema</a> of the credential (<em>mandatory</em>).</li>
 <li><code>issuer_grantor_validation_validity_period</code> (<em>mandatory</em>), default to 0 (days).</li>
 <li><code>verifier_grantor_validation_validity_period</code> (<em>mandatory</em>), default to 0 (days).</li>
@@ -1983,7 +2437,7 @@ messages.</p>
 <p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
 </li>
 <li>
-<p><code>tr_id</code> MUST represent an existing <code>TrustRegistry</code> entry <code>tr</code> and <code>tr.corporation</code> MUST be the <code>corporation</code> executing the method.</p>
+<p><code>ecosystem_id</code> MUST represent an existing <code>Ecosystem</code> entry <code>tr</code> and <code>ecosystem.corporation</code> MUST be the <code>corporation</code> executing the method.</p>
 </li>
 <li>
 <p><code>json_schema</code> MUST be a valid <a class="term-reference" href="#term:json-schema">Json Schema</a>, and size must not be greater than <code>GlobalVariables.credential_schema_schema_max_size</code>. <code>$id</code> of the <a class="term-reference" href="#term:json-schema">Json Schema</a> is ignored and will be replaced during execution by the auto-generated id of this <code>CredentialSchema</code>.</p>
@@ -2037,7 +2491,7 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 <p>create and persist a new <code>CredentialSchema</code> entry <code>cs</code>:</p>
 <ul>
 <li><code>cs.id</code>: auto-incremented uint64.</li>
-<li><code>cs.tr_id</code>: id of the <code>TrustRegistry</code> entry that will be the owner of <code>cs</code>.</li>
+<li><code>cs.ecosystem_id</code>: id of the <code>Ecosystem</code> entry that will be the owner of <code>cs</code>.</li>
 <li><code>cs.json_schema</code>: <code>json_schema</code>, with VPR_CREDENTIAL_SCHEMA_ID string replaced by generated <code>cs.id</code>, and then canonicalize it using the <a path-0="www.rfc-editor.org"path-1="rfc"path-2="rfc8785"href="https://www.rfc-editor.org/rfc/rfc8785" >JSON Canonicalization Scheme (JCS)</a> as defined in RFC 8785. Schema MUST be saved canonized.</li>
 <li><code>cs.issuer_grantor_validation_validity_period</code>: <code>issuer_grantor_validation_validity_period</code></li>
 <li><code>cs.verifier_grantor_validation_validity_period</code>: <code>verifier_grantor_validation_validity_period</code></li>
@@ -2055,7 +2509,7 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 </ul>
 </li>
 </ul>
-<div id="note-83" class="notice note"><a class="notice-link" href="#note-83">NOTE</a><p>If needed, depending on configuration mode, Trust Registry controller MAY need to create a ECOSYSTEM <code>Permission</code> so that validation processes can be run.</p>
+<div id="note-83" class="notice note"><a class="notice-link" href="#note-83">NOTE</a><p>If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM <code>Participant</code> so that onboarding processes can be run.</p>
 </div>
 <h4 id="mod-cs-msg-2-update-credential-schema"><a class="toc-anchor" href="#mod-cs-msg-2-update-credential-schema" >§</a> [MOD-CS-MSG-2] Update Credential Schema</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
@@ -2092,7 +2546,7 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 <p><code>id</code> MUST represent an existing <code>CredentialSchema</code> entry <code>cs</code>.</p>
 </li>
 <li>
-<p>load <code>TrustRegistry</code> <code>tr</code> from <code>cs.tr_id</code>. <code>tr.corporation</code> MUST be the <code>corporation</code> executing the method, else MUST abort.</p>
+<p>load <code>Ecosystem</code> <code>tr</code> from <code>cs.ecosystem_id</code>. <code>ecosystem.corporation</code> MUST be the <code>corporation</code> executing the method, else MUST abort.</p>
 </li>
 <li>
 <p><code>issuer_grantor_validation_validity_period</code> MUST be between 0 (never expire) and <code>GlobalVariables.credential_schema_issuer_grantor_validation_validity_period_max_days</code> days.</p>
@@ -2158,7 +2612,7 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 <p><code>id</code> MUST represent an existing <code>CredentialSchema</code> entry <code>cs</code>.</p>
 </li>
 <li>
-<p>load <code>TrustRegistry</code> <code>tr</code> from <code>cs.tr_id</code>. <code>tr.corporation</code> MUST be the <code>corporation</code> executing the method, else MUST abort.</p>
+<p>load <code>Ecosystem</code> <code>tr</code> from <code>cs.ecosystem_id</code>. <code>ecosystem.corporation</code> MUST be the <code>corporation</code> executing the method, else MUST abort.</p>
 </li>
 <li>
 <p><code>archive</code> (boolean) (<em>mandatory</em>) MUST be a boolean.</p>
@@ -2213,7 +2667,7 @@ FIAT metadata SHOULD be pulled from a standard library. It MUST NOT be stored on
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This message creates a <strong>draft</strong> <code>SchemaAuthorizationPolicy</code> for a given <code>(schema_id, role)</code>, or overwrites the existing draft policy if one already exists.<br>
 A draft policy is defined as a policy with <code>effective_from == null</code> and MUST NOT be revoked.</p>
-<p>Accordingly, if a credential schema defines one or more active policies for the ISSUER or VERIFIER role, the corresponding corporation that grants the ISSUER or VERIFIER role for this schema (ISSUER_GRANTOR, VERIFIER_GRANTOR, or ECOSYSTEM, depending on how schema issuer and verifier modes have been configured) MUST issue an IAC or VAC credential to the candidate upon successful completion of the validation process. Refer to the <a path-0="github.com"path-1="verana-labs"path-2="verifiable-trust-spec"href="https://github.com/verana-labs/verifiable-trust-spec" >Verifiable Trust spec</a> for more information.</p>
+<p>Accordingly, if a credential schema defines one or more active policies for the ISSUER or VERIFIER role, the corresponding corporation that grants the ISSUER or VERIFIER role for this schema (ISSUER_GRANTOR, VERIFIER_GRANTOR, or ECOSYSTEM, depending on how schema issuer and verifier modes have been configured) MUST issue an IAC or VAC credential to the candidate upon successful completion of the onboarding process. Refer to the <a path-0="github.com"path-1="verana-labs"path-2="verifiable-trust-spec"href="https://github.com/verana-labs/verifiable-trust-spec" >Verifiable Trust spec</a> for more information.</p>
 <h5 id="mod-cs-msg-5-1-create-schema-authorization-policy-parameters"><a class="toc-anchor" href="#mod-cs-msg-5-1-create-schema-authorization-policy-parameters" >§</a> [MOD-CS-MSG-5-1] Create Schema Authorization Policy parameters</h5>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
@@ -2339,7 +2793,7 @@ A draft policy is defined as a policy with <code>effective_from == null</code> a
 <h4 id="mod-cs-qry-1-list-credential-schemas"><a class="toc-anchor" href="#mod-cs-qry-1-list-credential-schemas" >§</a> [MOD-CS-QRY-1] List Credential Schemas</h4>
 <h5 id="mod-cs-qry-1-1-list-credential-schemas-parameters"><a class="toc-anchor" href="#mod-cs-qry-1-1-list-credential-schemas-parameters" >§</a> [MOD-CS-QRY-1-1] List Credential Schemas parameters</h5>
 <ul>
-<li><code>tr_id</code> (uint64) (<em>optional</em>): to filter by trust registry id.</li>
+<li><code>ecosystem_id</code> (uint64) (<em>optional</em>): to filter by ecosystem id.</li>
 <li><code>modified_after</code> (timestamp) (<em>optional</em>): show schemas modified after this timestamp.</li>
 <li><code>response_max_size</code> (small number) (<em>optional</em>): default to 64. Max 1,024.</li>
 <li><code>only_active</code> (boolean): if set to true, returns only not archived entries.</li>
@@ -2454,66 +2908,70 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li><code>revoked</code></li>
 </ul>
 <p>Entries MUST be ordered by ascending <code>version</code>.</p>
-<h3 id="permission-module"><a class="toc-anchor" href="#permission-module" >§</a> Permission Module</h3>
-<h4 id="permission-module-overview"><a class="toc-anchor" href="#permission-module-overview" >§</a> Permission Module Overview</h4>
+<h3 id="participant-module"><a class="toc-anchor" href="#participant-module" >§</a> Participant Module</h3>
+<h4 id="participant-module-overview"><a class="toc-anchor" href="#participant-module-overview" >§</a> Participant Module Overview</h4>
 <p><em>This section is non-normative.</em></p>
-<p>Permission are linked to a Credential Schema and representable as a tree.</p>
-<img src="https://www.plantuml.com/plantuml/svg/ZPDTRu8m58Rl-ojEv6QxC24naOMBHKLKacqkm4oscwL0nMvyfQrCi_ZVLwcoBM5rvmOElETzUdhQ4HUOYMsUeL7xncES4SZn3cvC4pve8ZO8K8NZTvmIwBaxd5TIu32Ia49Gd44GRqYEuP6md79Eom92HaWFC8UOmoT28AECtaWie1UoBHVWavHomVOmRcI2WJ5OHqaqb78uHTNwXVkAsE0wo-0v2DrxkFBBKbotmeGcDb7BiWKRDzyFlw0Uvrl2OCvm8Ke6amPAKmtC2u8drt-T--E7SEbtecWw-HlbA8HA36jeMII1YxnkZjE1MH56r_H7JzC6MEjwMhc-D_CkT5MdKntELPXpQfXcPAxDVq2xOMu7Qr5cYRH-WGQrKPancqrCQw01BPPtqnFcW0v8XZnL_VxjSSusfCTjaYFWwgn-5oFvkr6fKUcKPyDQRrWhmtQFj9OdxB50TQfLZqYHDBTLFRy0" alt="uml diagram">
-<p>The ECOSYSTEM type permissions are created by the Credential Schema owner. All other permissions are created by running a Validation Process (or by any account: - for <code>ISSUER</code> permissions if issuer_onboarding_mode is equal to <code>OPEN</code>, - for <code>VERIFIER</code> permissions if verifier_onboarding_mode is equal to <code>OPEN</code>).</p>
-<p>A Validation Process (VP) is a process which involves an <a class="term-reference" href="#term:applicant">applicant</a> (which is the <a class="term-reference" href="#term:corporation">corporation</a> of validation entry stored in a validation <a class="term-reference" href="#term:keeper">keeper</a>), a <a class="term-reference" href="#term:validator">validator</a> permission, and optional validation fees plus transaction fees.</p>
-<p>Validation is used by <a class="term-reference" href="#term:applicants">applicants</a> that want to:</p>
+<p>Participants are linked to a Credential Schema and representable as a tree.</p>
+<img src="https://www.plantuml.com/plantuml/svg/XPDHRu8m483V-oikusLxC24naOM7HKLKacqku4osbwNG4xk1aBOwbyN_lahLRH7nNk3eyNrNUdIbeaAjyenqZtSoeHb2JZTmQzlmoPbQ420bJJveYd3bRsXUwW9F8CEbuZI3A5bWJk590tZ2IxfKC1M8Lq0b91A-2G4THVoEYTA0f91VKc4ElQf22R3QyvZ57Lq9-n15XYxutYHwYQR-0ro7HQ5kZikCCnTD8wuIlUhvzfyba7A50aP2TrC8w5SgdfueWYXwziEtKTXxd4x2MW5F--S5dW6Rn78wZeCCpbZgwLuDV8Q2p_cV_WULPdtQ_ymFWs5mOGVhTD0ayGtya5gs7Tjp-wogNk7N6CP5nZJm5Ih1mcJMSDYtdVO9VZov7-pXMx8bElHaj5ftkrDp8H585KgGPjRAtraZUhqgCsVGM7f0hYyWrmPv_2JDqBrvzuRPOtDv5vUi-kNCzGS0" alt="uml diagram">
+<p><code>ECOSYSTEM</code> Participants are created directly by the <a class="term-reference" href="#term:credential-schema">credential schema</a> owner. All other Participants are created by running an <a class="term-reference" href="#term:onboarding-process">onboarding process</a> — except when onboarding mode is set to <code>OPEN</code> for ISSUER and/or VERIFIER Participants, which any account CAN create directly:</p>
+<ul>
+<li><code>ISSUER</code> Participants when <code>issuer_onboarding_mode</code> is <code>OPEN</code>;</li>
+<li><code>VERIFIER</code> Participants when <code>verifier_onboarding_mode</code> is <code>OPEN</code>.</li>
+</ul>
+<p>An <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (OP) involves an <a class="term-reference" href="#term:applicant">applicant</a> (the <a class="term-reference" href="#term:corporation">corporation</a> of a given Participant entry) and a <a class="term-reference" href="#term:validator">validator</a> Participant. It MAY require the applicant to pay <code>validation_fees</code> in addition to <a class="term-reference" href="#term:transaction-fees">transaction fees</a>.</p>
+<p>An <a class="term-reference" href="#term:onboarding-process">onboarding process</a> is run by <a class="term-reference" href="#term:applicants">applicants</a> that want to:</p>
 <ul>
 <li>be an <a class="term-reference" href="#term:issuer">issuer</a> of a specific <a class="term-reference" href="#term:credential-schema">credential schema</a>;</li>
 <li>be a <a class="term-reference" href="#term:verifier">verifier</a> of a specific <a class="term-reference" href="#term:credential-schema">credential schema</a>;</li>
 <li>be an <a class="term-reference" href="#term:issuer-grantor">issuer grantor</a> of a specific <a class="term-reference" href="#term:credential-schema">credential schema</a>;</li>
 <li>be a <a class="term-reference" href="#term:verifier-grantor">verifier grantor</a> of a specific <a class="term-reference" href="#term:credential-schema">credential schema</a>;</li>
 <li>get issued a credential of a specific <a class="term-reference" href="#term:credential-schema">credential schema</a>;</li>
-<li>obtain a HOLDER permission from a issuer of a specific <a class="term-reference" href="#term:credential-schema">credential schema</a> and get issued a verifiable credential of this schema (HOLDER permission provide credential status (revoked, etc…));</li>
+<li>obtain a <code>HOLDER</code> Participant entry from an <a class="term-reference" href="#term:issuer">issuer</a> of a specific <a class="term-reference" href="#term:credential-schema">credential schema</a> and be issued a verifiable credential of that schema (the <code>HOLDER</code> Participant entry carries credential status — revoked, etc.).</li>
 </ul>
-<p>In all cases, the process is very similar. Example execution of a validation process:</p>
+<p>In all cases, the process is very similar. Example execution of an <a class="term-reference" href="#term:onboarding-process">onboarding process</a>:</p>
 <ol>
-<li>Applicant starts a validation process by running the [start new validation] <a class="term-reference" href="#term:transaction">transaction</a>. Validation process may be subject to paying validation fees, as defined by validator.</li>
-<li>Validation process requires that <a class="term-reference" href="#term:applicant">applicant</a> connects to a validation <a class="term-reference" href="#term:vs">VS</a> identified by its <a class="term-reference" href="#term:did">DID</a>, and execute a some validation steps, required for the validation process to conclude.</li>
-<li>If <a class="term-reference" href="#term:applicant">applicant</a> qualifies, <a class="term-reference" href="#term:validator">validator</a> updates the validation entry by running the [set to validated] <a class="term-reference" href="#term:transaction">transaction</a>, and <a class="term-reference" href="#term:applicant">applicant</a> is granted new permissions, and/or gets issued a credential.</li>
+<li>The <a class="term-reference" href="#term:applicant">applicant</a> starts an <a class="term-reference" href="#term:onboarding-process">onboarding process</a> by running <a href="#mod-pp-msg-1-start-participant-op" >[MOD-PP-MSG-1]</a>. The process MAY be subject to paying <code>validation_fees</code>, as defined in the <a class="term-reference" href="#term:validator">validator</a>'s Participant entry.</li>
+<li>The <a class="term-reference" href="#term:applicant">applicant</a> connects to the <a class="term-reference" href="#term:validator">validator</a>'s <a class="term-reference" href="#term:vs">VS</a> (identified by its <a class="term-reference" href="#term:did">DID</a>) and executes the validation steps required for the <a class="term-reference" href="#term:onboarding-process">onboarding process</a> to conclude.</li>
+<li>If the <a class="term-reference" href="#term:applicant">applicant</a> qualifies, the <a class="term-reference" href="#term:validator">validator</a> runs <a href="#mod-pp-msg-3-set-participant-op-to-validated" >[MOD-PP-MSG-3]</a> to update the Participant entry; the <a class="term-reference" href="#term:applicant">applicant</a> is then granted the new <code>Participant</code> entries and/or issued a credential.</li>
 </ol>
-<p>Validation is valid for a specific period, for example 365 days, as configured in the <a class="term-reference" href="#term:credential-schema">credential schema</a> for credential schema related validations, or set by trust registry for user-agent validation.</p>
-<div id="note-84" class="notice note"><a class="notice-link" href="#note-84">NOTE</a><p>In some cases, even if the validation is valid for a period of time, the resulting created permission or issued credential might have a shorter expiration timestamp because the validated attribute(s) might expire before validation expiration: in this case, the <a class="term-reference" href="#term:applicant">applicant</a> must provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration, in order to get issued an updated new permission and/or an updated credential.</p>
+<p>Once in the <code>VALIDATED</code> state, a Participant entry remains valid for a specific period (e.g., 365 days), configured in the <a class="term-reference" href="#term:credential-schema">credential schema</a> for credential-schema-related onboarding, or set by the <a class="term-reference" href="#term:ecosystem">ecosystem</a> for user-agent onboarding.</p>
+<div id="note-84" class="notice note"><a class="notice-link" href="#note-84">NOTE</a><p>Even when the Participant entry remains in the <code>VALIDATED</code> state for the configured period, the resulting <code>Participant</code> entry or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the <a class="term-reference" href="#term:applicant">applicant</a> MUST provide updated information to the <a class="term-reference" href="#term:validator">validator</a> before attribute expiration in order to be issued an updated <code>Participant</code> entry and/or credential.</p>
 </div>
-<p>If validation is set to expire, <a class="term-reference" href="#term:applicant">applicant</a> that wishes to extend the expiration timestamp must renew its validation.</p>
-<p>At any time, <a class="term-reference" href="#term:applicant">applicant</a> can cancel the validation process.</p>
-<p>Some special unexpected situation may arise and must be mitigated. Examples:</p>
+<p>If the <code>VALIDATED</code> state is set to expire, an <a class="term-reference" href="#term:applicant">applicant</a> that wishes to extend the expiration timestamp MUST renew its <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-2-renew-participant-op" >[MOD-PP-MSG-2]</a>).</p>
+<p>At any time, the <a class="term-reference" href="#term:applicant">applicant</a> CAN cancel the <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-6-cancel-participant-op-last-request" >[MOD-PP-MSG-6]</a>).</p>
+<p>Some unexpected situations may arise and MUST be mitigated. Examples:</p>
 <ul>
-<li>if selected validator permission is revoked while applicant’s validation is in PENDING state: Applicant CAN cancel the validation process [MOD-PERM-MSG-6].</li>
-<li>if selected validator permission is revoked while applicant is in VALIDATED state: Applicant CAN renew the validation process by choosing a new validator [MOD-PERM-MSG-2].</li>
+<li>if the selected <a class="term-reference" href="#term:validator">validator</a> Participant entry is revoked while the <a class="term-reference" href="#term:applicant">applicant</a> is in <code>PENDING</code> state: applicant CAN cancel the <a class="term-reference" href="#term:onboarding-process">onboarding process</a> (see <a href="#mod-pp-msg-6-cancel-participant-op-last-request" >[MOD-PP-MSG-6]</a>);</li>
+<li>if the selected <a class="term-reference" href="#term:validator">validator</a> Participant entry is revoked while the <a class="term-reference" href="#term:applicant">applicant</a> is in <code>VALIDATED</code> state: applicant CAN renew the <a class="term-reference" href="#term:onboarding-process">onboarding process</a> by choosing a new validator (see <a href="#mod-pp-msg-2-renew-participant-op" >[MOD-PP-MSG-2]</a>).</li>
 </ul>
-<h4 id="mod-perm-msg-1-start-permission-vp"><a class="toc-anchor" href="#mod-perm-msg-1-start-permission-vp" >§</a> [MOD-PERM-MSG-1] Start Permission VP</h4>
+<h4 id="mod-pp-msg-1-start-participant-op"><a class="toc-anchor" href="#mod-pp-msg-1-start-participant-op" >§</a> [MOD-PP-MSG-1] Start Participant OP</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
-<h5 id="mod-perm-msg-1-1-start-permission-vp-parameters"><a class="toc-anchor" href="#mod-perm-msg-1-1-start-permission-vp-parameters" >§</a> [MOD-PERM-MSG-1-1] Start Permission VP parameters</h5>
-<p>An Applicant that would like to start a permission validation process MUST execute this method by specifying:</p>
+<h5 id="mod-pp-msg-1-1-start-participant-op-parameters"><a class="toc-anchor" href="#mod-pp-msg-1-1-start-participant-op-parameters" >§</a> [MOD-PP-MSG-1-1] Start Participant OP parameters</h5>
+<p>An Applicant that would like to start an onboarding process MUST execute this method by specifying:</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>vs_operator</code> (account) (<em>optional</em>): the account of the Veriable Service we want to authorize to create permission sessions linked to this permission. If not specified, Verifiable Service will not be able to use the payment delegation feature. <strong>Required</strong> to use the payment delegation feature.</li>
-<li><code>type</code> (PermissionType) (<em>mandatory</em>): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the permission that the applicant would like to get;</li>
-<li><code>validator_perm_id</code> (uint64) (<em>mandatory</em>): the <a class="term-reference" href="#term:validator">validator</a> permission (parent permission in the tree), chosen by the applicant.</li>
-<li><code>validation_fees</code> (number) (<em>optional</em>): Requested validation_fees for this permission (can be modified by validator).</li>
-<li><code>issuance_fees</code> (number) (<em>optional</em>): Requested issuance_fees for this permission (can be modified by validator).</li>
-<li><code>verification_fees</code> (number) (<em>optional</em>): Requested verification_fees for this permission (can be modified by validator).</li>
+<li><code>vs_operator</code> (account) (<em>optional</em>): the account of the Veriable Service we want to authorize to create participant sessions linked to this participant. If not specified, Verifiable Service will not be able to use the payment delegation feature. <strong>Required</strong> to use the payment delegation feature.</li>
+<li><code>role</code> (ParticipantRole) (<em>mandatory</em>): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the Participant role that the applicant would like to get;</li>
+<li><code>validator_participant_id</code> (uint64) (<em>mandatory</em>): the <a class="term-reference" href="#term:validator">validator</a> participant (parent participant in the tree), chosen by the applicant.</li>
+<li><code>validation_fees</code> (number) (<em>optional</em>): Requested validation_fees for this participant (can be modified by validator).</li>
+<li><code>issuance_fees</code> (number) (<em>optional</em>): Requested issuance_fees for this <code>Participant</code> entry (can be modified by validator).</li>
+<li><code>verification_fees</code> (number) (<em>optional</em>): Requested verification_fees for this <code>Participant</code> entry (can be modified by validator).</li>
 <li><code>did</code> (string) (<em>required</em>): MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
 </ul>
-<p>The following VS Operator Authorization parameters are <strong>optional</strong> and collectively define the initial <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> that will be created for this permission. Presence of <code>vs_operator_authz_msg_types</code> is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode (the corporation signs and pays for its own permission-related transactions directly). VSOA configuration is <strong>frozen at creation time</strong> and cannot be modified later; to change it, the permission MUST be revoked and re-created.</p>
+<p>The following VS Operator Authorization parameters are <strong>optional</strong> and collectively define the initial <a href="#participantauthorizationrecord" >ParticipantAuthorizationRecord</a> that will be created for this <code>Participant</code> entry. Presence of <code>vs_operator_authz_msg_types</code> is the trigger: if it is not provided, no authorization record is created and the <code>Participant</code> entry operates in manual mode (the corporation signs and pays for its own <code>Participant</code>-related transactions directly). VSOA configuration is <strong>frozen at creation time</strong> and cannot be modified later; to change it, the <code>Participant</code> entry MUST be revoked and re-created.</p>
 <ul>
-<li><code>vs_operator_authz_msg_types[]</code> (msg_type[]) (<em>optional</em>): list of VPR delegable message types <code>vs_operator</code> is authorized to execute on behalf of <code>corporation</code> in the context of this permission. If provided, a <code>PermissionAuthorizationRecord</code> is created (see execution below) and <code>vs_operator</code> MUST be specified. The permitted list of message types is provided below.</li>
-<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds <code>vs_operator</code> is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.</li>
-<li><code>vs_operator_authz_with_feegrant</code> (bool) (<em>optional</em>, default: false): if true, <code>corporation</code> pays transaction fees for <code>vs_operator</code> via an on-chain <code>FeeGrant</code> when executing authorized messages in the context of this permission.</li>
-<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of transaction fees that can be spent by <code>vs_operator</code> (paid by <code>corporation</code> via fee grant) in the context of this permission.</li>
-<li><code>vs_operator_authz_period</code> (duration) (<em>optional</em>): reset period for <code>vs_operator_authz_spend_limit</code> and <code>vs_operator_authz_fee_spend_limit</code> in the context of this permission.</li>
+<li><code>vs_operator_authz_msg_types[]</code> (msg_type[]) (<em>optional</em>): list of VPR delegable message types <code>vs_operator</code> is authorized to execute on behalf of <code>corporation</code> in the context of this <code>Participant</code> entry. If provided, a <code>ParticipantAuthorizationRecord</code> is created (see execution below) and <code>vs_operator</code> MUST be specified. The permitted list of message types is provided below.</li>
+<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds <code>vs_operator</code> is allowed to spend in the context of this <code>Participant</code> entry as a direct consequence of executing authorized messages.</li>
+<li><code>vs_operator_authz_with_feegrant</code> (bool) (<em>optional</em>, default: false): if true, <code>corporation</code> pays transaction fees for <code>vs_operator</code> via an on-chain <code>FeeGrant</code> when executing authorized messages in the context of this <code>Participant</code> entry.</li>
+<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of transaction fees that can be spent by <code>vs_operator</code> (paid by <code>corporation</code> via fee grant) in the context of this <code>Participant</code> entry.</li>
+<li><code>vs_operator_authz_period</code> (duration) (<em>optional</em>): reset period for <code>vs_operator_authz_spend_limit</code> and <code>vs_operator_authz_fee_spend_limit</code> in the context of this <code>Participant</code> entry.</li>
 </ul>
-<p>Permitted message types to be set in <code>vs_operator_authz_msg_types</code> depends on <code>type</code>.</p>
+<p>Permitted message types to be set in <code>vs_operator_authz_msg_types</code> depends on <code>role</code>.</p>
 <table>
 <thead>
 <tr>
-<th>Permission type</th>
+<th>Participant role</th>
 <th>Permitted Messages</th>
 </tr>
 </thead>
@@ -2524,61 +2982,61 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </tr>
 <tr>
 <td>ISSUER</td>
-<td>CreateOrUpdatePermissionSession, SetPermissionVPtoValidated</td>
+<td>CreateOrUpdateParticipantSession, SetParticipantOPtoValidated</td>
 </tr>
 <tr>
 <td>VERIFIER</td>
-<td>CreateOrUpdatePermissionSession</td>
+<td>CreateOrUpdateParticipantSession</td>
 </tr>
 <tr>
 <td>ISSUER_GRANTOR</td>
-<td>SetPermissionVPtoValidated</td>
+<td>SetParticipantOPtoValidated</td>
 </tr>
 <tr>
 <td>VERIFIER_GRANTOR</td>
-<td>SetPermissionVPtoValidated</td>
+<td>SetParticipantOPtoValidated</td>
 </tr>
 <tr>
 <td>ECOSYSTEM</td>
-<td>SetPermissionVPtoValidated</td>
+<td>SetParticipantOPtoValidated</td>
 </tr>
 </tbody>
 </table>
 <p>Available compatible perms can be found by using an indexer and presented in a front-end so applicant can choose its validator.</p>
-<h5 id="mod-perm-msg-1-2-start-permission-vp-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-1-2-start-permission-vp-precondition-checks" >§</a> [MOD-PERM-MSG-1-2] Start Permission VP precondition checks</h5>
+<h5 id="mod-pp-msg-1-2-start-participant-op-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-start-participant-op-precondition-checks" >§</a> [MOD-PP-MSG-1-2] Start Participant OP precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-1-2-1-start-permission-vp-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-1-2-1-start-permission-vp-basic-checks" >§</a> [MOD-PERM-MSG-1-2-1] Start Permission VP basic checks</h6>
+<h6 id="mod-pp-msg-1-2-1-start-participant-op-basic-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-1-start-participant-op-basic-checks" >§</a> [MOD-PP-MSG-1-2-1] Start Participant OP basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
 <li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
-<li><code>type</code> (PermissionType) (<em>mandatory</em>) MUST be a valid PermissionType: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.</li>
-<li><code>validator_perm_id</code> (uint64) (<em>mandatory</em>): see <a href="#mod-perm-msg-1-2-2-start-permission-vp-permission-checks" >MOD-PERM-MSG-1-2-2</a>.</li>
-<li><code>validation_fees</code> (number) (<em>optional</em>): Requested validation_fees for this permission (can be modified by validator).</li>
-<li><code>issuance_fees</code> (number) (<em>optional</em>): Requested issuance_fees for this permission (can be modified by validator).</li>
-<li><code>verification_fees</code> (number) (<em>optional</em>): Requested verification_fees for this permission (can be modified by validator).</li>
+<li><code>role</code> (ParticipantRole) (<em>mandatory</em>) MUST be a valid ParticipantRole: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.</li>
+<li><code>validator_participant_id</code> (uint64) (<em>mandatory</em>): see <a href="#mod-pp-msg-1-2-2-start-participant-op-permission-checks" >MOD-PP-MSG-1-2-2</a>.</li>
+<li><code>validation_fees</code> (number) (<em>optional</em>): Requested validation_fees for this <code>Participant</code> entry (can be modified by validator).</li>
+<li><code>issuance_fees</code> (number) (<em>optional</em>): Requested issuance_fees for this <code>Participant</code> entry (can be modified by validator).</li>
+<li><code>verification_fees</code> (number) (<em>optional</em>): Requested verification_fees for this <code>Participant</code> entry (can be modified by validator).</li>
 <li><code>did</code>, if specified, MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
-<li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-perm-msg-1-1-start-permission-vp-parameters" >MOD-PERM-MSG-1-1</a>.</li>
+<li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-pp-msg-1-1-start-participant-op-parameters" >MOD-PP-MSG-1-1</a>.</li>
 </ul>
-<div id="note-85" class="notice note"><a class="notice-link" href="#note-85">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the validation process is REQUIRED or not.</p>
+<div id="note-85" class="notice note"><a class="notice-link" href="#note-85">NOTE</a><p>A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It’s up to the issuer to decide if running the onboarding process is REQUIRED or not.</p>
 </div>
-<h6 id="mod-perm-msg-1-2-2-start-permission-vp-permission-checks"><a class="toc-anchor" href="#mod-perm-msg-1-2-2-start-permission-vp-permission-checks" >§</a> [MOD-PERM-MSG-1-2-2] Start Permission VP permission checks</h6>
+<h6 id="mod-pp-msg-1-2-2-start-participant-op-permission-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-2-start-participant-op-permission-checks" >§</a> [MOD-PP-MSG-1-2-2] Start Participant OP permission checks</h6>
 <ul>
 <li>
-<p>Load <code>Permission</code> entry <code>validator_perm</code> from <code>validator_perm_id</code>. It MUST be a <a class="term-reference" href="#term:active-permission">active permission</a> else transaction MUST abort.</p>
+<p>Load <code>Participant</code> entry <code>validator_participant</code> from <code>validator_participant_id</code>. It MUST be a <a class="term-reference" href="#term:active-participant">active participant</a> else transaction MUST abort.</p>
 </li>
 <li>
-<p>Load <code>CredentialSchema</code> entry <code>cs</code> from <code>validator_perm.schema_id</code>. It MUST exist.</p>
+<p>Load <code>CredentialSchema</code> entry <code>cs</code> from <code>validator_participant.schema_id</code>. It MUST exist.</p>
 </li>
 <li>
-<p>if <code>type</code> (PermissionType) is equal to ISSUER:</p>
+<p>if <code>role</code> (ParticipantRole) is equal to ISSUER:</p>
 <ul>
 <li>
-<p>if <code>cs.issuer_onboarding_mode</code> is equal to GRANTOR_VALIDATION_PROCESS: <code>validator_perm.type</code> MUST be ISSUER_GRANTOR, else MUST abort.</p>
+<p>if <code>cs.issuer_onboarding_mode</code> is equal to GRANTOR_ONBOARDING_PROCESS: <code>validator_participant.role</code> MUST be ISSUER_GRANTOR, else MUST abort.</p>
 </li>
 <li>
-<p>else if <code>cs.issuer_onboarding_mode</code> is equal to ECOSYSTEM_VALIDATION_PROCESS: <code>validator_perm.type</code> MUST be ECOSYSTEM, else MUST abort.</p>
+<p>else if <code>cs.issuer_onboarding_mode</code> is equal to ECOSYSTEM_ONBOARDING_PROCESS: <code>validator_participant.role</code> MUST be ECOSYSTEM, else MUST abort.</p>
 </li>
 <li>
 <p>else MUST abort.</p>
@@ -2586,10 +3044,10 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 <li>
-<p>else if <code>type</code> (PermissionType) is equal to ISSUER_GRANTOR:</p>
+<p>else if <code>role</code> (ParticipantRole) is equal to ISSUER_GRANTOR:</p>
 <ul>
 <li>
-<p>if <code>cs.issuer_onboarding_mode</code> is equal to GRANTOR_VALIDATION_PROCESS:  <code>validator_perm.type</code> MUST be ECOSYSTEM, else MUST abort.</p>
+<p>if <code>cs.issuer_onboarding_mode</code> is equal to GRANTOR_ONBOARDING_PROCESS:  <code>validator_participant.role</code> MUST be ECOSYSTEM, else MUST abort.</p>
 </li>
 <li>
 <p>else abort.</p>
@@ -2597,13 +3055,13 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 <li>
-<p>else if <code>type</code> (PermissionType) is equal to VERIFIER:</p>
+<p>else if <code>role</code> (ParticipantRole) is equal to VERIFIER:</p>
 <ul>
 <li>
-<p>if <code>cs.verifier_onboarding_mode</code> is equal to GRANTOR: <code>validator_perm.type</code> MUST be VERIFIER_GRANTOR, else MUST abort.</p>
+<p>if <code>cs.verifier_onboarding_mode</code> is equal to GRANTOR: <code>validator_participant.role</code> MUST be VERIFIER_GRANTOR, else MUST abort.</p>
 </li>
 <li>
-<p>else if <code>cs.verifier_onboarding_mode</code> is equal to ECOSYSTEM_VALIDATION_PROCESS: <code>validator_perm.type</code> MUST be ECOSYSTEM, else MUST abort.</p>
+<p>else if <code>cs.verifier_onboarding_mode</code> is equal to ECOSYSTEM_ONBOARDING_PROCESS: <code>validator_participant.role</code> MUST be ECOSYSTEM, else MUST abort.</p>
 </li>
 <li>
 <p>else abort.</p>
@@ -2611,10 +3069,10 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 <li>
-<p>else if <code>type</code> (PermissionType) is equal to VERIFIER_GRANTOR:</p>
+<p>else if <code>role</code> (ParticipantRole) is equal to VERIFIER_GRANTOR:</p>
 <ul>
 <li>
-<p>if <code>cs.verifier_onboarding_mode</code> is equal to GRANTOR_VALIDATION_PROCESS: <code>validator_perm.type</code> MUST be ECOSYSTEM, else MUST abort.</p>
+<p>if <code>cs.verifier_onboarding_mode</code> is equal to GRANTOR_ONBOARDING_PROCESS: <code>validator_participant.role</code> MUST be ECOSYSTEM, else MUST abort.</p>
 </li>
 <li>
 <p>else abort.</p>
@@ -2622,10 +3080,10 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 <li>
-<p>else if <code>type</code> (PermissionType) is equal to HOLDER:</p>
+<p>else if <code>role</code> (ParticipantRole) is equal to HOLDER:</p>
 <ul>
 <li>
-<p>if <code>cs.holder_onboarding_mode</code> is equal to ISSUER_VALIDATION_PROCESS: <code>validator_perm.type</code> MUST be ISSUER, else MUST abort.</p>
+<p>if <code>cs.holder_onboarding_mode</code> is equal to ISSUER_ONBOARDING_PROCESS: <code>validator_participant.role</code> MUST be ISSUER, else MUST abort.</p>
 </li>
 <li>
 <p>else abort.</p>
@@ -2633,14 +3091,14 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </ul>
 </li>
 </ul>
-<p>At the end, if a <a class="term-reference" href="#term:active-permission">active permission</a> <code>validator_perm</code> is not found, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-1-2-3-start-permission-vp-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-1-2-3-start-permission-vp-fee-checks" >§</a> [MOD-PERM-MSG-1-2-3] Start Permission VP fee checks</h6>
+<p>At the end, if a <a class="term-reference" href="#term:active-participant">active participant</a> <code>validator_participant</code> is not found, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<h6 id="mod-pp-msg-1-2-3-start-participant-op-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-3-start-participant-op-fee-checks" >§</a> [MOD-PP-MSG-1-2-3] Start Participant OP fee checks</h6>
 <ul>
 <li>
-<p>Load <code>Permission</code> entry <code>validator_perm</code> from <code>validator_perm_id</code>.</p>
+<p>Load <code>Participant</code> entry <code>validator_participant</code> from <code>validator_participant_id</code>.</p>
 </li>
 <li>
-<p>Load <code>CredentialSchema</code> entry <code>cs</code> from <code>validator_perm.schema_id</code>.</p>
+<p>Load <code>CredentialSchema</code> entry <code>cs</code> from <code>validator_participant.schema_id</code>.</p>
 </li>
 <li>
 <p>Fee payer MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>;</p>
@@ -2656,7 +3114,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <ul>
 <li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
-<li>the required <code>validation_fees_in_denom</code> = <code>validator_perm.validation_fees</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
+<li>the required <code>validation_fees_in_denom</code> = <code>validator_participant.validation_fees</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: <code>validation_fees_in_denom</code> * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 </li>
@@ -2665,7 +3123,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <ul>
 <li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
-<li>the required <code>validation_fees_in_denom</code> = getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validator_perm.validation_fees</code>) in <a class="term-reference" href="#term:native-denom">native denom</a>;</li>
+<li>the required <code>validation_fees_in_denom</code> = getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validator_participant.validation_fees</code>) in <a class="term-reference" href="#term:native-denom">native denom</a>;</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: <code>validation_fees_in_denom</code> * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 </li>
@@ -2674,7 +3132,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <ul>
 <li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
-<li>the required <code>validation_fees_in_denom</code> = <code>validator_perm.validation_fees</code> in specified (cs.pricing_asset_type, cs.pricing_asset)</li>
+<li>the required <code>validation_fees_in_denom</code> = <code>validator_participant.validation_fees</code> in specified (cs.pricing_asset_type, cs.pricing_asset)</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validation_fees_in_denom</code>) * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 </li>
@@ -2684,25 +3142,25 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
 <li>the required <code>validation_fees_in_denom</code> = 0 in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
-<li>the required <code>validation_trust_deposit_in_native_denom</code>: getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validator_perm.validation_fees</code>) * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
+<li>the required <code>validation_trust_deposit_in_native_denom</code>: getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validator_participant.validation_fees</code>) * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 </li>
 </ul>
 <div id="note-86" class="notice note"><a class="notice-link" href="#note-86">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
-<h6 id="mod-perm-msg-1-2-4-start-permission-vp-overlap-checks"><a class="toc-anchor" href="#mod-perm-msg-1-2-4-start-permission-vp-overlap-checks" >§</a> [MOD-PERM-MSG-1-2-4] Start Permission VP overlap checks</h6>
-<p>We want to make sure that 2 validation processes cannot be active at the same time in the same context. This does not prevent a <code>corporation</code> from running different VP with differents validators for the same <code>schema_id</code>, <code>type</code>.</p>
-<p>Find all permission <code>perms[]</code> for <code>schema_id</code>, <code>type</code>, <code>validator_perm_id</code>, <code>corporation</code> with vp_state = VALIDATED or PENDING.</p>
-<p>if size of <code>perms[]</code> &gt; 0, it means there is already an existing validation process in this context, so MUST abort.</p>
+<h6 id="mod-pp-msg-1-2-4-start-participant-op-overlap-checks"><a class="toc-anchor" href="#mod-pp-msg-1-2-4-start-participant-op-overlap-checks" >§</a> [MOD-PP-MSG-1-2-4] Start Participant OP overlap checks</h6>
+<p>We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a <code>corporation</code> from running different OP with differents validators for the same <code>schema_id</code>, <code>role</code>.</p>
+<p>Find all <code>Participant</code> entries <code>participants[]</code> for <code>schema_id</code>, <code>role</code>, <code>validator_participant_id</code>, <code>corporation</code> with op_state = VALIDATED or PENDING.</p>
+<p>if size of <code>participants[]</code> &gt; 0, it means there is already an existing onboarding process in this context, so MUST abort.</p>
 <blockquote>
 <p>note: this check was not present in v3.</p>
 </blockquote>
-<h5 id="mod-perm-msg-1-3-start-permission-vp-execution"><a class="toc-anchor" href="#mod-perm-msg-1-3-start-permission-vp-execution" >§</a> [MOD-PERM-MSG-1-3] Start Permission VP execution</h5>
+<h5 id="mod-pp-msg-1-3-start-participant-op-execution"><a class="toc-anchor" href="#mod-pp-msg-1-3-start-participant-op-execution" >§</a> [MOD-PP-MSG-1-3] Start Participant OP execution</h5>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>
-<p>Load <code>Permission</code> entry <code>validator_perm</code> of the selected validator.</p>
+<p>Load <code>Participant</code> entry <code>validator_participant</code> of the selected validator.</p>
 </li>
 <li>
 <p>calculate <code>validation_fees_in_denom</code> and <code>validation_trust_deposit_in_native_denom</code> as explained above in fee checks.</p>
@@ -2717,36 +3175,36 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <p>define <code>now</code>: current timestamp.</p>
 </li>
 <li>
-<p>create an persist a new permission entry <code>applicant_perm</code>:</p>
+<p>create an persist a new <code>Participant</code> entry <code>applicant_participant</code>:</p>
 <ul>
-<li><code>applicant_perm.id</code>: auto-incremented uint64.</li>
-<li><code>applicant_perm.schema_id</code> = <code>validator_perm.schema_id</code></li>
-<li><code>applicant_perm.corporation</code>: <code>corporation</code>.</li>
-<li><code>applicant_perm.vs_operator</code>: <code>vs_operator</code>.</li>
-<li><code>applicant_perm.type</code>: <code>type</code>.</li>
-<li><code>applicant_perm.created</code>: <code>now</code></li>
-<li><code>applicant_perm.modified</code>: <code>now</code></li>
-<li><code>applicant_perm.deposit</code>: <code>validation_trust_deposit_in_native_denom</code>.</li>
-<li><code>applicant_perm.validation_fees</code>: <code>validation_fees</code>.</li>
-<li><code>applicant_perm.issuance_fees</code>: <code>issuance_fees</code>.</li>
-<li><code>applicant_perm.verification_fees</code>: <code>verification_fees</code>.</li>
-<li><code>applicant_perm.validator_perm_id</code>: <code>validator_perm_id</code>.</li>
-<li><code>applicant_perm.vp_last_state_change</code>: <code>now</code></li>
-<li><code>applicant_perm.vp_state</code>: PENDING.</li>
-<li><code>applicant_perm.vp_current_fees</code> (number): <code>validation_fees_in_denom</code>.</li>
-<li><code>applicant_perm.vp_current_deposit</code> (number): <code>validation_trust_deposit_in_native_denom</code>.</li>
-<li><code>applicant_perm.vp_summary_digest</code>: null.</li>
-<li><code>applicant_perm.vp_validator_deposit</code>: 0.</li>
+<li><code>applicant_participant.id</code>: auto-incremented uint64.</li>
+<li><code>applicant_participant.schema_id</code> = <code>validator_participant.schema_id</code></li>
+<li><code>applicant_participant.corporation</code>: <code>corporation</code>.</li>
+<li><code>applicant_participant.vs_operator</code>: <code>vs_operator</code>.</li>
+<li><code>applicant_participant.role</code>: <code>role</code>.</li>
+<li><code>applicant_participant.created</code>: <code>now</code></li>
+<li><code>applicant_participant.modified</code>: <code>now</code></li>
+<li><code>applicant_participant.deposit</code>: <code>validation_trust_deposit_in_native_denom</code>.</li>
+<li><code>applicant_participant.validation_fees</code>: <code>validation_fees</code>.</li>
+<li><code>applicant_participant.issuance_fees</code>: <code>issuance_fees</code>.</li>
+<li><code>applicant_participant.verification_fees</code>: <code>verification_fees</code>.</li>
+<li><code>applicant_participant.validator_participant_id</code>: <code>validator_participant_id</code>.</li>
+<li><code>applicant_participant.op_last_state_change</code>: <code>now</code></li>
+<li><code>applicant_participant.op_state</code>: PENDING.</li>
+<li><code>applicant_participant.op_current_fees</code> (number): <code>validation_fees_in_denom</code>.</li>
+<li><code>applicant_participant.op_current_deposit</code> (number): <code>validation_trust_deposit_in_native_denom</code>.</li>
+<li><code>applicant_participant.op_summary_digest</code>: null.</li>
+<li><code>applicant_participant.op_validator_deposit</code>: 0.</li>
 </ul>
 </li>
 </ul>
-<p>If <code>vs_operator_authz_msg_types</code> is provided, create the <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> in <strong>disabled</strong> state (<code>expiration = now</code>) by calling <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a> Grant VS Operator Authorization with:</p>
+<p>If <code>vs_operator_authz_msg_types</code> is provided, create the <a href="#participantauthorizationrecord" >ParticipantAuthorizationRecord</a> in <strong>disabled</strong> state (<code>expiration = now</code>) by calling <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a> Grant VS Operator Authorization with:</p>
 <ul>
 <li><code>corporation</code>: <code>corporation</code></li>
 <li><code>vs_operator</code>: <code>vs_operator</code></li>
 <li><code>record</code>:
 <ul>
-<li><code>record.perm_id</code>: <code>applicant_perm.id</code></li>
+<li><code>record.participant_id</code>: <code>applicant_participant.id</code></li>
 <li><code>record.msg_types</code>: <code>vs_operator_authz_msg_types</code></li>
 <li><code>record.spend_limit</code>: <code>vs_operator_authz_spend_limit</code></li>
 <li><code>record.fee_spend_limit</code>: <code>vs_operator_authz_fee_spend_limit</code></li>
@@ -2757,65 +3215,65 @@ with a given <code>(schema_id, role)</code> pair.</p>
 </li>
 </ul>
 <blockquote>
-<p>Note: the record is created with <code>expiration = now</code> so authorization is <strong>not yet active</strong>. <a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a> will reject any attempt to use it until <a href="#mod-perm-msg-3-set-permission-vp-to-validated" >[MOD-PERM-MSG-3]</a> updates <code>expiration</code> to <code>applicant_perm.effective_until</code>. No on-chain <code>FeeGrant</code> object is created at this stage even if <code>with_feegrant</code> is true (the recompute subroutine in <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a> requires <code>expiration &gt; now</code>).</p>
+<p>Note: the record is created with <code>expiration = now</code> so authorization is <strong>not yet active</strong>. <a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a> will reject any attempt to use it until <a href="#mod-pp-msg-3-set-participant-op-to-validated" >[MOD-PP-MSG-3]</a> updates <code>expiration</code> to <code>applicant_participant.effective_until</code>. No on-chain <code>FeeGrant</code> object is created at this stage even if <code>with_feegrant</code> is true (the recompute subroutine in <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a> requires <code>expiration &gt; now</code>).</p>
 </blockquote>
 <h4 id="connecting-to-the-vs-of-the-validator"><a class="toc-anchor" href="#connecting-to-the-vs-of-the-validator" >§</a> Connecting to the VS of the Validator</h4>
 <p><em>This section is non-normative, and provided for understanding only.</em></p>
 <p>This action must be initiated by the <a class="term-reference" href="#term:applicant">applicant</a>.</p>
-<p>During a validation process, if the associated <code>validator_perm</code> includes a specific <code>did</code>, the <a class="term-reference" href="#term:applicant">applicant</a> should establish a secure connection with the validator’s <a class="term-reference" href="#term:vs">VS</a> (Verifiable Service) using a secure communication protocol such as <a class="term-reference" href="#term:didcomm">DIDComm</a>.</p>
+<p>During an onboarding process, if the associated <code>validator_participant</code> includes a specific <code>did</code>, the <a class="term-reference" href="#term:applicant">applicant</a> should establish a secure connection with the validator’s <a class="term-reference" href="#term:vs">VS</a> (Verifiable Service) using a secure communication protocol such as <a class="term-reference" href="#term:didcomm">DIDComm</a>.</p>
 <p>Upon connecting to the <a class="term-reference" href="#term:vs">VS</a>, the <a class="term-reference" href="#term:applicant">applicant</a> should be required by the <a class="term-reference" href="#term:validator">validator</a> to complete one or more of the following tasks:</p>
 <ol>
-<li><strong>Prove control</strong> over the <code>vs_operator</code> <a class="term-reference" href="#term:account">account</a> specifid in the permission (e.g., via blind signature or cryptographic challenge).</li>
+<li><strong>Prove control</strong> over the <code>vs_operator</code> <a class="term-reference" href="#term:account">account</a> specified in the <code>Participant</code> entry (e.g., via blind signature or cryptographic challenge).</li>
 <li><strong>Provide requested information</strong>, such as filling out forms, submitting documents, or other forms of disclosure as required by the validation <a class="term-reference" href="#term:vs">VS</a>.</li>
-<li>If the requested permission includes a <a class="term-reference" href="#term:vs">VS</a> DID, the <a class="term-reference" href="#term:applicant">applicant</a> should prove control over the corresponding <a class="term-reference" href="#term:did">DID</a> to the validator’s <a class="term-reference" href="#term:vs">VS</a>.</li>
+<li>If the requested <code>Participant</code> entry includes a <a class="term-reference" href="#term:vs">VS</a> DID, the <a class="term-reference" href="#term:applicant">applicant</a> should prove control over the corresponding <a class="term-reference" href="#term:did">DID</a> to the validator’s <a class="term-reference" href="#term:vs">VS</a>.</li>
 </ol>
-<p>Once the <a class="term-reference" href="#term:validator">validator</a> determines that the process is complete, they may terminate the validation process and create the permission accordingly. This permission configuration usually include:</p>
+<p>Once the <a class="term-reference" href="#term:validator">validator</a> determines that the process is complete, they may terminate the onboarding process and create the <code>Participant</code> entry accordingly. This <code>Participant</code>-entry configuration usually includes:</p>
 <ul>
 <li><code>validation_fees</code></li>
 <li><code>issuance_fees</code></li>
 <li><code>verification_fees</code></li>
-<li><code>permission expiration</code></li>
+<li><code>Participant</code> expiration</li>
 </ul>
-<p>The <a class="term-reference" href="#term:validator">validator</a> may compile a summary file of the validation process, documenting exchanged data, proofs, and decisions, and share it with the <a class="term-reference" href="#term:applicant">applicant</a> via the <a class="term-reference" href="#term:vs">VS</a> connection or another secure channel.</p>
-<p>For audit or governance purposes, the <a class="term-reference" href="#term:validator">validator</a> should register a digest (e.g., hash or SRI) of this summary in <code>applicant_perm.vp_summary_digest</code>.</p>
-<h4 id="mod-perm-msg-2-renew-permission-vp"><a class="toc-anchor" href="#mod-perm-msg-2-renew-permission-vp" >§</a> [MOD-PERM-MSG-2] Renew Permission VP</h4>
+<p>The <a class="term-reference" href="#term:validator">validator</a> may compile a summary file of the onboarding process, documenting exchanged data, proofs, and decisions, and share it with the <a class="term-reference" href="#term:applicant">applicant</a> via the <a class="term-reference" href="#term:vs">VS</a> connection or another secure channel.</p>
+<p>For audit or governance purposes, the <a class="term-reference" href="#term:validator">validator</a> should register a digest (e.g., hash or SRI) of this summary in <code>applicant_participant.op_summary_digest</code>.</p>
+<h4 id="mod-pp-msg-2-renew-participant-op"><a class="toc-anchor" href="#mod-pp-msg-2-renew-participant-op" >§</a> [MOD-PP-MSG-2] Renew Participant OP</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p><em>This section is non-normative.</em></p>
 <ul>
-<li>Requesting a renewal has no effect on permission expiration or issued credentials.</li>
+<li>Requesting a renewal has no effect on <code>Participant</code> expiration or issued credentials.</li>
 <li>Renewal is only possible with the same validator.</li>
-<li>If validator permission is not valid anymore, applicant MUST perform a new validation process with another validator.</li>
-<li>Renewal does not allow changing the <code>perm.validation_fees</code>, <code>perm.issuance_fees</code>, <code>perm.verification_fees</code>. To change these values, applicant MUST start a new validation process.</li>
-<li>if permission is revoked, slashed, or repaid, method MUST fail.</li>
+<li>If validator <code>Participant</code> is not valid anymore, applicant MUST perform a new onboarding process with another validator.</li>
+<li>Renewal does not allow changing the <code>participant.validation_fees</code>, <code>participant.issuance_fees</code>, <code>participant.verification_fees</code>. To change these values, applicant MUST start a new onboarding process.</li>
+<li>if <code>applicant_participant</code> is revoked, slashed, or repaid, method MUST fail.</li>
 </ul>
-<h5 id="mod-perm-msg-2-1-renew-permission-vp-parameters"><a class="toc-anchor" href="#mod-perm-msg-2-1-renew-permission-vp-parameters" >§</a> [MOD-PERM-MSG-2-1] Renew Permission VP parameters</h5>
+<h5 id="mod-pp-msg-2-1-renew-participant-op-parameters"><a class="toc-anchor" href="#mod-pp-msg-2-1-renew-participant-op-parameters" >§</a> [MOD-PP-MSG-2-1] Renew Participant OP parameters</h5>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): id of the permission for which applicant would like to renew the validation process;</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): id of the <code>Participant</code> entry for which applicant would like to renew the onboarding process;</li>
 </ul>
-<h5 id="mod-perm-msg-2-2-renew-permission-vp-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-2-2-renew-permission-vp-precondition-checks" >§</a> [MOD-PERM-MSG-2-2] Renew Permission VP precondition checks</h5>
+<h5 id="mod-pp-msg-2-2-renew-participant-op-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-2-2-renew-participant-op-precondition-checks" >§</a> [MOD-PP-MSG-2-2] Renew Participant OP precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-2-2-1-renew-permission-vp-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-2-2-1-renew-permission-vp-basic-checks" >§</a> [MOD-PERM-MSG-2-2-1] Renew Permission VP basic checks</h6>
+<h6 id="mod-pp-msg-2-2-1-renew-participant-op-basic-checks"><a class="toc-anchor" href="#mod-pp-msg-2-2-1-renew-participant-op-basic-checks" >§</a> [MOD-PP-MSG-2-2-1] Renew Participant OP basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
 <li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
-<li><code>id</code> MUST be a valid uint64 and a permission entry with the same id MUST exist.</li>
+<li><code>id</code> MUST be a valid uint64 and a <code>Participant</code> entry with the same id MUST exist.</li>
 </ul>
-<h6 id="mod-perm-msg-2-2-2-renew-permission-vp-permission-checks"><a class="toc-anchor" href="#mod-perm-msg-2-2-2-renew-permission-vp-permission-checks" >§</a> [MOD-PERM-MSG-2-2-2] Renew Permission VP permission checks</h6>
+<h6 id="mod-pp-msg-2-2-2-renew-participant-op-permission-checks"><a class="toc-anchor" href="#mod-pp-msg-2-2-2-renew-participant-op-permission-checks" >§</a> [MOD-PP-MSG-2-2-2] Renew Participant OP permission checks</h6>
 <ul>
-<li>Load <code>Permission</code> entry <code>applicant_perm</code>. <code>corporation</code> running the operation MUST be <code>applicant_perm.corporation</code>, else MUST abort. <code>applicant_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a>.</li>
-<li>Load <code>Permission</code> entry <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>. It MUST exist, and be a <a class="term-reference" href="#term:active-permission">active permission</a>, else MUST abort.</li>
+<li>Load <code>Participant</code> entry <code>applicant_participant</code>. <code>corporation</code> running the operation MUST be <code>applicant_participant.corporation</code>, else MUST abort. <code>applicant_participant</code> MUST be a <a class="term-reference" href="#term:active-participant">active participant</a>.</li>
+<li>Load <code>Participant</code> entry <code>validator_participant</code> from <code>applicant_participant.validator_participant_id</code>. It MUST exist, and be a <a class="term-reference" href="#term:active-participant">active participant</a>, else MUST abort.</li>
 </ul>
-<h6 id="mod-perm-msg-2-2-3-renew-permission-vp-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-2-2-3-renew-permission-vp-fee-checks" >§</a> [MOD-PERM-MSG-2-2-3] Renew Permission VP fee checks</h6>
+<h6 id="mod-pp-msg-2-2-3-renew-participant-op-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-2-2-3-renew-participant-op-fee-checks" >§</a> [MOD-PP-MSG-2-2-3] Renew Participant OP fee checks</h6>
 <ul>
 <li>
-<p>Load <code>Permission</code> entry <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>.</p>
+<p>Load <code>Participant</code> entry <code>validator_participant</code> from <code>applicant_participant.validator_participant_id</code>.</p>
 </li>
 <li>
-<p>Load <code>CredentialSchema</code> entry <code>cs</code> from <code>validator_perm.schema_id</code>.</p>
+<p>Load <code>CredentialSchema</code> entry <code>cs</code> from <code>validator_participant.schema_id</code>.</p>
 </li>
 <li>
 <p>Fee payer MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>;</p>
@@ -2831,7 +3289,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <ul>
 <li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
-<li>the required <code>validation_fees_in_denom</code> = <code>validator_perm.validation_fees</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
+<li>the required <code>validation_fees_in_denom</code> = <code>validator_participant.validation_fees</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: <code>validation_fees_in_denom</code> * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 </li>
@@ -2840,7 +3298,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <ul>
 <li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
-<li>the required <code>validation_fees_in_denom</code> = getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validator_perm.validation_fees</code>) in <a class="term-reference" href="#term:native-denom">native denom</a>;</li>
+<li>the required <code>validation_fees_in_denom</code> = getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validator_participant.validation_fees</code>) in <a class="term-reference" href="#term:native-denom">native denom</a>;</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: <code>validation_fees_in_denom</code> * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 </li>
@@ -2849,7 +3307,7 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <ul>
 <li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
-<li>the required <code>validation_fees_in_denom</code> = <code>validator_perm.validation_fees</code> in specified (cs.pricing_asset_type, cs.pricing_asset)</li>
+<li>the required <code>validation_fees_in_denom</code> = <code>validator_participant.validation_fees</code> in specified (cs.pricing_asset_type, cs.pricing_asset)</li>
 <li>the required <code>validation_trust_deposit_in_native_denom</code>: getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validation_fees_in_denom</code>) * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 </li>
@@ -2859,21 +3317,21 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <li><code>corporation</code> MUST have an available balance in its <a class="term-reference" href="#term:account">account</a>, to cover the following trust fees.
 <ul>
 <li>the required <code>validation_fees_in_denom</code> = 0 in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
-<li>the required <code>validation_trust_deposit_in_native_denom</code>: getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validator_perm.validation_fees</code>) * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
+<li>the required <code>validation_trust_deposit_in_native_denom</code>: getPrice(<code>cs.pricing_asset_type</code>, <code>cs.pricing_asset</code>, <code>COIN</code>, <code>[[ref: native denom]]</code>, <code>validator_participant.validation_fees</code>) * <code>GlobalVariables.trust_deposit_rate</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
 </ul>
 </li>
 </ul>
 <div id="note-87" class="notice note"><a class="notice-link" href="#note-87">NOTE</a><p>Trust deposit MUST always be paid in <a class="term-reference" href="#term:native-denom">native denom</a></p>
 </div>
-<h6 id="mod-perm-msg-2-3-renew-permission-vp-execution"><a class="toc-anchor" href="#mod-perm-msg-2-3-renew-permission-vp-execution" >§</a> [MOD-PERM-MSG-2-3] Renew Permission VP execution</h6>
+<h6 id="mod-pp-msg-2-3-renew-participant-op-execution"><a class="toc-anchor" href="#mod-pp-msg-2-3-renew-participant-op-execution" >§</a> [MOD-PP-MSG-2-3] Renew Participant OP execution</h6>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>
-<p>Load <code>Permission</code> entry <code>applicant_perm</code>.</p>
+<p>Load <code>Participant</code> entry <code>applicant_participant</code>.</p>
 </li>
 <li>
-<p>Load <code>Permission</code> entry <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>.</p>
+<p>Load <code>Participant</code> entry <code>validator_participant</code> from <code>applicant_participant.validator_participant_id</code>.</p>
 </li>
 <li>
 <p>calculate <code>validation_fees_in_denom</code> and <code>validation_trust_deposit_in_native_denom</code> as explained above in fee checks.</p>
@@ -2888,87 +3346,87 @@ with a given <code>(schema_id, role)</code> pair.</p>
 <p>define <code>now</code>: current timestamp.</p>
 </li>
 <li>
-<p>update permission entry:</p>
+<p>update <code>Participant</code> entry:</p>
 <ul>
-<li><code>applicant_perm.vp_state</code>: PENDING.</li>
-<li><code>applicant_perm.vp_last_state_change</code>: current timestamp.</li>
-<li><code>applicant_perm.deposit</code>: <code>applicant_perm.deposit</code> + <code>validation_trust_deposit_in_native_denom</code>.</li>
-<li><code>applicant_perm.vp_current_fees</code> (number): <code>validation_fees_in_denom</code>.</li>
-<li><code>applicant_perm.vp_current_deposit</code> (number): <code>validation_trust_deposit_in_native_denom</code>.</li>
-<li><code>applicant_perm.modified</code>: <code>now</code></li>
+<li><code>applicant_participant.op_state</code>: PENDING.</li>
+<li><code>applicant_participant.op_last_state_change</code>: current timestamp.</li>
+<li><code>applicant_participant.deposit</code>: <code>applicant_participant.deposit</code> + <code>validation_trust_deposit_in_native_denom</code>.</li>
+<li><code>applicant_participant.op_current_fees</code> (number): <code>validation_fees_in_denom</code>.</li>
+<li><code>applicant_participant.op_current_deposit</code> (number): <code>validation_trust_deposit_in_native_denom</code>.</li>
+<li><code>applicant_participant.modified</code>: <code>now</code></li>
 </ul>
 </li>
 </ul>
-<h4 id="mod-perm-msg-3-set-permission-vp-to-validated"><a class="toc-anchor" href="#mod-perm-msg-3-set-permission-vp-to-validated" >§</a> [MOD-PERM-MSG-3] Set Permission VP to Validated</h4>
+<h4 id="mod-pp-msg-3-set-participant-op-to-validated"><a class="toc-anchor" href="#mod-pp-msg-3-set-participant-op-to-validated" >§</a> [MOD-PP-MSG-3] Set Participant OP to Validated</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
-<h5 id="mod-perm-msg-3-1-set-permission-vp-to-validated-parameters"><a class="toc-anchor" href="#mod-perm-msg-3-1-set-permission-vp-to-validated-parameters" >§</a> [MOD-PERM-MSG-3-1] Set Permission VP to Validated parameters</h5>
+<h5 id="mod-pp-msg-3-1-set-participant-op-to-validated-parameters"><a class="toc-anchor" href="#mod-pp-msg-3-1-set-participant-op-to-validated-parameters" >§</a> [MOD-PP-MSG-3-1] Set Participant OP to Validated parameters</h5>
 <p>An <a class="term-reference" href="#term:account">account</a> that would like to set a validation entry to VALIDATED MUST execute this method by specifying:</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): id of the validation process;</li>
-<li><code>effective_until</code> (timestamp) (<em>optional</em>): timestamp until when (exclusive) this <code>Permission</code> is effective, null if no time limit should been set for this permission or if we want it to be aligned with the validation process expiration timestamp calculated by this method.</li>
-<li><code>validation_fees</code> (number) (<em>mandatory</em>): Agreed validation_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.</li>
-<li><code>issuance_fees</code> (number) (<em>mandatory</em>): Agreed issuance_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.</li>
-<li><code>verification_fees</code> (number) (<em>mandatory</em>): Agreed verification_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.</li>
-<li><code>vp_summary_digest</code> (string) (<em>optional</em>): an optional digest, set by <a class="term-reference" href="#term:validator">validator</a>, of a summary of the information, proofs… provided by the <a class="term-reference" href="#term:applicant">applicant</a>.</li>
-<li><code>issuance_fee_discount</code>: (number) (<em>mandatory</em>): use 0 for no discount. Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_VALIDATION_PROCESS mode) or an ISSUER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
-<li><code>verification_fee_discount</code>: (number) (<em>mandatory</em>): use 0 for no discount. Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_VALIDATION_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): id of the onboarding process;</li>
+<li><code>effective_until</code> (timestamp) (<em>optional</em>): timestamp until when (exclusive) this <code>Participant</code> is effective, null if no time limit should been set for this <code>Participant</code> entry or if we want it to be aligned with the onboarding process expiration timestamp calculated by this method.</li>
+<li><code>validation_fees</code> (number) (<em>mandatory</em>): Agreed validation_fees for this <code>Participant</code> entry. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.</li>
+<li><code>issuance_fees</code> (number) (<em>mandatory</em>): Agreed issuance_fees for this <code>Participant</code> entry. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.</li>
+<li><code>verification_fees</code> (number) (<em>mandatory</em>): Agreed verification_fees for this <code>Participant</code> entry. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.</li>
+<li><code>op_summary_digest</code> (string) (<em>optional</em>): an optional digest, set by <a class="term-reference" href="#term:validator">validator</a>, of a summary of the information, proofs… provided by the <a class="term-reference" href="#term:applicant">applicant</a>.</li>
+<li><code>issuance_fee_discount</code>: (number) (<em>mandatory</em>): use 0 for no discount. Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR or ISSUER <code>Participant</code> entry (if GRANTOR_ONBOARDING_PROCESS mode) or to an ISSUER <code>Participant</code> entry (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated issuance fees for the subtree of <code>Participant</code> entries. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
+<li><code>verification_fee_discount</code>: (number) (<em>mandatory</em>): use 0 for no discount. Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR or VERIFIER <code>Participant</code> entry (if GRANTOR_ONBOARDING_PROCESS mode) and/or to a VERIFIER <code>Participant</code> entry (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated fees for the subtree of <code>Participant</code> entries. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.</li>
 </ul>
-<h5 id="mod-perm-msg-3-2-set-permission-vp-to-validated-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-3-2-set-permission-vp-to-validated-precondition-checks" >§</a> [MOD-PERM-MSG-3-2] Set Permission VP to Validated precondition checks</h5>
+<h5 id="mod-pp-msg-3-2-set-participant-op-to-validated-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-3-2-set-participant-op-to-validated-precondition-checks" >§</a> [MOD-PP-MSG-3-2] Set Participant OP to Validated precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-3-2-1-set-permission-vp-to-validated-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-3-2-1-set-permission-vp-to-validated-basic-checks" >§</a> [MOD-PERM-MSG-3-2-1] Set Permission VP to Validated basic checks</h6>
+<h6 id="mod-pp-msg-3-2-1-set-participant-op-to-validated-basic-checks"><a class="toc-anchor" href="#mod-pp-msg-3-2-1-set-participant-op-to-validated-basic-checks" >§</a> [MOD-PP-MSG-3-2-1] Set Participant OP to Validated basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
 <li><code>id</code> MUST be a valid uint64.</li>
-<li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>. If no entry found, abort.</li>
-<li>Load <code>Permission</code> entry <code>validator_perm</code> from <code>applicant_perm_validator_perm_id</code>.</li>
+<li>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>. If no entry found, abort.</li>
+<li>Load <code>Participant</code> entry <code>validator_participant</code> from <code>applicant_participant_validator_participant_id</code>.</li>
 <li>Authorization:</li>
 </ul>
 <p>either (executed by any operator of corporation):
-<a href="#authz-check-1-operator-authorization-checks" >[AUTHZ-CHECK-1]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) tuple and <code>SetPermissionVPtoValidated</code> message.
-<a href="#authz-check-2-fee-grant-checks" >[AUTHZ-CHECK-2]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) tuple and <code>SetPermissionVPtoValidated</code> message.
-OR (executed by vs-agent account defined in validator permission):
-<a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>validator_perm</code>) tuple.
-<a href="#authz-check-4-vs-operator-fee-grant-checks" >[AUTHZ-CHECK-4]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>validator_perm</code>) tuple.
+<a href="#authz-check-1-operator-authorization-checks" >[AUTHZ-CHECK-1]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) tuple and <code>SetParticipantOPtoValidated</code> message.
+<a href="#authz-check-2-fee-grant-checks" >[AUTHZ-CHECK-2]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) tuple and <code>SetParticipantOPtoValidated</code> message.
+OR (executed by vs-agent account defined in validator <code>Participant</code>):
+<a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>validator_participant</code>) tuple.
+<a href="#authz-check-4-vs-operator-fee-grant-checks" >[AUTHZ-CHECK-4]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>validator_participant</code>) tuple.
 else MUST abort.</p>
 <ul>
 <li>
-<p><code>applicant_perm.vp_state</code> MUST be equal to PENDING, else abort.</p>
+<p><code>applicant_participant.op_state</code> MUST be equal to PENDING, else abort.</p>
 </li>
 <li>
-<p><code>validation_fees</code> (number) (<em>mandatory</em>): MUST be zero or a positive integer. If <code>applicant_perm.effective_from</code> is not null (we are in renewal) <code>validation_fees</code> MUST be equal to <code>applicant_perm.validation_fees</code>, else abort.</p>
+<p><code>validation_fees</code> (number) (<em>mandatory</em>): MUST be zero or a positive integer. If <code>applicant_participant.effective_from</code> is not null (we are in renewal) <code>validation_fees</code> MUST be equal to <code>applicant_participant.validation_fees</code>, else abort.</p>
 </li>
 <li>
-<p><code>issuance_fees</code> (number) (<em>mandatory</em>): MUST be zero or a positive integer.  If <code>applicant_perm.effective_from</code> is not null (we are in renewal) <code>issuance_fees</code> MUST be equal to <code>applicant_perm.issuance_fees</code> or, else abort.</p>
+<p><code>issuance_fees</code> (number) (<em>mandatory</em>): MUST be zero or a positive integer.  If <code>applicant_participant.effective_from</code> is not null (we are in renewal) <code>issuance_fees</code> MUST be equal to <code>applicant_participant.issuance_fees</code> or, else abort.</p>
 </li>
 <li>
-<p><code>verification_fees</code> (number) (<em>mandatory</em>): MUST be zero or a positive integer.  If <code>applicant_perm.effective_from</code> is not null (we are in renewal) <code>verification_fees</code> MUST be equal to <code>applicant_perm.verification_fees</code>, else abort.</p>
+<p><code>verification_fees</code> (number) (<em>mandatory</em>): MUST be zero or a positive integer.  If <code>applicant_participant.effective_from</code> is not null (we are in renewal) <code>verification_fees</code> MUST be equal to <code>applicant_participant.verification_fees</code>, else abort.</p>
 </li>
 <li>
-<p><code>vp_summary_digest</code> (string) (<em>optional</em>): MUST be null if <code>validation.type</code> is set to HOLDER (for HOLDER, proofs can be stored in credentials). Else, MUST be a valid digest. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</p>
+<p><code>op_summary_digest</code> (string) (<em>optional</em>): MUST be a valid digest. Example: <code>sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26</code>.</p>
 </li>
 <li>
-<p>Load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_perm.schema_id</code>.</p>
+<p>Load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_participant.schema_id</code>.</p>
 </li>
 <li>
-<p>Load <code>Permission</code> <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>.</p>
+<p>Load <code>Participant</code> <code>validator_participant</code> from <code>applicant_participant.validator_participant_id</code>.</p>
 </li>
 <li>
 <p><code>issuance_fee_discount</code> : (number) (<em>mandatory</em>):</p>
 <ul>
-<li>if <code>applicant_perm.effective_from</code> is not null (renewal), then <code>issuance_fee_discount</code> must be equal to <code>applicant_perm.issuance_fee_discount</code> else MUST abort.</li>
-<li>if <code>cs.issuer_onboarding_mode</code> is set to GRANTOR_VALIDATION_PROCESS:
+<li>if <code>applicant_participant.effective_from</code> is not null (renewal), then <code>issuance_fee_discount</code> must be equal to <code>applicant_participant.issuance_fee_discount</code> else MUST abort.</li>
+<li>if <code>cs.issuer_onboarding_mode</code> is set to GRANTOR_ONBOARDING_PROCESS:
 <ul>
-<li>if <code>applicant_perm.type</code> == ISSUER_GRANTOR: <code>issuance_fee_discount</code> can be set between 0 (no discount) and 1 (100% discount) inclusive.</li>
-<li>if <code>applicant_perm.type</code> == ISSUER: if <code>validator_perm.issuance_fee_discount</code> is defined,  <code>issuance_fee_discount</code> can be set between 0 (no discount) and <code>validator_perm.issuance_fee_discount</code> (100% discount) inclusive.</li>
+<li>if <code>applicant_participant.role</code> == ISSUER_GRANTOR: <code>issuance_fee_discount</code> can be set between 0 (no discount) and 1 (100% discount) inclusive.</li>
+<li>if <code>applicant_participant.role</code> == ISSUER: if <code>validator_participant.issuance_fee_discount</code> is defined,  <code>issuance_fee_discount</code> can be set between 0 (no discount) and <code>validator_participant.issuance_fee_discount</code> (100% discount) inclusive.</li>
 </ul>
 </li>
-<li>if <code>cs.issuer_onboarding_mode</code> is set to ECOSYSTEM_VALIDATION_PROCESS:
+<li>if <code>cs.issuer_onboarding_mode</code> is set to ECOSYSTEM_ONBOARDING_PROCESS:
 <ul>
-<li>if <code>applicant_perm.type</code> == ISSUER: <code>issuance_fee_discount</code> can be set between 0 (no discount) and 1 (100% discount) inclusive.</li>
+<li>if <code>applicant_participant.role</code> == ISSUER: <code>issuance_fee_discount</code> can be set between 0 (no discount) and 1 (100% discount) inclusive.</li>
 </ul>
 </li>
 <li>else MUST abort.</li>
@@ -2977,90 +3435,90 @@ else MUST abort.</p>
 <li>
 <p><code>verification_fee_discount</code> : (number) (<em>mandatory</em>):</p>
 <ul>
-<li>if <code>applicant_perm.effective_from</code> is not null (renewal), then <code>verification_fee_discount</code> must be equal to <code>applicant_perm.verification_fee_discount</code> else MUST abort.</li>
-<li>if <code>cs.verifier_onboarding_mode</code> is set to GRANTOR_VALIDATION_PROCESS:
+<li>if <code>applicant_participant.effective_from</code> is not null (renewal), then <code>verification_fee_discount</code> must be equal to <code>applicant_participant.verification_fee_discount</code> else MUST abort.</li>
+<li>if <code>cs.verifier_onboarding_mode</code> is set to GRANTOR_ONBOARDING_PROCESS:
 <ul>
-<li>if <code>applicant_perm.type</code> == VERIFIER_GRANTOR: <code>verification_fee_discount</code> can be set between 0 (no discount) and 1 (100% discount) inclusive.</li>
-<li>if <code>applicant_perm.type</code> == VERIFIER: if <code>validator_perm.verification_fee_discount</code> is defined,  <code>verification_fee_discount</code> can be set between 0 (no discount) and <code>validator_perm.verification_fee_discount</code> (100% discount) inclusive.</li>
+<li>if <code>applicant_participant.role</code> == VERIFIER_GRANTOR: <code>verification_fee_discount</code> can be set between 0 (no discount) and 1 (100% discount) inclusive.</li>
+<li>if <code>applicant_participant.role</code> == VERIFIER: if <code>validator_participant.verification_fee_discount</code> is defined,  <code>verification_fee_discount</code> can be set between 0 (no discount) and <code>validator_participant.verification_fee_discount</code> (100% discount) inclusive.</li>
 </ul>
 </li>
-<li>if <code>cs.verifier_onboarding_mode</code> is set to ECOSYSTEM_VALIDATION_PROCESS:
+<li>if <code>cs.verifier_onboarding_mode</code> is set to ECOSYSTEM_ONBOARDING_PROCESS:
 <ul>
-<li>if <code>applicant_perm.type</code> == VERIFIER: <code>verification_fee_discount</code> can be set between 0 (no discount) and 1 (100% discount) inclusive.</li>
+<li>if <code>applicant_participant.role</code> == VERIFIER: <code>verification_fee_discount</code> can be set between 0 (no discount) and 1 (100% discount) inclusive.</li>
 </ul>
 </li>
 <li>else MUST abort.</li>
 </ul>
 </li>
 </ul>
-<p>Calculation of <code>vp_exp</code>, the validation process expiration timestamp, required to verify provided <code>effective_until</code>:</p>
+<p>Calculation of <code>op_exp</code>, the onboarding process expiration timestamp, required to verify provided <code>effective_until</code>:</p>
 <ul>
 <li>
-<p>let’s define <code>validity_period</code> = <code>cs.issuer_grantor_validation_validity_period</code> (if <code>applicant_perm.type</code> is ISSUER_GRANTOR), <code>cs.verifier_grantor_validation_validity_period</code> (if <code>applicant_perm.type</code> is VERIFIER_GRANTOR), <code>cs.issuer_validation_validity_period</code> (if <code>applicant_perm.type</code> is ISSUER), <code>cs.verifier_validation_validity_period</code> (if <code>applicant_perm.type</code> is VERIFIER), or <code>cs.holder_validation_validity_period</code> (if <code>applicant_perm.type</code> is HOLDER).</p>
+<p>let’s define <code>validity_period</code> = <code>cs.issuer_grantor_validation_validity_period</code> (if <code>applicant_participant.role</code> is ISSUER_GRANTOR), <code>cs.verifier_grantor_validation_validity_period</code> (if <code>applicant_participant.role</code> is VERIFIER_GRANTOR), <code>cs.issuer_validation_validity_period</code> (if <code>applicant_participant.role</code> is ISSUER), <code>cs.verifier_validation_validity_period</code> (if <code>applicant_participant.role</code> is VERIFIER), or <code>cs.holder_validation_validity_period</code> (if <code>applicant_participant.role</code> is HOLDER).</p>
 </li>
 <li>
-<p>if <code>validity_period</code> is NULL:  <code>vp_exp</code> = NULL.</p>
+<p>if <code>validity_period</code> is NULL:  <code>op_exp</code> = NULL.</p>
 </li>
 <li>
-<p>else if <code>applicant_perm.vp_exp</code> is null, <code>vp_exp</code> =  timestamp of now() plus <code>validity_period</code>.</p>
+<p>else if <code>applicant_participant.op_exp</code> is null, <code>op_exp</code> =  timestamp of now() plus <code>validity_period</code>.</p>
 </li>
 <li>
-<p>else <code>vp_exp</code> =  <code>applicant_perm.vp_exp</code> plus <code>validity_period</code></p>
+<p>else <code>op_exp</code> =  <code>applicant_participant.op_exp</code> plus <code>validity_period</code></p>
 </li>
 </ul>
 <p>Now, let’s verify <code>effective_until</code>:</p>
 <ul>
 <li>if <code>effective_until</code> is NULL, no issue.</li>
-<li>else if <code>applicant_perm.effective_until</code> is NULL, <code>effective_until</code> MUST be greater than current current timestamp AND, if <code>vp_exp</code> is not null, lower or equal to <code>vp_exp</code>.</li>
-<li>else <code>effective_until</code> MUST be greater than <code>applicant_perm.effective_until</code> AND, if <code>vp_exp</code> is not null, lower or equal to <code>vp_exp</code>.</li>
+<li>else if <code>applicant_participant.effective_until</code> is NULL, <code>effective_until</code> MUST be greater than current current timestamp AND, if <code>op_exp</code> is not null, lower or equal to <code>op_exp</code>.</li>
+<li>else <code>effective_until</code> MUST be greater than <code>applicant_participant.effective_until</code> AND, if <code>op_exp</code> is not null, lower or equal to <code>op_exp</code>.</li>
 </ul>
-<h6 id="mod-perm-msg-3-2-2-set-permission-vp-to-validated-validator-perms"><a class="toc-anchor" href="#mod-perm-msg-3-2-2-set-permission-vp-to-validated-validator-perms" >§</a> [MOD-PERM-MSG-3-2-2] Set Permission VP to Validated validator perms</h6>
+<h6 id="mod-pp-msg-3-2-2-set-participant-op-to-validated-validator-perms"><a class="toc-anchor" href="#mod-pp-msg-3-2-2-set-participant-op-to-validated-validator-perms" >§</a> [MOD-PP-MSG-3-2-2] Set Participant OP to Validated validator perms</h6>
 <ul>
-<li>load <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>. <code>validator_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a>.</li>
-<li><code>corporation</code> running the method MUST be <code>validator_perm.corporation</code>.</li>
+<li>load <code>validator_participant</code> from <code>applicant_participant.validator_participant_id</code>. <code>validator_participant</code> MUST be a <a class="term-reference" href="#term:active-participant">active participant</a>.</li>
+<li><code>corporation</code> running the method MUST be <code>validator_participant.corporation</code>.</li>
 </ul>
-<p>If <code>validator_perm</code> is not a <a class="term-reference" href="#term:active-permission">active permission</a> (expired, revoked, slashed…) then applicant MUST start a new validation process.</p>
-<h6 id="mod-perm-msg-3-2-3-set-permission-vp-to-validated-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-3-2-3-set-permission-vp-to-validated-fee-checks" >§</a> [MOD-PERM-MSG-3-2-3] Set Permission VP to Validated fee checks</h6>
+<p>If <code>validator_participant</code> is not a <a class="term-reference" href="#term:active-participant">active participant</a> (expired, revoked, slashed…) then applicant MUST start a new onboarding process.</p>
+<h6 id="mod-pp-msg-3-2-3-set-participant-op-to-validated-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-3-2-3-set-participant-op-to-validated-fee-checks" >§</a> [MOD-PP-MSG-3-2-3] Set Participant OP to Validated fee checks</h6>
 <ul>
 <li>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</li>
-<li>if <code>applicant_perm.vp_current_fees</code> is not in <a class="term-reference" href="#term:native-denom">native denom</a>, <code>corporation</code> account MUST have <code>applicant_perm.vp_current_deposit</code> available in <a class="term-reference" href="#term:native-denom">native denom</a> on its account for paying the trust deposit.</li>
+<li>if <code>applicant_participant.op_current_fees</code> is not in <a class="term-reference" href="#term:native-denom">native denom</a>, <code>corporation</code> account MUST have <code>applicant_participant.op_current_deposit</code> available in <a class="term-reference" href="#term:native-denom">native denom</a> on its account for paying the trust deposit.</li>
 </ul>
-<h6 id="mod-perm-msg-3-2-4-set-permission-vp-to-validated-overlap-checks"><a class="toc-anchor" href="#mod-perm-msg-3-2-4-set-permission-vp-to-validated-overlap-checks" >§</a> [MOD-PERM-MSG-3-2-4] Set Permission VP to Validated overlap checks</h6>
-<p>We want to make sure that 2 permissions cannot be active at the same time for the same <code>validator_perm_id</code>. That should not occur in this method, but better do the check anyway.</p>
-<p>Find all <a class="term-reference" href="#term:active-permissions">active permissions</a> <code>perms[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, <code>type</code>, <code>validator_perm_id</code>, <code>corporation</code>.</p>
-<p>for each <code>Permission</code> entry <code>p</code> from <code>perms[]</code>:</p>
+<h6 id="mod-pp-msg-3-2-4-set-participant-op-to-validated-overlap-checks"><a class="toc-anchor" href="#mod-pp-msg-3-2-4-set-participant-op-to-validated-overlap-checks" >§</a> [MOD-PP-MSG-3-2-4] Set Participant OP to Validated overlap checks</h6>
+<p>We want to make sure that 2 <code>Participant</code> entries cannot be active at the same time for the same <code>validator_participant_id</code>. That should not occur in this method, but better do the check anyway.</p>
+<p>Find all <a class="term-reference" href="#term:active-participants">active participants</a> <code>participants[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, <code>role</code>, <code>validator_participant_id</code>, <code>corporation</code>.</p>
+<p>for each <code>Participant</code> entry <code>p</code> from <code>participants[]</code>:</p>
 <ul>
 <li>if <code>p.effective_until</code> is greater than <code>effective_from</code>, method execution MUST abort.</li>
 <li>if <code>p.effective_from</code> is lower than <code>effective_until</code>, method execution MUST abort.</li>
-<li>if <code>p.effective_until</code> is NULL (never expire), creation of a new permission doesn’t make any sense and method execution MUST abort.</li>
+<li>if <code>p.effective_until</code> is NULL (never expire), creation of a new <code>Participant</code> entry doesn’t make any sense and method execution MUST abort.</li>
 </ul>
 <blockquote>
 <p>note: this check was not present in v3.</p>
 </blockquote>
-<h5 id="mod-perm-msg-3-3-set-permission-vp-to-validated-execution"><a class="toc-anchor" href="#mod-perm-msg-3-3-set-permission-vp-to-validated-execution" >§</a> [MOD-PERM-MSG-3-3] Set Permission VP to Validated execution</h5>
+<h5 id="mod-pp-msg-3-3-set-participant-op-to-validated-execution"><a class="toc-anchor" href="#mod-pp-msg-3-3-set-participant-op-to-validated-execution" >§</a> [MOD-PP-MSG-3-3] Set Participant OP to Validated execution</h5>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
-<li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>.</li>
-<li>Load <code>Permission</code> entry <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>.</li>
+<li>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>.</li>
+<li>Load <code>Participant</code> entry <code>validator_participant</code> from <code>applicant_participant.validator_participant_id</code>.</li>
 <li>define <code>now</code> timestamp of now().</li>
 </ul>
-<p>Calculate <code>vp_exp</code>:</p>
+<p>Calculate <code>op_exp</code>:</p>
 <ul>
 <li>
-<p>Load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_perm.schema_id</code>.</p>
+<p>Load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_participant.schema_id</code>.</p>
 </li>
 <li>
-<p>let’s define <code>validity_period</code> = <code>cs.issuer_grantor_validation_validity_period</code> (if <code>applicant_perm.type</code> is ISSUER_GRANTOR), <code>cs.verifier_grantor_validation_validity_period</code> (if <code>applicant_perm.type</code> is VERIFIER_GRANTOR), <code>cs.issuer_validation_validity_period</code> (if <code>applicant_perm.type</code> is ISSUER), <code>cs.verifier_validation_validity_period</code> (if <code>applicant_perm.type</code> is VERIFIER), or <code>cs.holder_validation_validity_period</code> (if <code>applicant_perm.type</code> is HOLDER).</p>
+<p>let’s define <code>validity_period</code> = <code>cs.issuer_grantor_validation_validity_period</code> (if <code>applicant_participant.role</code> is ISSUER_GRANTOR), <code>cs.verifier_grantor_validation_validity_period</code> (if <code>applicant_participant.role</code> is VERIFIER_GRANTOR), <code>cs.issuer_validation_validity_period</code> (if <code>applicant_participant.role</code> is ISSUER), <code>cs.verifier_validation_validity_period</code> (if <code>applicant_participant.role</code> is VERIFIER), or <code>cs.holder_validation_validity_period</code> (if <code>applicant_participant.role</code> is HOLDER).</p>
 </li>
 <li>
-<p>if <code>validity_period</code> is NULL:  <code>vp_exp</code> = NULL.</p>
+<p>if <code>validity_period</code> is NULL:  <code>op_exp</code> = NULL.</p>
 </li>
 <li>
-<p>else if <code>applicant_perm.vp_exp</code> is null, <code>vp_exp</code> =  timestamp of now() plus <code>validity_period</code>.</p>
+<p>else if <code>applicant_participant.op_exp</code> is null, <code>op_exp</code> =  timestamp of now() plus <code>validity_period</code>.</p>
 </li>
 <li>
-<p>else <code>vp_exp</code> =  <code>applicant_perm.vp_exp</code> plus <code>validity_period</code>.</p>
+<p>else <code>op_exp</code> =  <code>applicant_participant.op_exp</code> plus <code>validity_period</code>.</p>
 </li>
 </ul>
 <p>Change value of provided <code>effective_until</code> if needed, and abort if needed:</p>
@@ -3068,164 +3526,164 @@ else MUST abort.</p>
 <li>
 <p>if provided  <code>effective_until</code> is NULL:</p>
 <ul>
-<li>change value of provided <code>effective_until</code> to <code>vp_exp</code>.</li>
+<li>change value of provided <code>effective_until</code> to <code>op_exp</code>.</li>
 </ul>
 </li>
 <li>
-<p>else if <code>applicant_perm.effective_until</code> is NULL:</p>
+<p>else if <code>applicant_participant.effective_until</code> is NULL:</p>
 <ul>
 <li>verify that provided <code>effective_until</code> is greater than <code>now</code> else MUST abort</li>
-<li>if <code>vp_exp</code> is not null, verify that provided <code>effective_until</code> is lower or equal to <code>vp_exp</code> else MUST abort</li>
+<li>if <code>op_exp</code> is not null, verify that provided <code>effective_until</code> is lower or equal to <code>op_exp</code> else MUST abort</li>
 </ul>
 </li>
 <li>
 <p>else:</p>
 <ul>
-<li><code>effective_until</code> MUST be greater than <code>applicant_perm.effective_until</code> else MUST abort</li>
-<li>if <code>vp_exp</code> is not null, verify that provided <code>effective_until</code> is lower or equal to <code>vp_exp</code> else MUST abort.</li>
+<li><code>effective_until</code> MUST be greater than <code>applicant_participant.effective_until</code> else MUST abort</li>
+<li>if <code>op_exp</code> is not null, verify that provided <code>effective_until</code> is lower or equal to <code>op_exp</code> else MUST abort.</li>
 </ul>
 </li>
 </ul>
 <p>Fees and Trust Deposits:</p>
 <ul>
-<li>transfer the full amount <code>applicant_perm.vp_current_fees</code> in the proper <a class="term-reference" href="#term:denom">denom</a> from escrow <a class="term-reference" href="#term:account">account</a> to validator <code>corporation</code> <a class="term-reference" href="#term:account">account</a> <code>validator_perm.corporation</code>;</li>
-<li>Increase validator perm trust deposit: use [MOD-TD-MSG-1] to increase by <code>applicant_perm.vp_current_deposit</code> the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>corporation</code> running the method and transfer the corresponding amount to <code>TrustDeposit</code> module. Set <code>applicant_perm.vp_validator_deposit</code> to <code>applicant_perm.vp_validator_deposit</code> + <code>applicant_perm.vp_current_deposit</code>.</li>
+<li>transfer the full amount <code>applicant_participant.op_current_fees</code> in the proper <a class="term-reference" href="#term:denom">denom</a> from escrow <a class="term-reference" href="#term:account">account</a> to validator <code>corporation</code> <a class="term-reference" href="#term:account">account</a> <code>validator_participant.corporation</code>;</li>
+<li>Increase validator perm trust deposit: use [MOD-TD-MSG-1] to increase by <code>applicant_participant.op_current_deposit</code> the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>corporation</code> running the method and transfer the corresponding amount to <code>TrustDeposit</code> module. Set <code>applicant_participant.op_validator_deposit</code> to <code>applicant_participant.op_validator_deposit</code> + <code>applicant_participant.op_current_deposit</code>.</li>
 </ul>
 <blockquote>
-<p>Important: if <code>applicant_perm.vp_current_fees</code> is not in <a class="term-reference" href="#term:native-denom">native denom</a>, <code>corporation</code> account MUST have <code>applicant_perm.vp_current_deposit</code> available for paying the trust deposit.</p>
+<p>Important: if <code>applicant_participant.op_current_fees</code> is not in <a class="term-reference" href="#term:native-denom">native denom</a>, <code>corporation</code> account MUST have <code>applicant_participant.op_current_deposit</code> available for paying the trust deposit.</p>
 </blockquote>
-<p>Update <code>Permission</code> <code>applicant_perm</code>:</p>
+<p>Update <code>Participant</code> <code>applicant_participant</code>:</p>
 <ul>
-<li>set <code>applicant_perm.modified</code> to <code>now</code>.</li>
-<li>set <code>applicant_perm.vp_state</code> to VALIDATED.</li>
-<li>set <code>applicant_perm.vp_last_state_change</code> to <code>now</code>.</li>
-<li>set <code>applicant_perm.vp_current_fees</code> to 0;</li>
-<li>set <code>applicant_perm.vp_current_deposit</code> to 0;</li>
-<li>set <code>applicant_perm.vp_summary_digest</code> to <code>vp_summary_digest</code>.</li>
-<li>set <code>applicant_perm.vp_exp</code> to <code>vp_exp</code>.</li>
-<li>set <code>applicant_perm.effective_until</code> to <code>effective_until</code>.</li>
-<li>if <code>applicant_perm.effective_from</code> IS NULL (first time method is called for this perm, and thus we are not in a renewal):
+<li>set <code>applicant_participant.modified</code> to <code>now</code>.</li>
+<li>set <code>applicant_participant.op_state</code> to VALIDATED.</li>
+<li>set <code>applicant_participant.op_last_state_change</code> to <code>now</code>.</li>
+<li>set <code>applicant_participant.op_current_fees</code> to 0;</li>
+<li>set <code>applicant_participant.op_current_deposit</code> to 0;</li>
+<li>set <code>applicant_participant.op_summary_digest</code> to <code>op_summary_digest</code>.</li>
+<li>set <code>applicant_participant.op_exp</code> to <code>op_exp</code>.</li>
+<li>set <code>applicant_participant.effective_until</code> to <code>effective_until</code>.</li>
+<li>if <code>applicant_participant.effective_from</code> IS NULL (first time method is called for this perm, and thus we are not in a renewal):
 <ul>
-<li>set <code>applicant_perm.validation_fees</code> to <code>validation_fees</code>;</li>
-<li>set <code>applicant_perm.issuance_fees</code> to <code>issuance_fees</code>;</li>
-<li>set <code>applicant_perm.verification_fees</code> to <code>verification_fees</code>;</li>
-<li>set <code>applicant_perm.effective_from</code> to <code>now</code>.</li>
-<li>set <code>applicant_perm.issuance_fee_discount</code> to <code>issuance_fee_discount</code>.</li>
-<li>set <code>applicant_perm.verification_fee_discount</code> to <code>verification_fee_discount</code>.</li>
+<li>set <code>applicant_participant.validation_fees</code> to <code>validation_fees</code>;</li>
+<li>set <code>applicant_participant.issuance_fees</code> to <code>issuance_fees</code>;</li>
+<li>set <code>applicant_participant.verification_fees</code> to <code>verification_fees</code>;</li>
+<li>set <code>applicant_participant.effective_from</code> to <code>now</code>.</li>
+<li>set <code>applicant_participant.issuance_fee_discount</code> to <code>issuance_fee_discount</code>.</li>
+<li>set <code>applicant_participant.verification_fee_discount</code> to <code>verification_fee_discount</code>.</li>
 </ul>
 </li>
 </ul>
 <p>Activate VS Operator Authorization, if any. Call <a href="#mod-de-msg-9-update-vs-operator-authorization-expiration" >[MOD-DE-MSG-9]</a> Update VS Operator Authorization Expiration with:</p>
 <ul>
-<li><code>perm_id</code>: <code>applicant_perm.id</code></li>
-<li><code>new_expiration</code>: <code>applicant_perm.effective_until</code></li>
+<li><code>participant_id</code>: <code>applicant_participant.id</code></li>
+<li><code>new_expiration</code>: <code>applicant_participant.effective_until</code></li>
 </ul>
-<p>This call is a no-op if no record was created at <a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a> (i.e., the applicant did not declare <code>vs_operator_authz_msg_types</code>). If a record exists, its <code>expiration</code> is updated from <code>now</code> (disabled) to <code>applicant_perm.effective_until</code>, and the on-chain <code>FeeGrant</code> for the containing VSOA is granted for the first time (or refreshed) via <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a>.</p>
-<h4 id="mod-perm-msg-4-void"><a class="toc-anchor" href="#mod-perm-msg-4-void" >§</a> [MOD-PERM-MSG-4] Void</h4>
-<h4 id="mod-perm-msg-5-void"><a class="toc-anchor" href="#mod-perm-msg-5-void" >§</a> [MOD-PERM-MSG-5] Void</h4>
-<h4 id="mod-perm-msg-6-cancel-permission-vp-last-request"><a class="toc-anchor" href="#mod-perm-msg-6-cancel-permission-vp-last-request" >§</a> [MOD-PERM-MSG-6] Cancel Permission VP Last Request</h4>
+<p>This call is a no-op if no record was created at <a href="#mod-pp-msg-1-start-participant-op" >[MOD-PP-MSG-1]</a> (i.e., the applicant did not declare <code>vs_operator_authz_msg_types</code>). If a record exists, its <code>expiration</code> is updated from <code>now</code> (disabled) to <code>applicant_participant.effective_until</code>, and the on-chain <code>FeeGrant</code> for the containing VSOA is granted for the first time (or refreshed) via <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a>.</p>
+<h4 id="mod-pp-msg-4-void"><a class="toc-anchor" href="#mod-pp-msg-4-void" >§</a> [MOD-PP-MSG-4] Void</h4>
+<h4 id="mod-pp-msg-5-void"><a class="toc-anchor" href="#mod-pp-msg-5-void" >§</a> [MOD-PP-MSG-5] Void</h4>
+<h4 id="mod-pp-msg-6-cancel-participant-op-last-request"><a class="toc-anchor" href="#mod-pp-msg-6-cancel-participant-op-last-request" >§</a> [MOD-PP-MSG-6] Cancel Participant OP Last Request</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
-<p>At any time, <a class="term-reference" href="#term:applicant">applicant</a> of a permission validation process may request cancellation of the process, provided state is PENDING. Upon method execution, the pending validation is cancelled and escrewed <a class="term-reference" href="#term:trust-fees">trust fees</a> are refunded. If <code>vp_exp</code> is not null, <code>vp_state</code> is set back to VALIDATED, else <code>vp_state</code> is set to TERMINATED.</p>
-<h5 id="mod-perm-msg-6-1-cancel-permission-vp-last-request-parameters"><a class="toc-anchor" href="#mod-perm-msg-6-1-cancel-permission-vp-last-request-parameters" >§</a> [MOD-PERM-MSG-6-1] Cancel Permission VP Last Request parameters</h5>
+<p>At any time, <a class="term-reference" href="#term:applicant">applicant</a> of an onboarding process may request cancellation of the process, provided state is PENDING. Upon method execution, the pending validation is cancelled and escrewed <a class="term-reference" href="#term:trust-fees">trust fees</a> are refunded. If <code>op_exp</code> is not null, <code>op_state</code> is set back to VALIDATED, else <code>op_state</code> is set to TERMINATED.</p>
+<h5 id="mod-pp-msg-6-1-cancel-participant-op-last-request-parameters"><a class="toc-anchor" href="#mod-pp-msg-6-1-cancel-participant-op-last-request-parameters" >§</a> [MOD-PP-MSG-6-1] Cancel Participant OP Last Request parameters</h5>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): id of the <code>Permission</code> entry;</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): id of the <code>Participant</code> entry;</li>
 </ul>
-<h5 id="mod-perm-msg-6-2-cancel-permission-vp-last-request-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-6-2-cancel-permission-vp-last-request-precondition-checks" >§</a> [MOD-PERM-MSG-6-2] Cancel Permission VP Last Request precondition checks</h5>
+<h5 id="mod-pp-msg-6-2-cancel-participant-op-last-request-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-6-2-cancel-participant-op-last-request-precondition-checks" >§</a> [MOD-PP-MSG-6-2] Cancel Participant OP Last Request precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-6-2-1-cancel-permission-vp-last-request-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-6-2-1-cancel-permission-vp-last-request-basic-checks" >§</a> [MOD-PERM-MSG-6-2-1] Cancel Permission VP Last Request basic checks</h6>
+<h6 id="mod-pp-msg-6-2-1-cancel-participant-op-last-request-basic-checks"><a class="toc-anchor" href="#mod-pp-msg-6-2-1-cancel-participant-op-last-request-basic-checks" >§</a> [MOD-PP-MSG-6-2-1] Cancel Participant OP Last Request basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
 <li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>id</code> MUST be a valid uint64.</li>
-<li>Load <code>Permission</code> entry <code>applicant_perm</code> with this id. It MUST exist.</li>
-<li><code>corporation</code> running the <a class="term-reference" href="#term:transaction">transaction</a> MUST be <code>applicant_perm.corporation</code>.</li>
-<li><code>applicant_perm.vp_state</code> MUST be PENDING.</li>
-<li>if <code>applicant_perm.deposit</code> has been slashed and not repaid, MUST abort</li>
+<li>Load <code>Participant</code> entry <code>applicant_participant</code> with this id. It MUST exist.</li>
+<li><code>corporation</code> running the <a class="term-reference" href="#term:transaction">transaction</a> MUST be <code>applicant_participant.corporation</code>.</li>
+<li><code>applicant_participant.op_state</code> MUST be PENDING.</li>
+<li>if <code>applicant_participant.deposit</code> has been slashed and not repaid, MUST abort</li>
 </ul>
-<h6 id="mod-perm-msg-6-2-2-cancel-permission-vp-last-request-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-6-2-2-cancel-permission-vp-last-request-fee-checks" >§</a> [MOD-PERM-MSG-6-2-2] Cancel Permission VP Last Request fee checks</h6>
+<h6 id="mod-pp-msg-6-2-2-cancel-participant-op-last-request-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-6-2-2-cancel-participant-op-last-request-fee-checks" >§</a> [MOD-PP-MSG-6-2-2] Cancel Participant OP Last Request fee checks</h6>
 <p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h5 id="mod-perm-msg-6-3-cancel-permission-vp-last-request-execution"><a class="toc-anchor" href="#mod-perm-msg-6-3-cancel-permission-vp-last-request-execution" >§</a> [MOD-PERM-MSG-6-3] Cancel Permission VP Last Request execution</h5>
+<h5 id="mod-pp-msg-6-3-cancel-participant-op-last-request-execution"><a class="toc-anchor" href="#mod-pp-msg-6-3-cancel-participant-op-last-request-execution" >§</a> [MOD-PP-MSG-6-3] Cancel Participant OP Last Request execution</h5>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>
-<p>Load <code>Permission</code> entry <code>applicant_perm</code> with <code>id</code>. It MUST exist.</p>
+<p>Load <code>Participant</code> entry <code>applicant_participant</code> with <code>id</code>. It MUST exist.</p>
 </li>
 <li>
 <p>define <code>now</code>: current timestamp.</p>
 </li>
 <li>
-<p>set <code>applicant_perm.modified</code> to <code>now</code>.</p>
+<p>set <code>applicant_participant.modified</code> to <code>now</code>.</p>
 </li>
 <li>
-<p>if <code>applicant_perm.vp_exp</code> is null (validation never completed), set <code>applicant_perm.vp_state</code> to TERMINATED, else set <code>applicant_perm.vp_state</code> to VALIDATED.</p>
+<p>if <code>applicant_participant.op_exp</code> is null (validation never completed), set <code>applicant_participant.op_state</code> to TERMINATED, else set <code>applicant_participant.op_state</code> to VALIDATED.</p>
 </li>
 <li>
-<p>set <code>applicant_perm.vp_last_state_change</code> to <code>now</code>.</p>
+<p>set <code>applicant_participant.op_last_state_change</code> to <code>now</code>.</p>
 </li>
 <li>
-<p>if <code>applicant_perm.vp_current_fees</code> &gt; 0:</p>
+<p>if <code>applicant_participant.op_current_fees</code> &gt; 0:</p>
 <ul>
-<li>transfer <code>applicant_perm.vp_current_fees</code> in proper <a class="term-reference" href="#term:denom">denom</a> back from escrow <a class="term-reference" href="#term:account">account</a> to <a class="term-reference" href="#term:applicant">applicant</a> <a class="term-reference" href="#term:account">account</a>, <code>applicant_perm.corporation</code>.</li>
-<li>set <code>applicant_perm.vp_current_fees</code> to 0;</li>
+<li>transfer <code>applicant_participant.op_current_fees</code> in proper <a class="term-reference" href="#term:denom">denom</a> back from escrow <a class="term-reference" href="#term:account">account</a> to <a class="term-reference" href="#term:applicant">applicant</a> <a class="term-reference" href="#term:account">account</a>, <code>applicant_participant.corporation</code>.</li>
+<li>set <code>applicant_participant.op_current_fees</code> to 0;</li>
 </ul>
 </li>
 <li>
-<p>if <code>applicant_perm.vp_current_deposit</code> &gt; 0:</p>
+<p>if <code>applicant_participant.op_current_deposit</code> &gt; 0:</p>
 <ul>
-<li>call [MOD-TD-MSG-1] to reduce trust deposit of <code>applicant_perm.corporation</code> by <code>applicant_perm.vp_current_deposit</code></li>
-<li>set <code>applicant_perm.vp_current_deposit</code> to 0.</li>
+<li>call [MOD-TD-MSG-1] to reduce trust deposit of <code>applicant_participant.corporation</code> by <code>applicant_participant.op_current_deposit</code></li>
+<li>set <code>applicant_participant.op_current_deposit</code> to 0.</li>
 </ul>
 </li>
 </ul>
-<p>If <code>applicant_perm.vp_state</code> was set to TERMINATED (i.e. <code>applicant_perm.vp_exp</code> was null so validation never completed), call <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a> Revoke VS Operator Authorization with <code>perm_id = applicant_perm.id</code> to remove any disabled authorization record created at <a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a>. The call is a no-op if no record exists. If <code>applicant_perm.vp_state</code> was set back to VALIDATED, no VSOA changes are needed (the existing record’s <code>expiration</code> remains at the value set by the previous successful validation).</p>
-<h4 id="mod-perm-msg-7-create-root-permission"><a class="toc-anchor" href="#mod-perm-msg-7-create-root-permission" >§</a> [MOD-PERM-MSG-7] Create Root Permission</h4>
+<p>If <code>applicant_participant.op_state</code> was set to TERMINATED (i.e. <code>applicant_participant.op_exp</code> was null so validation never completed), call <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a> Revoke VS Operator Authorization with <code>participant_id = applicant_participant.id</code> to remove any disabled authorization record created at <a href="#mod-pp-msg-1-start-participant-op" >[MOD-PP-MSG-1]</a>. The call is a no-op if no record exists. If <code>applicant_participant.op_state</code> was set back to VALIDATED, no VSOA changes are needed (the existing record’s <code>expiration</code> remains at the value set by the previous successful validation).</p>
+<h4 id="mod-pp-msg-7-create-root-participant"><a class="toc-anchor" href="#mod-pp-msg-7-create-root-participant" >§</a> [MOD-PP-MSG-7] Create Root Participant</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
-<p>This method is used by controller authorities of Trust Registries. When they create a Credential Schema, they need to create (a) permission(s) of type ECOSYSTEM so that other participants can run validation processes (if schema mode is ECOSYSTEM) or self create their permissions (schema mode set to OPEN).</p>
-<h5 id="mod-perm-msg-7-1-create-root-permission-parameters"><a class="toc-anchor" href="#mod-perm-msg-7-1-create-root-permission-parameters" >§</a> [MOD-PERM-MSG-7-1] Create Root Permission parameters</h5>
-<p>An <a class="term-reference" href="#term:account">account</a> that would like to create a <code>Permission</code> entry MUST call this method by specifying:</p>
+<p>This method is used by controller authorities of Ecosystems. When they create a Credential Schema, they need to create (a) <code>Participant</code> entry(ies) of role ECOSYSTEM so that other participants can run onboarding processes (if schema mode is ECOSYSTEM) or self create their <code>Participant</code> entries (schema mode set to OPEN).</p>
+<h5 id="mod-pp-msg-7-1-create-root-participant-parameters"><a class="toc-anchor" href="#mod-pp-msg-7-1-create-root-participant-parameters" >§</a> [MOD-PP-MSG-7-1] Create Root Participant parameters</h5>
+<p>An <a class="term-reference" href="#term:account">account</a> that would like to create a <code>Participant</code> entry MUST call this method by specifying:</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
 <li><code>schema_id</code> (uint64) (<em>mandatory</em>)</li>
-<li><code>vs_operator</code> (account) (<em>optional</em>): the account we want to authorize to act on behalf of <code>corporation</code> in the context of this permission. <strong>Required</strong> for payment delegation.</li>
+<li><code>vs_operator</code> (account) (<em>optional</em>): the account we want to authorize to act on behalf of <code>corporation</code> in the context of this <code>Participant</code> entry. <strong>Required</strong> for payment delegation.</li>
 <li><code>did</code> (string) (<em>mandatory</em>): <a class="term-reference" href="#term:did">DID</a> of the VS.</li>
 <li><code>effective_from</code> (timestamp) (<em>mandatory</em>): timestamp from when (exclusive) this Perm is effective. MUST be in the future.</li>
 <li><code>effective_until</code> (timestamp) (<em>optional</em>): timestamp until when (exclusive) this Perm is effective, null if it doesn’t expire. If not null, MUST be greater than <code>effective_from</code>.</li>
-<li><code>validation_fees</code> (number) (<em>mandatory</em>): price to pay by applicant to validator for running a validation process that uses this perm as validator, for a given validation period, in the denom specified in the credential schema. Default to 0. Note that setting validation fees for OPEN schemas has no effect and does not mean a validation process must take place. For enabling validation processes, at least one of the two issuer, verifier mode must be different than OPEN.</li>
+<li><code>validation_fees</code> (number) (<em>mandatory</em>): price to pay by applicant to validator for running an onboarding process that uses this perm as validator, for a given validation period, in the denom specified in the credential schema. Default to 0. Note that setting validation fees for OPEN schemas has no effect and does not mean an onboarding process must take place. For enabling onboarding processes, at least one of the two issuer, verifier mode must be different than OPEN.</li>
 <li><code>issuance_fees</code> (number) (<em>mandatory</em>): price to pay by the issuer of a credential of this schema to the grantee of this perm when a credential is issued, in the denom specified in the credential schema. Default to 0.</li>
 <li><code>verification_fees</code> (number) (<em>mandatory</em>): price to pay by the verifier of a credential of this schema to the grantee of this perm when a credential is verified, in the denom specified in the credential schema. Default to 0.</li>
 </ul>
-<p>The following VS Operator Authorization parameters are <strong>optional</strong> and collectively define the initial <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> for this permission. Presence of <code>vs_operator_authz_msg_types</code> is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is <strong>frozen at creation time</strong> and cannot be modified later; to change it, the permission MUST be revoked and re-created.</p>
+<p>The following VS Operator Authorization parameters are <strong>optional</strong> and collectively define the initial <a href="#participantauthorizationrecord" >ParticipantAuthorizationRecord</a> for this <code>Participant</code> entry. Presence of <code>vs_operator_authz_msg_types</code> is the trigger: if it is not provided, no authorization record is created and the <code>Participant</code> entry operates in manual mode. VSOA configuration is <strong>frozen at creation time</strong> and cannot be modified later; to change it, the <code>Participant</code> entry MUST be revoked and re-created.</p>
 <ul>
-<li><code>vs_operator_authz_msg_types[]</code> (msg_type[]) (<em>optional</em>): list of VPR delegable message types <code>vs_operator</code> is authorized to execute on behalf of <code>corporation</code> in the context of this permission. If provided, a <code>PermissionAuthorizationRecord</code> is created (see execution below) and <code>vs_operator</code> MUST be specified. The permitted list of message types is provided below.</li>
-<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds <code>vs_operator</code> is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.</li>
-<li><code>vs_operator_authz_with_feegrant</code> (bool) (<em>optional</em>, default: false): if true, <code>corporation</code> pays transaction fees for <code>vs_operator</code> via an on-chain <code>FeeGrant</code> when executing authorized messages in the context of this permission.</li>
-<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of transaction fees that can be spent by <code>vs_operator</code> (paid by <code>corporation</code> via fee grant) in the context of this permission.</li>
-<li><code>vs_operator_authz_period</code> (duration) (<em>optional</em>): reset period for <code>vs_operator_authz_spend_limit</code> and <code>vs_operator_authz_fee_spend_limit</code> in the context of this permission.</li>
+<li><code>vs_operator_authz_msg_types[]</code> (msg_type[]) (<em>optional</em>): list of VPR delegable message types <code>vs_operator</code> is authorized to execute on behalf of <code>corporation</code> in the context of this <code>Participant</code> entry. If provided, a <code>ParticipantAuthorizationRecord</code> is created (see execution below) and <code>vs_operator</code> MUST be specified. The permitted list of message types is provided below.</li>
+<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds <code>vs_operator</code> is allowed to spend in the context of this <code>Participant</code> entry as a direct consequence of executing authorized messages.</li>
+<li><code>vs_operator_authz_with_feegrant</code> (bool) (<em>optional</em>, default: false): if true, <code>corporation</code> pays transaction fees for <code>vs_operator</code> via an on-chain <code>FeeGrant</code> when executing authorized messages in the context of this <code>Participant</code> entry.</li>
+<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of transaction fees that can be spent by <code>vs_operator</code> (paid by <code>corporation</code> via fee grant) in the context of this <code>Participant</code> entry.</li>
+<li><code>vs_operator_authz_period</code> (duration) (<em>optional</em>): reset period for <code>vs_operator_authz_spend_limit</code> and <code>vs_operator_authz_fee_spend_limit</code> in the context of this <code>Participant</code> entry.</li>
 </ul>
-<p>Permitted message types to be set in <code>vs_operator_authz_msg_types</code> depends on <code>type</code>. Since <a href="#mod-perm-msg-7-create-root-permission" >Create Root Permission</a> always creates an ECOSYSTEM permission, only the following is allowed:</p>
+<p>Permitted message types to be set in <code>vs_operator_authz_msg_types</code> depends on <code>role</code>. Since <a href="#mod-pp-msg-7-create-root-participant" >Create Root Participant</a> always creates an ECOSYSTEM <code>Participant</code> entry, only the following is allowed:</p>
 <table>
 <thead>
 <tr>
-<th>Permission type</th>
+<th>Participant role</th>
 <th>Permitted Messages</th>
 </tr>
 </thead>
 <tbody>
 <tr>
 <td>ECOSYSTEM</td>
-<td>SetPermissionVPtoValidated</td>
+<td>SetParticipantOPtoValidated</td>
 </tr>
 </tbody>
 </table>
-<h5 id="mod-perm-msg-7-2-create-root-permission-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-7-2-create-root-permission-precondition-checks" >§</a> [MOD-PERM-MSG-7-2] Create Root Permission precondition checks</h5>
+<h5 id="mod-pp-msg-7-2-create-root-participant-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-7-2-create-root-participant-precondition-checks" >§</a> [MOD-PP-MSG-7-2] Create Root Participant precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-7-2-1-create-root-permission-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-7-2-1-create-root-permission-basic-checks" >§</a> [MOD-PERM-MSG-7-2-1] Create Root Permission basic checks</h6>
+<h6 id="mod-pp-msg-7-2-1-create-root-participant-basic-checks"><a class="toc-anchor" href="#mod-pp-msg-7-2-1-create-root-participant-basic-checks" >§</a> [MOD-PP-MSG-7-2-1] Create Root Participant basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
@@ -3238,142 +3696,142 @@ else MUST abort.</p>
 <li><code>validation_fees</code> (number) (<em>mandatory</em>): MUST be &gt;= 0.</li>
 <li><code>issuance_fees</code> (number) (<em>mandatory</em>): MUST be &gt;= 0.</li>
 <li><code>verification_fees</code> (number) (<em>mandatory</em>): MUST be &gt;= 0.</li>
-<li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-perm-msg-7-1-create-root-permission-parameters" >MOD-PERM-MSG-7-1</a>.</li>
+<li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-pp-msg-7-1-create-root-participant-parameters" >MOD-PP-MSG-7-1</a>.</li>
 </ul>
-<h6 id="mod-perm-msg-7-2-2-create-root-permission-permission-checks"><a class="toc-anchor" href="#mod-perm-msg-7-2-2-create-root-permission-permission-checks" >§</a> [MOD-PERM-MSG-7-2-2] Create Root Permission permission checks</h6>
+<h6 id="mod-pp-msg-7-2-2-create-root-participant-permission-checks"><a class="toc-anchor" href="#mod-pp-msg-7-2-2-create-root-participant-permission-checks" >§</a> [MOD-PP-MSG-7-2-2] Create Root Participant permission checks</h6>
 <p>To execute this method, <a class="term-reference" href="#term:account">account</a> MUST match at least one these rules, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li>The related <code>CredentialSchema</code> entry is loaded with <code>schema_id</code>, and will be named <code>cs</code> in this section.</li>
-<li>The related <code>TrustRegistry</code> entry <code>tr</code> is loaded from <code>cs.tr_id</code>.</li>
-<li><code>corporation</code> executing the method MUST be <code>tr.corporation</code>.</li>
+<li>The related <code>Ecosystem</code> entry <code>tr</code> is loaded from <code>cs.ecosystem_id</code>.</li>
+<li><code>corporation</code> executing the method MUST be <code>ecosystem.corporation</code>.</li>
 <li>else MUST abort.</li>
 </ul>
-<h6 id="mod-perm-msg-7-2-3-create-root-permission-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-7-2-3-create-root-permission-fee-checks" >§</a> [MOD-PERM-MSG-7-2-3] Create Root Permission fee checks</h6>
+<h6 id="mod-pp-msg-7-2-3-create-root-participant-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-7-2-3-create-root-participant-fee-checks" >§</a> [MOD-PP-MSG-7-2-3] Create Root Participant fee checks</h6>
 <p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> available.</p>
-<h6 id="mod-perm-msg-7-2-4-create-root-permission-overlap-checks"><a class="toc-anchor" href="#mod-perm-msg-7-2-4-create-root-permission-overlap-checks" >§</a> [MOD-PERM-MSG-7-2-4] Create Root Permission overlap checks</h6>
-<p>We want to make sure that 2 permissions cannot be active at the same time. If <code>corporation</code> wishes to create a new permission but existing active one never expires (or expire too far from now), <code>corporation</code> MUST use first the <a href="#mod-perm-msg-8-adjust-permission" >Extend Perm Msg</a> to set or adjust the <code>effective_until</code> value.</p>
-<p>Find all <a class="term-reference" href="#term:active-permissions">active permissions</a> <code>perms[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, ECOSYSTEM,  <code>corporation</code>.</p>
+<h6 id="mod-pp-msg-7-2-4-create-root-participant-overlap-checks"><a class="toc-anchor" href="#mod-pp-msg-7-2-4-create-root-participant-overlap-checks" >§</a> [MOD-PP-MSG-7-2-4] Create Root Participant overlap checks</h6>
+<p>We want to make sure that 2 <code>Participant</code> entries cannot be active at the same time. If <code>corporation</code> wishes to create a new <code>Participant</code> entry but the existing one never expires (or expires too far from now), <code>corporation</code> MUST use first the <a href="#mod-pp-msg-8-set-participant-effective-until" >Set Participant Effective Until</a> to set or adjust the <code>effective_until</code> value.</p>
+<p>Find all <a class="term-reference" href="#term:active-participants">active participants</a> <code>participants[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, ECOSYSTEM,  <code>corporation</code>.</p>
 <blockquote>
-<p>Note: unlike overlap checks from other methods, here we do not need to check for <code>validator_perm_id</code>, as for ECOSYSTEM type permissions it is NULL.</p>
+<p>Note: unlike overlap checks from other methods, here we do not need to check for <code>validator_participant_id</code>, as for ECOSYSTEM-role <code>Participant</code> entries it is NULL.</p>
 </blockquote>
-<p>for each <code>Permission</code> entry <code>p</code> from <code>perms[]</code>:</p>
+<p>for each <code>Participant</code> entry <code>p</code> from <code>participants[]</code>:</p>
 <ul>
 <li>if <code>p.effective_until</code> is greater than <code>effective_from</code>, method execution MUST abort.</li>
 <li>if <code>p.effective_from</code> is lower than <code>effective_until</code>, method execution MUST abort.</li>
-<li>if <code>p.effective_until</code> is NULL (never expire), creation of a new permission doesn’t make any sense and method execution MUST abort.</li>
+<li>if <code>p.effective_until</code> is NULL (never expire), creation of a new <code>Participant</code> entry doesn’t make any sense and method execution MUST abort.</li>
 </ul>
 <blockquote>
 <p>note: this check was not present in v3.</p>
 </blockquote>
-<h5 id="mod-perm-msg-7-3-create-root-permission-execution"><a class="toc-anchor" href="#mod-perm-msg-7-3-create-root-permission-execution" >§</a> [MOD-PERM-MSG-7-3] Create Root Permission execution</h5>
+<h5 id="mod-pp-msg-7-3-create-root-participant-execution"><a class="toc-anchor" href="#mod-pp-msg-7-3-create-root-participant-execution" >§</a> [MOD-PP-MSG-7-3] Create Root Participant execution</h5>
 <p>If all precondition checks passed, method is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>define <code>now</code>: current timestamp.</li>
 </ul>
-<p>A new entry <code>Permission</code> <code>perm</code> MUST be created:</p>
+<p>A new entry <code>Participant</code> <code>perm</code> MUST be created:</p>
 <ul>
-<li><code>perm.id</code>: auto-incremented uint64.</li>
-<li><code>perm.schema_id</code>: <code>schema_id</code>.</li>
-<li><code>perm.modified</code> to <code>now</code>.</li>
-<li><code>perm.type</code>: ECOSYSTEM.</li>
-<li><code>perm.did</code>: <code>did</code>.</li>
-<li><code>perm.corporation</code>: <code>corporation</code>.</li>
-<li><code>perm.vs_operator</code>: <code>vs_operator</code>.</li>
-<li><code>perm.created</code>: <code>now</code></li>
-<li><code>perm.effective_from</code>: <code>effective_from</code></li>
-<li><code>perm.effective_until</code>: <code>effective_until</code></li>
-<li><code>perm.validation_fees</code>: <code>validation_fees</code></li>
-<li><code>perm.issuance_fees</code>: <code>issuance_fees</code></li>
-<li><code>perm.verification_fees</code>: <code>verification_fees</code></li>
-<li><code>perm.deposit</code>: 0</li>
+<li><code>participant.id</code>: auto-incremented uint64.</li>
+<li><code>participant.schema_id</code>: <code>schema_id</code>.</li>
+<li><code>participant.modified</code> to <code>now</code>.</li>
+<li><code>participant.role</code>: ECOSYSTEM.</li>
+<li><code>participant.did</code>: <code>did</code>.</li>
+<li><code>participant.corporation</code>: <code>corporation</code>.</li>
+<li><code>participant.vs_operator</code>: <code>vs_operator</code>.</li>
+<li><code>participant.created</code>: <code>now</code></li>
+<li><code>participant.effective_from</code>: <code>effective_from</code></li>
+<li><code>participant.effective_until</code>: <code>effective_until</code></li>
+<li><code>participant.validation_fees</code>: <code>validation_fees</code></li>
+<li><code>participant.issuance_fees</code>: <code>issuance_fees</code></li>
+<li><code>participant.verification_fees</code>: <code>verification_fees</code></li>
+<li><code>participant.deposit</code>: 0</li>
 </ul>
-<p>If <code>vs_operator_authz_msg_types</code> is provided, create the <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> in <strong>active</strong> state by calling <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a> Grant VS Operator Authorization with:</p>
+<p>If <code>vs_operator_authz_msg_types</code> is provided, create the <a href="#participantauthorizationrecord" >ParticipantAuthorizationRecord</a> in <strong>active</strong> state by calling <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a> Grant VS Operator Authorization with:</p>
 <ul>
 <li><code>corporation</code>: <code>corporation</code></li>
 <li><code>vs_operator</code>: <code>vs_operator</code></li>
 <li><code>record</code>:
 <ul>
-<li><code>record.perm_id</code>: <code>perm.id</code></li>
+<li><code>record.participant_id</code>: <code>participant.id</code></li>
 <li><code>record.msg_types</code>: <code>vs_operator_authz_msg_types</code></li>
 <li><code>record.spend_limit</code>: <code>vs_operator_authz_spend_limit</code></li>
 <li><code>record.fee_spend_limit</code>: <code>vs_operator_authz_fee_spend_limit</code></li>
 <li><code>record.with_feegrant</code>: <code>vs_operator_authz_with_feegrant</code> (default: false)</li>
-<li><code>record.expiration</code>: <code>perm.effective_until</code></li>
+<li><code>record.expiration</code>: <code>participant.effective_until</code></li>
 <li><code>record.period</code>: <code>vs_operator_authz_period</code></li>
 </ul>
 </li>
 </ul>
 <blockquote>
-<p>Note: like <a href="#mod-perm-msg-14-self-create-permission" >[MOD-PERM-MSG-14]</a>, the record is created with <code>expiration = perm.effective_until</code> and is therefore immediately active. If <code>with_feegrant</code> is true and <code>perm.effective_until &gt; now</code>, <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a> grants the on-chain <code>FeeGrant</code> as part of this execution.</p>
+<p>Note: like <a href="#mod-pp-msg-14-self-create-participant" >[MOD-PP-MSG-14]</a>, the record is created with <code>expiration = participant.effective_until</code> and is therefore immediately active. If <code>with_feegrant</code> is true and <code>participant.effective_until &gt; now</code>, <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a> grants the on-chain <code>FeeGrant</code> as part of this execution.</p>
 </blockquote>
-<h4 id="mod-perm-msg-8-adjust-permission"><a class="toc-anchor" href="#mod-perm-msg-8-adjust-permission" >§</a> [MOD-PERM-MSG-8] Adjust Permission</h4>
+<h4 id="mod-pp-msg-8-set-participant-effective-until"><a class="toc-anchor" href="#mod-pp-msg-8-set-participant-effective-until" >§</a> [MOD-PP-MSG-8] Set Participant Effective Until</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This method can be called:</p>
 <ul>
-<li>by <code>perm.corporation</code>, if permission is of type ECOSYSTEM.</li>
-<li>by <code>perm.corporation</code>, if it is a self-created permission (schema configuration is open)</li>
-<li>by a <code>corporation</code> of a validator permission (if permission is managed by a VP).</li>
+<li>by <code>participant.corporation</code>, if the <code>Participant</code> entry has role ECOSYSTEM.</li>
+<li>by <code>participant.corporation</code>, if it is a self-created <code>Participant</code> entry (schema configuration is open).</li>
+<li>by a <code>corporation</code> of a validator <code>Participant</code>, if the <code>Participant</code> entry is managed by an OP.</li>
 </ul>
-<h5 id="mod-perm-msg-8-1-adjust-permission-parameters"><a class="toc-anchor" href="#mod-perm-msg-8-1-adjust-permission-parameters" >§</a> [MOD-PERM-MSG-8-1] Adjust Permission parameters</h5>
+<h5 id="mod-pp-msg-8-1-set-participant-effective-until-parameters"><a class="toc-anchor" href="#mod-pp-msg-8-1-set-participant-effective-until-parameters" >§</a> [MOD-PP-MSG-8-1] Set Participant Effective Until parameters</h5>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): id of the permission;</li>
-<li><code>effective_until</code> (timestamp) (<em>mandatory</em>): timestamp until when (exclusive) this <code>Permission</code> will be effective.</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): id of the <code>Participant</code> entry;</li>
+<li><code>effective_until</code> (timestamp) (<em>mandatory</em>): timestamp until when (exclusive) this <code>Participant</code> will be effective.</li>
 </ul>
-<h5 id="mod-perm-msg-8-2-adjust-permission-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-8-2-adjust-permission-precondition-checks" >§</a> [MOD-PERM-MSG-8-2] Adjust Permission precondition checks</h5>
+<h5 id="mod-pp-msg-8-2-set-participant-effective-until-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-8-2-set-participant-effective-until-precondition-checks" >§</a> [MOD-PP-MSG-8-2] Set Participant Effective Until precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-8-2-1-adjust-permission-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-8-2-1-adjust-permission-basic-checks" >§</a> [MOD-PERM-MSG-8-2-1] Adjust Permission basic checks</h6>
+<h6 id="mod-pp-msg-8-2-1-set-participant-effective-until-basic-checks"><a class="toc-anchor" href="#mod-pp-msg-8-2-1-set-participant-effective-until-basic-checks" >§</a> [MOD-PP-MSG-8-2-1] Set Participant Effective Until basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
 <li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>id</code> MUST be a valid uint64.</li>
-<li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>. If no entry found, abort.</li>
-<li><code>applicant_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a></li>
-<li><code>applicant_perm.effective_until</code> MUST be greater than now().</li>
+<li>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>. If no entry found, abort.</li>
+<li><code>applicant_participant</code> MUST be a <a class="term-reference" href="#term:active-participant">active participant</a></li>
+<li><code>applicant_participant.effective_until</code> MUST be greater than now().</li>
 <li>else MUST abort.</li>
 </ul>
 <blockquote>
 <p>Note: This method can be used to both Extend or Reduce the <code>effective_until</code>, or set an <code>effective_until</code> if it was null,  which was not the case in spec v3.</p>
 </blockquote>
-<h6 id="mod-perm-msg-8-2-2-adjust-permission-advanced-checks"><a class="toc-anchor" href="#mod-perm-msg-8-2-2-adjust-permission-advanced-checks" >§</a> [MOD-PERM-MSG-8-2-2] Adjust Permission advanced checks</h6>
+<h6 id="mod-pp-msg-8-2-2-set-participant-effective-until-advanced-checks"><a class="toc-anchor" href="#mod-pp-msg-8-2-2-set-participant-effective-until-advanced-checks" >§</a> [MOD-PP-MSG-8-2-2] Set Participant Effective Until advanced checks</h6>
 <ol>
-<li>ECOSYSTEM permissions</li>
+<li>ECOSYSTEM <code>Participant</code> entries</li>
 </ol>
 <ul>
-<li>if <code>applicant_perm.validator_perm_id</code> is null and <code>applicant_perm.type</code> is ECOSYSTEM, <code>corporation</code> running the method MUST be <code>applicant_perm.corporation</code>.</li>
+<li>if <code>applicant_participant.validator_participant_id</code> is null and <code>applicant_participant.role</code> is ECOSYSTEM, <code>corporation</code> running the method MUST be <code>applicant_participant.corporation</code>.</li>
 </ul>
 <ol start="2">
-<li>Self-created permissions</li>
+<li>Self-created <code>Participant</code> entries</li>
 </ol>
 <ul>
-<li>load <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>. <code>validator_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a> of type ECOSYSTEM. <code>corporation</code> running the method MUST be <code>applicant_perm.corporation</code>.</li>
+<li>load <code>validator_participant</code> from <code>applicant_participant.validator_participant_id</code>. <code>validator_participant</code> MUST be a <a class="term-reference" href="#term:active-participant">active participant</a> of role ECOSYSTEM. <code>corporation</code> running the method MUST be <code>applicant_participant.corporation</code>.</li>
 </ul>
 <ol start="3">
-<li>VP managed permissions</li>
+<li>OP-managed <code>Participant</code> entries</li>
 </ol>
 <ul>
-<li><code>effective_until</code> MUST be lower or equal to <code>applicant_perm.vp_exp</code> else MUST abort.</li>
-<li>load <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>. <code>validator_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a>. <code>corporation</code> running the method MUST be <code>validator_perm.corporation</code>.</li>
+<li><code>effective_until</code> MUST be lower or equal to <code>applicant_participant.op_exp</code> else MUST abort.</li>
+<li>load <code>validator_participant</code> from <code>applicant_participant.validator_participant_id</code>. <code>validator_participant</code> MUST be a <a class="term-reference" href="#term:active-participant">active participant</a>. <code>corporation</code> running the method MUST be <code>validator_participant.corporation</code>.</li>
 </ul>
-<h6 id="mod-perm-msg-8-2-3-adjust-permission-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-8-2-3-adjust-permission-fee-checks" >§</a> [MOD-PERM-MSG-8-2-3] Adjust Permission fee checks</h6>
+<h6 id="mod-pp-msg-8-2-3-set-participant-effective-until-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-8-2-3-set-participant-effective-until-fee-checks" >§</a> [MOD-PP-MSG-8-2-3] Set Participant Effective Until fee checks</h6>
 <p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-8-2-4-adjust-permission-overlap-checks"><a class="toc-anchor" href="#mod-perm-msg-8-2-4-adjust-permission-overlap-checks" >§</a> [MOD-PERM-MSG-8-2-4] Adjust Permission overlap checks</h6>
-<p>We want to make sure that 2 permissions cannot be active at the same time for the same <code>validator_perm_id</code>. If <code>corporation</code> wishes to create a new permission but existing active one never expires (or expire too far from now), <code>corporation</code> MUST use first the <a href="#mod-perm-msg-8-adjust-permission" >Extend Perm Msg</a> to set or adjust the <code>effective_until</code> value.</p>
-<p>Find all <a class="term-reference" href="#term:active-permissions">active permissions</a> <code>perms[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, <code>type</code>, <code>validator_perm_id</code>, <code>corporation</code>.</p>
-<p>for each <code>Permission</code> entry <code>p</code> from <code>perms[]</code>:</p>
+<h6 id="mod-pp-msg-8-2-4-set-participant-effective-until-overlap-checks"><a class="toc-anchor" href="#mod-pp-msg-8-2-4-set-participant-effective-until-overlap-checks" >§</a> [MOD-PP-MSG-8-2-4] Set Participant Effective Until overlap checks</h6>
+<p>We want to make sure that 2 <code>Participant</code> entries cannot be active at the same time for the same <code>validator_participant_id</code>. If <code>corporation</code> wishes to create a new <code>Participant</code> entry but the existing one never expires (or expires too far from now), <code>corporation</code> MUST use first the <a href="#mod-pp-msg-8-set-participant-effective-until" >Set Participant Effective Until</a> to set or adjust the <code>effective_until</code> value.</p>
+<p>Find all <a class="term-reference" href="#term:active-participants">active participants</a> <code>participants[]</code> (not revoked, not slashed, not repaid) for <code>schema_id</code>, <code>role</code>, <code>validator_participant_id</code>, <code>corporation</code>.</p>
+<p>for each <code>Participant</code> entry <code>p</code> from <code>participants[]</code>:</p>
 <ul>
 <li>if <code>p.effective_until</code> is greater than <code>effective_from</code>, method execution MUST abort.</li>
 <li>if <code>p.effective_from</code> is lower than <code>effective_until</code>, method execution MUST abort.</li>
-<li>if <code>p.effective_until</code> is NULL (never expire), creation of a new permission doesn’t make any sense and method execution MUST abort.</li>
+<li>if <code>p.effective_until</code> is NULL (never expire), creation of a new <code>Participant</code> entry doesn’t make any sense and method execution MUST abort.</li>
 </ul>
 <blockquote>
 <p>note: this check was not present in v3.</p>
 </blockquote>
-<h5 id="mod-perm-msg-8-3-adjust-permission-execution"><a class="toc-anchor" href="#mod-perm-msg-8-3-adjust-permission-execution" >§</a> [MOD-PERM-MSG-8-3] Adjust Permission execution</h5>
+<h5 id="mod-pp-msg-8-3-set-participant-effective-until-execution"><a class="toc-anchor" href="#mod-pp-msg-8-3-set-participant-effective-until-execution" >§</a> [MOD-PP-MSG-8-3] Set Participant Effective Until execution</h5>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
@@ -3381,85 +3839,85 @@ else MUST abort.</p>
 <p>define <code>now</code>: current timestamp.</p>
 </li>
 <li>
-<p>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>.</p>
+<p>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>.</p>
 </li>
 <li>
-<p>set <code>applicant_perm.effective_until</code> to <code>effective_until</code></p>
+<p>set <code>applicant_participant.effective_until</code> to <code>effective_until</code></p>
 </li>
 <li>
-<p>set <code>applicant_perm.adjusted</code> to <code>now</code></p>
+<p>set <code>applicant_participant.adjusted</code> to <code>now</code></p>
 </li>
 <li>
-<p>set <code>applicant_perm.modified</code> to <code>now</code></p>
+<p>set <code>applicant_participant.modified</code> to <code>now</code></p>
 </li>
 </ul>
 <p>Synchronise VS Operator Authorization expiration, if any. Call <a href="#mod-de-msg-9-update-vs-operator-authorization-expiration" >[MOD-DE-MSG-9]</a> Update VS Operator Authorization Expiration with:</p>
 <ul>
-<li><code>perm_id</code>: <code>applicant_perm.id</code></li>
-<li><code>new_expiration</code>: <code>applicant_perm.effective_until</code></li>
+<li><code>participant_id</code>: <code>applicant_participant.id</code></li>
+<li><code>new_expiration</code>: <code>applicant_participant.effective_until</code></li>
 </ul>
-<p>This call is a no-op if no record exists for <code>applicant_perm.id</code>. If a record exists, its <code>expiration</code> is updated and the on-chain <code>FeeGrant</code> for the containing VSOA is refreshed via <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a>. Adjust Permission does <strong>not</strong> accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see <a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a> and <a href="#mod-perm-msg-14-self-create-permission" >[MOD-PERM-MSG-14]</a>). Adjust also cannot create a record that does not already exist.</p>
-<h4 id="mod-perm-msg-9-revoke-permission"><a class="toc-anchor" href="#mod-perm-msg-9-revoke-permission" >§</a> [MOD-PERM-MSG-9] Revoke Permission</h4>
+<p>This call is a no-op if no record exists for <code>applicant_participant.id</code>. If a record exists, its <code>expiration</code> is updated and the on-chain <code>FeeGrant</code> for the containing VSOA is refreshed via <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a>. Set Participant Effective Until does <strong>not</strong> accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see <a href="#mod-pp-msg-1-start-participant-op" >[MOD-PP-MSG-1]</a> and <a href="#mod-pp-msg-14-self-create-participant" >[MOD-PP-MSG-14]</a>). This method also cannot create a record that does not already exist.</p>
+<h4 id="mod-pp-msg-9-revoke-participant"><a class="toc-anchor" href="#mod-pp-msg-9-revoke-participant" >§</a> [MOD-PP-MSG-9] Revoke Participant</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
 <p>This method can only be called:</p>
 <ul>
-<li>by an ancestor (<code>corporation</code> of a validator in the permission branch until the root permission (GRANTOR, ECOSYSTEM, OPEN schema mode)).</li>
+<li>by an ancestor (<code>corporation</code> of a validator in the <code>Participant</code> branch until the root <code>Participant</code> entry (GRANTOR, ECOSYSTEM, OPEN schema mode)).</li>
 <li>by the grantee <code>corporation</code> (OPEN, GRANTOR, ECOSYSTEM schema mode).</li>
-<li>by the <code>TrustRegistry</code> <code>corporation</code> (owner of the credential schema).</li>
+<li>by the <code>Ecosystem</code> <code>corporation</code> (owner of the credential schema).</li>
 </ul>
-<h5 id="mod-perm-msg-9-1-revoke-permission-parameters"><a class="toc-anchor" href="#mod-perm-msg-9-1-revoke-permission-parameters" >§</a> [MOD-PERM-MSG-9-1] Revoke Permission parameters</h5>
+<h5 id="mod-pp-msg-9-1-revoke-participant-parameters"><a class="toc-anchor" href="#mod-pp-msg-9-1-revoke-participant-parameters" >§</a> [MOD-PP-MSG-9-1] Revoke Participant parameters</h5>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): id of the permission;</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): id of the <code>Participant</code> entry;</li>
 </ul>
-<h5 id="mod-perm-msg-9-2-revoke-permission-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-9-2-revoke-permission-precondition-checks" >§</a> [MOD-PERM-MSG-9-2] Revoke Permission precondition checks</h5>
+<h5 id="mod-pp-msg-9-2-revoke-participant-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-9-2-revoke-participant-precondition-checks" >§</a> [MOD-PP-MSG-9-2] Revoke Participant precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-9-2-1-revoke-permission-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-9-2-1-revoke-permission-basic-checks" >§</a> [MOD-PERM-MSG-9-2-1] Revoke Permission basic checks</h6>
+<h6 id="mod-pp-msg-9-2-1-revoke-participant-basic-checks"><a class="toc-anchor" href="#mod-pp-msg-9-2-1-revoke-participant-basic-checks" >§</a> [MOD-PP-MSG-9-2-1] Revoke Participant basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
 <li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>id</code> MUST be a valid uint64.</li>
-<li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>. If no entry found, abort.</li>
-<li><code>applicant_perm</code> MUST be a <a class="term-reference" href="#term:active-permission">active permission</a></li>
+<li>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>. If no entry found, abort.</li>
+<li><code>applicant_participant</code> MUST be a <a class="term-reference" href="#term:active-participant">active participant</a></li>
 </ul>
-<h6 id="mod-perm-msg-9-2-2-revoke-permission-advanced-checks"><a class="toc-anchor" href="#mod-perm-msg-9-2-2-revoke-permission-advanced-checks" >§</a> [MOD-PERM-MSG-9-2-2] Revoke Permission advanced checks</h6>
+<h6 id="mod-pp-msg-9-2-2-revoke-participant-advanced-checks"><a class="toc-anchor" href="#mod-pp-msg-9-2-2-revoke-participant-advanced-checks" >§</a> [MOD-PP-MSG-9-2-2] Revoke Participant advanced checks</h6>
 <p>Either Option #1, #2 or #3 MUST return true, else abort.</p>
 <p><em>Option #1</em>: executed by a validator ancestor</p>
-<p>if <code>applicant_perm.validator_perm_id</code> is defined:</p>
+<p>if <code>applicant_participant.validator_participant_id</code> is defined:</p>
 <ul>
-<li>set <code>validator_perm</code> = <code>applicant_perm</code></li>
-<li>while <code>validator_perm.validator_perm_id</code> is defined,
+<li>set <code>validator_participant</code> = <code>applicant_participant</code></li>
+<li>while <code>validator_participant.validator_participant_id</code> is defined,
 <ul>
-<li>load <code>validator_perm</code> from <code>validator_perm.validator_perm_id</code>.</li>
-<li>if <code>validator_perm</code> is a <a class="term-reference" href="#term:active-permission">active permission</a> and <code>validator_perm.corporation</code> is who is running the method, =&gt; return true.</li>
+<li>load <code>validator_participant</code> from <code>validator_participant.validator_participant_id</code>.</li>
+<li>if <code>validator_participant</code> is a <a class="term-reference" href="#term:active-participant">active participant</a> and <code>validator_participant.corporation</code> is who is running the method, =&gt; return true.</li>
 </ul>
 </li>
 <li>end</li>
 <li>return false.</li>
 </ul>
-<p><em>Option #2</em>: executed by <code>TrustRegistry</code> controller</p>
+<p><em>Option #2</em>: executed by <code>Ecosystem</code> controller</p>
 <ul>
-<li>load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_perm.schema_id</code></li>
-<li>load <code>TrustRegistry</code> <code>tr</code> from <code>cs.tr_id</code></li>
-<li>if <code>corporation</code> running the method is <code>tr.corporation</code>, return true.</li>
+<li>load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_participant.schema_id</code></li>
+<li>load <code>Ecosystem</code> <code>tr</code> from <code>cs.ecosystem_id</code></li>
+<li>if <code>corporation</code> running the method is <code>ecosystem.corporation</code>, return true.</li>
 <li>else return false.</li>
 </ul>
-<p><em>Option #3</em>: executed by <code>applicant_perm.corporation</code>: return true.</p>
+<p><em>Option #3</em>: executed by <code>applicant_participant.corporation</code>: return true.</p>
 <p>Example:</p>
-<p>In the following permission tree, “Verifier E” permission can be revoked:</p>
+<p>In the following <code>Participant</code> tree, the “Verifier E” <code>Participant</code> entry can be revoked:</p>
 <ul>
-<li>by “Verifier E”, if the corresponding permission is a <a class="term-reference" href="#term:active-permission">active permission</a>;</li>
-<li>by “Verifier Grantor D”, if the corresponding permission is a <a class="term-reference" href="#term:active-permission">active permission</a>;</li>
-<li>by “Ecosystem A”, if the corresponding root permission is a <a class="term-reference" href="#term:active-permission">active permission</a>;</li>
-<li>by the <code>TrustRegistry</code> object controller, obtained by resolving perm =&gt; credential schema =&gt; trust registry.</li>
+<li>by “Verifier E”, if the corresponding <code>Participant</code> entry is a <a class="term-reference" href="#term:active-participant">active participant</a>;</li>
+<li>by “Verifier Grantor D”, if the corresponding <code>Participant</code> entry is a <a class="term-reference" href="#term:active-participant">active participant</a>;</li>
+<li>by “Ecosystem A”, if the corresponding root <code>Participant</code> entry is a <a class="term-reference" href="#term:active-participant">active participant</a>;</li>
+<li>by the <code>Ecosystem</code> object controller, obtained by resolving perm =&gt; credential schema =&gt; ecosystem.</li>
 </ul>
-<img src="https://www.plantuml.com/plantuml/svg/ZPDTJy8m58Rl-ojEu4OlJ9QGCCE50SQ09IfccoHwOxhjCAhxIbicnF3VBUkOak2mD-r9t_C-FJtjK4ZAvIPDoB1PYP0c22dTmgrXm2UBv9e0AMZuGME4ZhsbQQ445iS8Cybe0bwunfJ24_AK2S7o37oEs04g81JmHGYeaGVl64gL7-PY9oIcCAeKaaEtjmgYeA-KK8-YiV9t1Gx0jXRUY-VR3t3bvhcyReGHYmQeJpJ0e_EesjwVO1qXDiXXncacSmxZYitY5gRZUS-s-pPpHu_-mZrBPF7uRvIb4JhecdtJn0Wkyivph3EO9NAsOhzgcbJ0igscfUqwK-T2LMKyQSFP6dCCkuOH62lZ7z3pCBjcdS3cUH8fxrUeM6iTTQVJiM7sMaZpnVsavko9iYH4lQwRcxj3emSG7-v9zK3ev_gJJDHsfTAzQbCU3Sjsmr8RDfVKQbbZ3mcwqbRr4BEe-h1w_WO0" alt="uml diagram">
-<h6 id="mod-perm-msg-9-2-3-revoke-permission-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-9-2-3-revoke-permission-fee-checks" >§</a> [MOD-PERM-MSG-9-2-3] Revoke Permission fee checks</h6>
+<img src="https://www.plantuml.com/plantuml/svg/XPDHRu8m483V-oikyh8zc92OoCB3eY8goJONS2RRorBWn6uWfAtCPV6_hr9qCwBsfLpk-BuhFNf2KYxNMKfwXoSHqHGXenkuCqtuOh5S4Y05ZJvfWj1oDpGhL873CSQLP3I585fYHk5P0LZ42hgICEE8BQ028W4_X81QUVY1aLI0A1VVGc86_Qf2SZ0wYp0EkweIwiNp56rmdMdm6ipSHxZnyrpU7j8nYstKZTYuv_MhzFP8vWcnHWvZhfhAEGmg8qjEJ5uGlBZ--zZlFyscVgE79OFp0aU3TM1ONSl26CvOckbE0toEd2tOl_w7bQOyxN_k-jx8ktA2CXbUahWQlWyDqmpDXNbMrQnmQyEHOfAdiIA-GMLOwiWOZGQcrJdXJwOFmvg-9Gf4Y9gGTlj-TsqsH1ofH052prpnDtD4vQioVGaNI_V8yWgorCZ3DxaChSsxD_GPBvVtS1LNlvxUVm40" alt="uml diagram">
+<h6 id="mod-pp-msg-9-2-3-revoke-participant-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-9-2-3-revoke-participant-fee-checks" >§</a> [MOD-PP-MSG-9-2-3] Revoke Participant fee checks</h6>
 <p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h5 id="mod-perm-msg-9-3-revoke-permission-execution"><a class="toc-anchor" href="#mod-perm-msg-9-3-revoke-permission-execution" >§</a> [MOD-PERM-MSG-9-3] Revoke Permission execution</h5>
+<h5 id="mod-pp-msg-9-3-revoke-participant-execution"><a class="toc-anchor" href="#mod-pp-msg-9-3-revoke-participant-execution" >§</a> [MOD-PP-MSG-9-3] Revoke Participant execution</h5>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
@@ -3467,118 +3925,118 @@ else MUST abort.</p>
 <p>define <code>now</code>: current timestamp.</p>
 </li>
 <li>
-<p>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>.</p>
+<p>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>.</p>
 </li>
 <li>
-<p>set <code>applicant_perm.revoked</code> to <code>now</code></p>
+<p>set <code>applicant_participant.revoked</code> to <code>now</code></p>
 </li>
 <li>
-<p>set <code>applicant_perm.modified</code> to <code>now</code></p>
+<p>set <code>applicant_participant.modified</code> to <code>now</code></p>
 </li>
 </ul>
-<p>Call <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a> Revoke VS Operator Authorization with <code>perm_id = applicant_perm.id</code> to remove any authorization record for this permission. The call is a no-op if no record exists.</p>
-<h4 id="mod-perm-msg-10-create-or-update-permission-session"><a class="toc-anchor" href="#mod-perm-msg-10-create-or-update-permission-session" >§</a> [MOD-PERM-MSG-10] Create or Update Permission Session</h4>
+<p>Call <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a> Revoke VS Operator Authorization with <code>participant_id = applicant_participant.id</code> to remove any authorization record for this <code>Participant</code> entry. The call is a no-op if no record exists.</p>
+<h4 id="mod-pp-msg-10-create-or-update-participant-session"><a class="toc-anchor" href="#mod-pp-msg-10-create-or-update-participant-session" >§</a> [MOD-PP-MSG-10] Create or Update Participant Session</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
-<p>Any credential exchange that requires issuer or verifier to pay fees, register a digest_sri, or produce a proof implies the creation of a <code>PermissionSession</code>.</p>
+<p>Any credential exchange that requires issuer or verifier to pay fees, register a digest_sri, or produce a proof implies the creation of a <code>ParticipantSession</code>.</p>
 <p>If the peer wants to issue a credential, the <code>agent</code>, the Verifiable User Agent or Verifiable Service that receive the request MUST send to peer:</p>
 <ul>
 <li>a <code>uuid</code> for session identification;</li>
-<li><em>optional</em>: the <code>agent_perm_id</code> permission id of the agent that will receive the credential, if peer is a <strong>Verifiable User Agent</strong>. it MUST NOT be set if peer is a <strong>Verifiable Service</strong>.</li>
-<li><em>optional</em>: the <code>wallet_agent_perm_id</code> permission id of the agent wallet that will store the credential. If this is the same software than the agent, then it should be equal to <code>agent_perm_id</code>. It MUST NOT be set if peer is a <strong>Verifiable Service</strong>.</li>
+<li><em>optional</em>: the <code>agent_participant_id</code> <code>Participant</code> id of the agent that will receive the credential, if peer is a <strong>Verifiable User Agent</strong>. it MUST NOT be set if peer is a <strong>Verifiable Service</strong>.</li>
+<li><em>optional</em>: the <code>wallet_agent_participant_id</code> <code>Participant</code> id of the agent wallet that will store the credential. If this is the same software than the agent, then it should be equal to <code>agent_participant_id</code>. It MUST NOT be set if peer is a <strong>Verifiable Service</strong>.</li>
 </ul>
 <p>If the peer wants to verify a credential, agent must send to peer:</p>
 <ul>
 <li>a <code>uuid</code> for session identification;</li>
-<li><em>optional</em>: the <code>agent_perm_id</code> permission id of the agent that will receive the credential, if peer is a <strong>Verifiable User Agent</strong>. it MUST NOT be set if peer is a <strong>Verifiable Service</strong>.</li>
-<li><em>optional</em>: a map of compatible found credentials in available wallets for the requested schema_id: Map&lt;uint64[] issuer_perm_ids, uint64: wallet_agent_perm_id&gt;. wallet_agent_perm_id MUST NOT be set if peer is a <strong>Verifiable Service</strong>.</li>
+<li><em>optional</em>: the <code>agent_participant_id</code> <code>Participant</code> id of the agent that will receive the credential, if peer is a <strong>Verifiable User Agent</strong>. it MUST NOT be set if peer is a <strong>Verifiable Service</strong>.</li>
+<li><em>optional</em>: a map of compatible found credentials in available wallets for the requested schema_id: Map&lt;uint64[] issuer_participant_ids, uint64: wallet_agent_participant_id&gt;. wallet_agent_participant_id MUST NOT be set if peer is a <strong>Verifiable Service</strong>.</li>
 </ul>
-<p>In case peer is a <strong>Verifiable Service</strong> and illegaly set <code>agent_perm_id</code> and/or <code>wallet_agent_perm_id</code>, the other end MUST refuse the request.</p>
-<p><code>payer</code> MUST create a Permission Session using the above information, then, <code>agent</code> MUST check session has been created and is valid before accepting the action (receive and store issued credential, or accept a presentation request).</p>
-<img src="https://www.plantuml.com/plantuml/svg/VPB1Ri8m44Jl_eeHfrPg4CSALHNSG3qK5JMdIcXhB-0gSI9x0ytVrmu1qWhr6FljoypAio3afIaB5JGLZ9A-yJYPu6YDx1LfgJn6ynqx-N3v-npnCr-FG07B41esK7MSjzhMv0IZ5RNi8pb0_1yaNxrrbuSwtYZLQvwohCUdMEAOIAbWqma8shE94ImLsFggHD1xBWdMO3mU9x2jchCfovulfWLxZXB8dX4u15ivD4qS8sUwmoCL1Sk6Ki5DpRxSMAFws4aKGqxJtqakWbk9p-uJQHvI7cXoEB2tstOOhJFkMDQdaRiKvtxex82piFhyOYstgYrFRilcLpihgU_hopL2uBxhTOctAgmJzWzY8X8Vmr03w_e5ebkWcaL7V4e_" alt="uml diagram">
+<p>In case peer is a <strong>Verifiable Service</strong> and illegaly set <code>agent_participant_id</code> and/or <code>wallet_agent_participant_id</code>, the other end MUST refuse the request.</p>
+<p><code>payer</code> MUST create a Participant Session using the above information, then, <code>agent</code> MUST check session has been created and is valid before accepting the action (receive and store issued credential, or accept a presentation request).</p>
+<img src="https://www.plantuml.com/plantuml/svg/VPB1Ri8m44Jl_eeHfrPg8euLgYguWNeeAYgdIcXhB-0gSI9x0-NlQuS4qWhr6FljoypAqo3afIaB5JGLZ9A-yJWUusYDx1LfgJn6inqx-N3hzndYvter0WKiGcZOGDLntcfRanECbdHY7ya1ulyWw-LRUtceuurIdUOfopfyWWMEYPGADfs0e3sR6C5IWQslIWIzvv9W3V8yJ-2fQdfJbZrVJ7Fs72MGFIDm2BPoQ9euHiwqXqSg2fODfOARGSoDDQfBdtmnwoI58BbuRWNlVt4cpKEA1KqE1_PsUnecR8qxbjLvv2wbkXywMw0NLfzVhELMmyNPRTdyAcabrNvzkKO8t5M-xl9MXLN2_a5CHEAR66fWNRT7j7jKq-Y8B-e7" alt="uml diagram">
 <p>See <a class="term-reference" href="#term:vt-spec">VT spec</a>.</p>
-<h5 id="mod-perm-msg-10-1-create-or-update-permission-session-parameters"><a class="toc-anchor" href="#mod-perm-msg-10-1-create-or-update-permission-session-parameters" >§</a> [MOD-PERM-MSG-10-1] Create or Update Permission Session parameters</h5>
-<p>An <a class="term-reference" href="#term:account">account</a> that would like to create or update a <code>PermissionSession</code> entry MUST send a Msg by specifying:</p>
+<h5 id="mod-pp-msg-10-1-create-or-update-participant-session-parameters"><a class="toc-anchor" href="#mod-pp-msg-10-1-create-or-update-participant-session-parameters" >§</a> [MOD-PP-MSG-10-1] Create or Update Participant Session parameters</h5>
+<p>An <a class="term-reference" href="#term:account">account</a> that would like to create or update a <code>ParticipantSession</code> entry MUST send a Msg by specifying:</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uuid) (<em>mandatory</em>): id of the <code>PermissionSession</code>.</li>
-<li><code>issuer_perm_id</code> (uint64) (<em>optional</em>): the id of the perm of the issuer, if we are dealing with the issuance of a credential.</li>
-<li><code>verifier_perm_id</code> (uint64) (<em>optional</em>): the id of the perm of the verifier, if we are dealing with the verification of a credential.</li>
-<li><code>agent_perm_id</code> (uint64) (<em>optional</em>): the agent credential issuer permission id (extracted from the agent credential that VUA has in its wallet) of the agent that received the request (credential offer for issuance, presentation request for verification). Only set by VUAs, MUST NOT be specified when peer is a VS.</li>
-<li><code>wallet_agent_perm_id</code> (uint64) (<em>optional</em>): the wallet credential issuer permission id of the VUA where the credential will be or is stored. Can be the same perm than <code>agent_perm_id</code> if agent and wallet_agent are the same agent. Only set by VUAs, MUST NOT be specified when peer is a VS.</li>
+<li><code>id</code> (uuid) (<em>mandatory</em>): id of the <code>ParticipantSession</code>.</li>
+<li><code>issuer_participant_id</code> (uint64) (<em>optional</em>): the id of the perm of the issuer, if we are dealing with the issuance of a credential.</li>
+<li><code>verifier_participant_id</code> (uint64) (<em>optional</em>): the id of the perm of the verifier, if we are dealing with the verification of a credential.</li>
+<li><code>agent_participant_id</code> (uint64) (<em>optional</em>): the agent credential issuer <code>Participant</code> id (extracted from the agent credential that VUA has in its wallet) of the agent that received the request (credential offer for issuance, presentation request for verification). Only set by VUAs, MUST NOT be specified when peer is a VS.</li>
+<li><code>wallet_agent_participant_id</code> (uint64) (<em>optional</em>): the wallet credential issuer <code>Participant</code> id of the VUA where the credential will be or is stored. Can be the same perm than <code>agent_participant_id</code> if agent and wallet_agent are the same agent. Only set by VUAs, MUST NOT be specified when peer is a VS.</li>
 <li><code>digest</code> (string) (<em>optional</em>): digest derived from an issued or verified credential.</li>
 </ul>
-<h5 id="mod-perm-msg-10-2-create-or-update-permission-session-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-10-2-create-or-update-permission-session-precondition-checks" >§</a> [MOD-PERM-MSG-10-2] Create or Update Permission Session precondition checks</h5>
+<h5 id="mod-pp-msg-10-2-create-or-update-participant-session-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-10-2-create-or-update-participant-session-precondition-checks" >§</a> [MOD-PP-MSG-10-2] Create or Update Participant Session precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
 <li><code>id</code> MUST be a valid uuid. If an entry <code>existing_entry</code> with <code>id</code> already exist, then  <code>existing_entry.corporation</code> MUST be equal to <code>corporation</code> AND <code>existing_entry.vs_operator</code> MUST be equal to <code>operator</code>, else abort.</li>
 </ul>
-<p>if <code>issuer_perm_id</code> is null AND <code>verifier_perm_id</code> is null, MUST abort.</p>
+<p>if <code>issuer_participant_id</code> is null AND <code>verifier_participant_id</code> is null, MUST abort.</p>
 <ul>
-<li>define <code>issuer_perm</code> as null.</li>
-<li>define <code>verifier_perm</code> as null.</li>
+<li>define <code>issuer_participant</code> as null.</li>
+<li>define <code>verifier_participant</code> as null.</li>
 </ul>
-<p>if <code>issuer_perm_id</code> is not null:</p>
+<p>if <code>issuer_participant_id</code> is not null:</p>
 <ul>
-<li>Load <code>issuer_perm</code> from <code>issuer_perm_id</code>.</li>
-<li>if <code>issuer_perm.type</code> is not ISSUER, abort.</li>
-<li>if <code>issuer_perm</code> is not a <a class="term-reference" href="#term:active-permission">active permission</a>, abort.</li>
-<li>if <code>issuer_perm.vs_operator</code> is not equal to <code>operator</code>, abort.</li>
-<li>if <code>issuer_perm.corporation</code> is not equal to <code>corporation</code>, abort.</li>
+<li>Load <code>issuer_participant</code> from <code>issuer_participant_id</code>.</li>
+<li>if <code>issuer_participant.role</code> is not ISSUER, abort.</li>
+<li>if <code>issuer_participant</code> is not a <a class="term-reference" href="#term:active-participant">active participant</a>, abort.</li>
+<li>if <code>issuer_participant.vs_operator</code> is not equal to <code>operator</code>, abort.</li>
+<li>if <code>issuer_participant.corporation</code> is not equal to <code>corporation</code>, abort.</li>
 <li>if <code>digest_sri</code> is present but not a valid digest SRI, abort.</li>
 </ul>
-<p>if <code>verifier_perm_id</code> is not null:</p>
+<p>if <code>verifier_participant_id</code> is not null:</p>
 <ul>
-<li>Load <code>verifier_perm</code> from <code>verifier_perm_id</code>.</li>
-<li>if <code>verifier_perm.type</code> is not VERIFIER, abort.</li>
-<li>if <code>verifier_perm</code> is not a <a class="term-reference" href="#term:active-permission">active permission</a>, abort.</li>
-<li>if <code>verifier_perm.vs_operator</code> is not equal to <code>operator</code>, abort.</li>
-<li>if <code>verifier_perm.corporation</code> is not equal to <code>corporation</code>, abort.</li>
+<li>Load <code>verifier_participant</code> from <code>verifier_participant_id</code>.</li>
+<li>if <code>verifier_participant.role</code> is not VERIFIER, abort.</li>
+<li>if <code>verifier_participant</code> is not a <a class="term-reference" href="#term:active-participant">active participant</a>, abort.</li>
+<li>if <code>verifier_participant.vs_operator</code> is not equal to <code>operator</code>, abort.</li>
+<li>if <code>verifier_participant.corporation</code> is not equal to <code>corporation</code>, abort.</li>
 <li>if <code>digest_sri</code> is present but not a valid digest SRI, abort.</li>
 </ul>
-<p>Define the <strong>primary permission</strong> <code>perm</code>: if <code>verifier_perm</code> is not null, <code>perm</code> = <code>verifier_perm</code> (the caller is the <code>vs_operator</code> of the verifier). Else, <code>perm</code> = <code>issuer_perm</code> (the caller is the <code>vs_operator</code> of the issuer).</p>
+<p>Define the <strong>primary <code>Participant</code></strong> <code>perm</code>: if <code>verifier_participant</code> is not null, <code>perm</code> = <code>verifier_participant</code> (the caller is the <code>vs_operator</code> of the verifier). Else, <code>perm</code> = <code>issuer_participant</code> (the caller is the <code>vs_operator</code> of the issuer).</p>
 <p><a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>perm</code>) tuple.
 <a href="#authz-check-4-vs-operator-fee-grant-checks" >[AUTHZ-CHECK-4]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>perm</code>) tuple.</p>
 <p>agent:</p>
 <ul>
-<li>Load <code>agent_perm</code> from <code>agent_perm_id</code>.</li>
-<li>if <code>agent_perm.type</code> is not ISSUER, abort.</li>
-<li>if <code>agent_perm</code> is not a <a class="term-reference" href="#term:active-permission">active permission</a>, abort.</li>
+<li>Load <code>agent_participant</code> from <code>agent_participant_id</code>.</li>
+<li>if <code>agent_participant.role</code> is not ISSUER, abort.</li>
+<li>if <code>agent_participant</code> is not a <a class="term-reference" href="#term:active-participant">active participant</a>, abort.</li>
 </ul>
 <p>wallet_agent:</p>
 <ul>
-<li>Load <code>wallet_agent_perm</code> from <code>wallet_agent_perm_id</code>.</li>
-<li>if <code>wallet_agent_perm.type</code> is not ISSUER, abort.</li>
-<li>if <code>wallet_agent_perm</code> is not a <a class="term-reference" href="#term:active-permission">active permission</a>, abort.</li>
+<li>Load <code>wallet_agent_participant</code> from <code>wallet_agent_participant_id</code>.</li>
+<li>if <code>wallet_agent_participant.role</code> is not ISSUER, abort.</li>
+<li>if <code>wallet_agent_participant</code> is not a <a class="term-reference" href="#term:active-participant">active participant</a>, abort.</li>
 </ul>
-<div id="warning-47" class="notice warning"><a class="notice-link" href="#warning-47">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a permission that is not controlled by its owner.</p>
+<div id="warning-47" class="notice warning"><a class="notice-link" href="#warning-47">WARNING</a><p>we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a <code>Participant</code> entry that is not controlled by its owner.</p>
 </div>
-<h6 id="mod-perm-msg-10-3-create-or-update-permission-session-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-10-3-create-or-update-permission-session-fee-checks" >§</a> [MOD-PERM-MSG-10-3] Create or Update Permission Session fee checks</h6>
+<h6 id="mod-pp-msg-10-3-create-or-update-participant-session-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-10-3-create-or-update-participant-session-fee-checks" >§</a> [MOD-PP-MSG-10-3] Create or Update Participant Session fee checks</h6>
 <ul>
-<li>Load <code>CredentialSchema</code> entry <code>cs</code> from <code>issuer_perm.schema_id</code> if <code>issuer_perm</code> is not null, else from <code>verifier_perm.schema_id</code>.</li>
+<li>Load <code>CredentialSchema</code> entry <code>cs</code> from <code>issuer_participant.schema_id</code> if <code>issuer_participant</code> is not null, else from <code>verifier_participant.schema_id</code>.</li>
 <li>Fee payer MUST have sufficient available balance for the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</li>
 </ul>
 <p>For trust fees, <code>corporation</code> account MUST have sufficient available balance as explained below.</p>
 <p><strong>Step 1: Calculate total beneficiary fees in credential schema pricing asset</strong></p>
-<p>Use “Find Beneficiaries” query method to get the set of beneficiary permissions <code>found_perm_set</code> (all ancestors in the permission tree).</p>
+<p>Use “Find Beneficiaries” query method to get the set of beneficiary <code>Participant</code> entries <code>found_participant_set</code> (all ancestors in the <code>Participant</code> tree).</p>
 <ul>
 <li>define <code>total_beneficiary_fees</code> = 0</li>
 </ul>
-<p>If <strong>Credential Issuance</strong> (<code>issuer_perm</code> is NOT null):</p>
+<p>If <strong>Credential Issuance</strong> (<code>issuer_participant</code> is NOT null):</p>
 <ul>
-<li>for each <code>perm</code> in <code>found_perm_set</code>:
+<li>for each <code>perm</code> in <code>found_participant_set</code>:
 <ul>
-<li><code>total_beneficiary_fees</code> = <code>total_beneficiary_fees</code> + <code>perm.issuance_fees</code> × (1 - <code>issuer_perm.issuance_fee_discount</code>)</li>
+<li><code>total_beneficiary_fees</code> = <code>total_beneficiary_fees</code> + <code>participant.issuance_fees</code> × (1 - <code>issuer_participant.issuance_fee_discount</code>)</li>
 </ul>
 </li>
 </ul>
-<p>If <strong>Credential Verification</strong> (<code>verifier_perm</code> is NOT null):</p>
+<p>If <strong>Credential Verification</strong> (<code>verifier_participant</code> is NOT null):</p>
 <ul>
-<li>for each <code>perm</code> in <code>found_perm_set</code>:
+<li>for each <code>perm</code> in <code>found_participant_set</code>:
 <ul>
-<li><code>total_beneficiary_fees</code> = <code>total_beneficiary_fees</code> + <code>perm.verification_fees</code> × (1 - <code>verifier_perm.verification_fee_discount</code>)</li>
+<li><code>total_beneficiary_fees</code> = <code>total_beneficiary_fees</code> + <code>participant.verification_fees</code> × (1 - <code>verifier_participant.verification_fee_discount</code>)</li>
 </ul>
 </li>
 </ul>
@@ -3649,11 +4107,11 @@ else MUST abort.</p>
 <li><code>total_payees_trust_deposit</code> = <code>total_payer_trust_deposit</code></li>
 <li><code>total_payees_fees_to_account</code> = <code>total_fees_in_native_denom</code> × (1 - <code>GlobalVariables.trust_deposit_rate</code>)</li>
 </ul>
-<p>if <code>agent_perm_id</code> is set:</p>
+<p>if <code>agent_participant_id</code> is set:</p>
 <ul>
 <li><code>total_user_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></li>
 </ul>
-<p>if <code>wallet_agent_perm_id</code> is set:</p>
+<p>if <code>wallet_agent_participant_id</code> is set:</p>
 <ul>
 <li><code>total_wallet_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></li>
 </ul>
@@ -3671,11 +4129,11 @@ else MUST abort.</p>
 <li><code>total_payees_trust_deposit</code> = <code>total_payer_trust_deposit</code></li>
 <li><code>total_payees_fees_to_account</code> = <code>total_fees_in_native_denom</code> × (1 - <code>GlobalVariables.trust_deposit_rate</code>)</li>
 </ul>
-<p>if <code>agent_perm_id</code> is set:</p>
+<p>if <code>agent_participant_id</code> is set:</p>
 <ul>
 <li><code>total_user_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></li>
 </ul>
-<p>if <code>wallet_agent_perm_id</code> is set:</p>
+<p>if <code>wallet_agent_participant_id</code> is set:</p>
 <ul>
 <li><code>total_wallet_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></li>
 </ul>
@@ -3693,11 +4151,11 @@ else MUST abort.</p>
 <li><code>total_payees_trust_deposit</code> = <code>total_payer_trust_deposit</code></li>
 <li><code>total_payees_fees_to_account</code> = <code>total_fees_in_pricing_asset</code> × (1 - <code>GlobalVariables.trust_deposit_rate</code>)</li>
 </ul>
-<p>if <code>agent_perm_id</code> is set:</p>
+<p>if <code>agent_participant_id</code> is set:</p>
 <ul>
 <li><code>total_user_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></li>
 </ul>
-<p>if <code>wallet_agent_perm_id</code> is set:</p>
+<p>if <code>wallet_agent_participant_id</code> is set:</p>
 <ul>
 <li><code>total_wallet_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></li>
 </ul>
@@ -3716,11 +4174,11 @@ else MUST abort.</p>
 <li><code>total_payees_trust_deposit</code> = <code>total_payer_trust_deposit</code></li>
 <li><code>total_payees_fees_to_account</code> = 0 (FIAT payments are managed off-chain)</li>
 </ul>
-<p>if <code>agent_perm_id</code> is set:</p>
+<p>if <code>agent_participant_id</code> is set:</p>
 <ul>
 <li><code>total_user_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></li>
 </ul>
-<p>if <code>wallet_agent_perm_id</code> is set:</p>
+<p>if <code>wallet_agent_participant_id</code> is set:</p>
 <ul>
 <li><code>total_wallet_agent_reward</code> = <code>total_fees_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></li>
 </ul>
@@ -3734,13 +4192,13 @@ else MUST abort.</p>
 <li>When paying with COIN ≠ <a class="term-reference" href="#term:native-denom">native denom</a> or with FIAT, payer pays trust deposits on behalf of payees (since payees receive non-native assets that cannot be directly staked).</li>
 </ul>
 </div>
-<h5 id="mod-perm-msg-10-4-create-or-update-permission-session-execution"><a class="toc-anchor" href="#mod-perm-msg-10-4-create-or-update-permission-session-execution" >§</a> [MOD-PERM-MSG-10-4] Create or Update Permission Session execution</h5>
+<h5 id="mod-pp-msg-10-4-create-or-update-participant-session-execution"><a class="toc-anchor" href="#mod-pp-msg-10-4-create-or-update-participant-session-execution" >§</a> [MOD-PP-MSG-10-4] Create or Update Participant Session execution</h5>
 <p>If all precondition checks passed, method is executed.</p>
 <ul>
-<li>Load all permissions as in basic checks.</li>
-<li>Load <code>CredentialSchema</code> entry <code>cs</code> from <code>issuer_perm.schema_id</code> if <code>issuer_perm</code> is not null, else from <code>verifier_perm.schema_id</code>.</li>
+<li>Load all <code>Participant</code> entries as in basic checks.</li>
+<li>Load <code>CredentialSchema</code> entry <code>cs</code> from <code>issuer_participant.schema_id</code> if <code>issuer_participant</code> is not null, else from <code>verifier_participant.schema_id</code>.</li>
 <li>define <code>now</code>: current timestamp.</li>
-<li>use “Find Beneficiaries” to build <code>found_perm_set</code>.</li>
+<li>use “Find Beneficiaries” to build <code>found_participant_set</code>.</li>
 </ul>
 <blockquote>
 <p>Note: All funds are transferred from the <code>corporation</code> account executing the method. The steps below describe what each recipient must receive. Implementation details (batching, order of transfers) are left to the implementer.</p>
@@ -3755,29 +4213,29 @@ else MUST abort.</p>
 <p>Determine the operation type and applicable discount:</p>
 <ul>
 <li>
-<p>If <strong>Credential Issuance</strong> (<code>issuer_perm</code> is NOT null):</p>
+<p>If <strong>Credential Issuance</strong> (<code>issuer_participant</code> is NOT null):</p>
 <ul>
 <li><code>fee_field</code> = <code>issuance_fees</code></li>
-<li><code>discount</code> = <code>issuer_perm.issuance_fee_discount</code></li>
-<li><code>payer_perm</code> = <code>issuer_perm</code></li>
+<li><code>discount</code> = <code>issuer_participant.issuance_fee_discount</code></li>
+<li><code>payer_participant</code> = <code>issuer_participant</code></li>
 </ul>
 </li>
 <li>
-<p>Else if <strong>Credential Verification</strong> (<code>verifier_perm</code> is NOT null):</p>
+<p>Else if <strong>Credential Verification</strong> (<code>verifier_participant</code> is NOT null):</p>
 <ul>
 <li><code>fee_field</code> = <code>verification_fees</code></li>
-<li><code>discount</code> = <code>verifier_perm.verification_fee_discount</code></li>
-<li><code>payer_perm</code> = <code>verifier_perm</code></li>
+<li><code>discount</code> = <code>verifier_participant.verification_fee_discount</code></li>
+<li><code>payer_participant</code> = <code>verifier_participant</code></li>
 </ul>
 </li>
 </ul>
-<p><strong>For each beneficiary permission <code>perm</code> in <code>found_perm_set</code>:</strong></p>
-<p>If <code>perm.[fee_field]</code> &gt; 0:</p>
+<p><strong>For each beneficiary <code>Participant</code> <code>perm</code> in <code>found_participant_set</code>:</strong></p>
+<p>If <code>participant.[fee_field]</code> &gt; 0:</p>
 <ol>
 <li>
 <p>Calculate the discounted fee for this beneficiary:</p>
 <ul>
-<li><code>beneficiary_fee_in_pricing_asset</code> = <code>perm.[fee_field]</code> × (1 - <code>discount</code>)</li>
+<li><code>beneficiary_fee_in_pricing_asset</code> = <code>participant.[fee_field]</code> × (1 - <code>discount</code>)</li>
 </ul>
 </li>
 <li>
@@ -3791,9 +4249,9 @@ else MUST abort.</p>
 </ul>
 </li>
 </ol>
-<p>if <code>agent_perm_id</code> is set:
+<p>if <code>agent_participant_id</code> is set:
 - <code>user_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></p>
-<p>if <code>wallet_agent_perm_id</code> is set:
+<p>if <code>wallet_agent_participant_id</code> is set:
 - <code>wallet_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></p>
 <p><strong>Case B: <code>(cs.pricing_asset_type, cs.pricing_asset)</code> = <code>(TU, &quot;tu&quot;)</code></strong></p>
 <ul>
@@ -3802,9 +4260,9 @@ else MUST abort.</p>
 <li><code>payee_trust_deposit</code> = <code>payer_trust_deposit</code></li>
 <li><code>payee_fees_to_account</code> = <code>fee_in_native_denom</code> × (1 - <code>GlobalVariables.trust_deposit_rate</code>)</li>
 </ul>
-<p>if <code>agent_perm_id</code> is set:
+<p>if <code>agent_participant_id</code> is set:
 - <code>user_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></p>
-<p>if <code>wallet_agent_perm_id</code> is set:
+<p>if <code>wallet_agent_participant_id</code> is set:
 - <code>wallet_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></p>
 <p><strong>Case C: <code>(cs.pricing_asset_type, cs.pricing_asset)</code> = <code>(COIN, &lt;arbitrary_denom&gt;)</code></strong></p>
 <ul>
@@ -3813,9 +4271,9 @@ else MUST abort.</p>
 <li><code>payee_trust_deposit</code> = <code>payer_trust_deposit</code></li>
 <li><code>payee_fees_to_account</code> = <code>beneficiary_fee_in_pricing_asset</code> × (1 - <code>GlobalVariables.trust_deposit_rate</code>) <em>(in <code>&lt;arbitrary_denom&gt;</code>)</em></li>
 </ul>
-<p>if <code>agent_perm_id</code> is set:
+<p>if <code>agent_participant_id</code> is set:
 - <code>user_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></p>
-<p>if <code>wallet_agent_perm_id</code> is set:
+<p>if <code>wallet_agent_participant_id</code> is set:
 - <code>wallet_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></p>
 <p><strong>Case D: <code>(cs.pricing_asset_type, cs.pricing_asset)</code> = <code>(FIAT, &lt;fiat_denom&gt;)</code></strong></p>
 <ul>
@@ -3824,17 +4282,17 @@ else MUST abort.</p>
 <li><code>payee_trust_deposit</code> = <code>payer_trust_deposit</code></li>
 <li><code>payee_fees_to_account</code> = 0 <em>(FIAT payments are managed off-chain)</em></li>
 </ul>
-<p>if <code>agent_perm_id</code> is set:
+<p>if <code>agent_participant_id</code> is set:
 - <code>user_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.user_agent_reward_rate</code></p>
-<p>if <code>wallet_agent_perm_id</code> is set:
+<p>if <code>wallet_agent_participant_id</code> is set:
 - <code>wallet_agent_reward_portion</code> = <code>fee_in_native_denom</code> × <code>GlobalVariables.wallet_user_agent_reward_rate</code></p>
 <ol start="3">
 <li>
 <p>Execute transfers and deposits for this beneficiary:</p>
 <ul>
-<li>If <code>payee_fees_to_account</code> &gt; 0: transfer <code>payee_fees_to_account</code> to <code>perm.corporation</code> (in the appropriate denom).</li>
-<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>perm.corporation</code> by <code>payee_trust_deposit</code>. Increase <code>perm.deposit</code> by the same value.</li>
-<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>corporation</code> (payer) by <code>payer_trust_deposit</code>. Increase <code>payer_perm.deposit</code> by the same value.</li>
+<li>If <code>payee_fees_to_account</code> &gt; 0: transfer <code>payee_fees_to_account</code> to <code>participant.corporation</code> (in the appropriate denom).</li>
+<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>participant.corporation</code> by <code>payee_trust_deposit</code>. Increase <code>participant.deposit</code> by the same value.</li>
+<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>corporation</code> (payer) by <code>payer_trust_deposit</code>. Increase <code>payer_participant.deposit</code> by the same value.</li>
 </ul>
 </li>
 <li>
@@ -3849,35 +4307,35 @@ else MUST abort.</p>
 <p><strong>Step 2: Process agent rewards</strong></p>
 <p>After processing all beneficiaries, distribute accumulated rewards to agents.</p>
 <p><strong>User Agent Reward:</strong></p>
-<p>If <code>agent_perm_id</code> is set AND <code>accumulated_user_agent_reward</code> &gt; 0:</p>
+<p>If <code>agent_participant_id</code> is set AND <code>accumulated_user_agent_reward</code> &gt; 0:</p>
 <ul>
 <li><code>agent_trust_deposit</code> = <code>accumulated_user_agent_reward</code> × <code>GlobalVariables.trust_deposit_rate</code></li>
 <li><code>agent_fees_to_account</code> = <code>accumulated_user_agent_reward</code> - <code>agent_trust_deposit</code></li>
-<li>Transfer <code>agent_fees_to_account</code> to <code>agent_perm.corporation</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
-<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>agent_perm.corporation</code> by <code>agent_trust_deposit</code>. Increase <code>agent_perm.deposit</code> by the same value.</li>
+<li>Transfer <code>agent_fees_to_account</code> to <code>agent_participant.corporation</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
+<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>agent_participant.corporation</code> by <code>agent_trust_deposit</code>. Increase <code>agent_participant.deposit</code> by the same value.</li>
 </ul>
 <p><strong>Wallet Agent Reward:</strong></p>
-<p>If <code>wallet_agent_perm_id</code> is set AND <code>accumulated_wallet_agent_reward</code> &gt; 0:</p>
+<p>If <code>wallet_agent_participant_id</code> is set AND <code>accumulated_wallet_agent_reward</code> &gt; 0:</p>
 <ul>
 <li><code>wallet_agent_trust_deposit</code> = <code>accumulated_wallet_agent_reward</code> × <code>GlobalVariables.trust_deposit_rate</code></li>
 <li><code>wallet_agent_fees_to_account</code> = <code>accumulated_wallet_agent_reward</code> - <code>wallet_agent_trust_deposit</code></li>
-<li>Transfer <code>wallet_agent_fees_to_account</code> to <code>wallet_agent_perm.corporation</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
-<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>wallet_agent_perm.corporation</code> by <code>wallet_agent_trust_deposit</code>. Increase <code>wallet_agent_perm.deposit</code> by the same value.</li>
+<li>Transfer <code>wallet_agent_fees_to_account</code> to <code>wallet_agent_participant.corporation</code> in <a class="term-reference" href="#term:native-denom">native denom</a>.</li>
+<li>Use [MOD-TD-MSG-1] to increase the <a class="term-reference" href="#term:trust-deposit">trust deposit</a> of <code>wallet_agent_participant.corporation</code> by <code>wallet_agent_trust_deposit</code>. Increase <code>wallet_agent_participant.deposit</code> by the same value.</li>
 </ul>
 <hr>
 <p><strong>Step 3: Create or update session records</strong></p>
 <blockquote>
 <p>Now that all transfers have been done, we can create the entries</p>
 </blockquote>
-<p>Create a <code>PermissionSessionRecord</code> <code>cspsr</code>:</p>
+<p>Create a <code>ParticipantSessionRecord</code> <code>cspsr</code>:</p>
 <ul>
 <li><code>cspsr.created</code>: <code>now</code></li>
-<li><code>cspsr.issuer_perm_id</code>: <code>issuer_perm_id</code></li>
-<li><code>cspsr.verifier_perm_id</code>: <code>verifier_perm_id</code></li>
-<li><code>cspsr.agent_perm_id</code>: <code>agent_perm_id</code></li>
-<li><code>cspsr.wallet_agent_perm_id</code>: <code>wallet_agent_perm_id</code></li>
+<li><code>cspsr.issuer_participant_id</code>: <code>issuer_participant_id</code></li>
+<li><code>cspsr.verifier_participant_id</code>: <code>verifier_participant_id</code></li>
+<li><code>cspsr.agent_participant_id</code>: <code>agent_participant_id</code></li>
+<li><code>cspsr.wallet_agent_participant_id</code>: <code>wallet_agent_participant_id</code></li>
 </ul>
-<p>If new, create entry <code>PermissionSession</code> <code>session</code>:</p>
+<p>If new, create entry <code>ParticipantSession</code> <code>session</code>:</p>
 <ul>
 <li><code>session.id</code>: <code>id</code></li>
 <li><code>session.corporation</code>: <code>corporation</code></li>
@@ -3891,82 +4349,82 @@ else MUST abort.</p>
 </ul>
 <p>then, add the <code>cspsr</code> to <code>session.session_records</code></p>
 <p>if current transaction if for issuance of a credential, persist the digest SRI by calling <a href="#mod-di-msg-1-store-digest" >[MOD-DI-MSG-1]</a>.</p>
-<div id="warning-49" class="notice warning"><a class="notice-link" href="#warning-49">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_perm_id</code> OR <code>verifier_perm_id</code></p>
+<div id="warning-49" class="notice warning"><a class="notice-link" href="#warning-49">WARNING</a><p><code>session.authz[]</code> can contain null <code>issuer_participant_id</code> OR <code>verifier_participant_id</code></p>
 </div>
-<h4 id="mod-perm-msg-11-update-permission-module-parameters"><a class="toc-anchor" href="#mod-perm-msg-11-update-permission-module-parameters" >§</a> [MOD-PERM-MSG-11] Update Permission Module Parameters</h4>
-<p>Update Permission Module Parameters.</p>
+<h4 id="mod-pp-msg-11-update-participant-module-parameters"><a class="toc-anchor" href="#mod-pp-msg-11-update-participant-module-parameters" >§</a> [MOD-PP-MSG-11] Update Participant Module Parameters</h4>
+<p>Update Participant Module Parameters.</p>
 <p>Can only be executed through a governance proposal.</p>
-<h5 id="mod-perm-msg-11-1-update-permission-module-parameters-parameters"><a class="toc-anchor" href="#mod-perm-msg-11-1-update-permission-module-parameters-parameters" >§</a> [MOD-PERM-MSG-11-1] Update Permission Module Parameters parameters</h5>
+<h5 id="mod-pp-msg-11-1-update-participant-module-parameters-parameters"><a class="toc-anchor" href="#mod-pp-msg-11-1-update-participant-module-parameters-parameters" >§</a> [MOD-PP-MSG-11-1] Update Participant Module Parameters parameters</h5>
 <ul>
 <li><code>params</code> (KeySet&lt;String, String&gt;): the parameters to update and their values.</li>
 </ul>
-<h5 id="mod-perm-msg-11-2-update-permission-module-parameters-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-11-2-update-permission-module-parameters-precondition-checks" >§</a> [MOD-PERM-MSG-11-2] Update Permission Module Parameters precondition checks</h5>
+<h5 id="mod-pp-msg-11-2-update-participant-module-parameters-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-11-2-update-participant-module-parameters-precondition-checks" >§</a> [MOD-PP-MSG-11-2] Update Participant Module Parameters precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-11-2-1-update-permission-module-parameters-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-11-2-1-update-permission-module-parameters-basic-checks" >§</a> [MOD-PERM-MSG-11-2-1] Update Permission Module Parameters basic checks</h6>
+<h6 id="mod-pp-msg-11-2-1-update-participant-module-parameters-basic-checks"><a class="toc-anchor" href="#mod-pp-msg-11-2-1-update-participant-module-parameters-basic-checks" >§</a> [MOD-PP-MSG-11-2-1] Update Participant Module Parameters basic checks</h6>
 <ul>
 <li><code>params</code>: size of <code>params</code> MUST be greater than 0. For each <code>param</code> &lt;<code>key</code>, <code>value</code>&gt; <code>key</code> MUST exist, else abort.</li>
 </ul>
-<h6 id="mod-perm-msg-11-2-2-update-permission-module-parameters-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-11-2-2-update-permission-module-parameters-fee-checks" >§</a> [MOD-PERM-MSG-11-2-2] Update Permission Module Parameters fee checks</h6>
+<h6 id="mod-pp-msg-11-2-2-update-participant-module-parameters-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-11-2-2-update-participant-module-parameters-fee-checks" >§</a> [MOD-PP-MSG-11-2-2] Update Participant Module Parameters fee checks</h6>
 <p>provided transaction fees MUST be sufficient for execution</p>
-<h5 id="mod-perm-msg-11-3-update-permission-module-parameters-execution"><a class="toc-anchor" href="#mod-perm-msg-11-3-update-permission-module-parameters-execution" >§</a> [MOD-PERM-MSG-11-3] Update Permission Module Parameters execution</h5>
+<h5 id="mod-pp-msg-11-3-update-participant-module-parameters-execution"><a class="toc-anchor" href="#mod-pp-msg-11-3-update-participant-module-parameters-execution" >§</a> [MOD-PP-MSG-11-3] Update Participant Module Parameters execution</h5>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <p>for each parameter <code>param</code> &lt;<code>key</code>, <code>value</code>&gt; in <code>parameters</code>:</p>
 <ul>
 <li>update parameter set value = <code>value</code> where key = <code>key</code>.</li>
 </ul>
-<h4 id="mod-perm-msg-12-slash-permission-trust-deposit"><a class="toc-anchor" href="#mod-perm-msg-12-slash-permission-trust-deposit" >§</a> [MOD-PERM-MSG-12] Slash Permission Trust Deposit</h4>
+<h4 id="mod-pp-msg-12-slash-participant-trust-deposit"><a class="toc-anchor" href="#mod-pp-msg-12-slash-participant-trust-deposit" >§</a> [MOD-PP-MSG-12] Slash Participant Trust Deposit</h4>
 <p>This method can only be called by either:</p>
 <ul>
-<li>a <code>corporation</code> ancestor validator of this permission;</li>
-<li>the <code>corporation</code> controller of the <code>TrustRegistry</code> object, owner of the corresponding credential schema.</li>
+<li>a <code>corporation</code> ancestor validator of this <code>Participant</code> entry;</li>
+<li>the <code>corporation</code> controller of the <code>Ecosystem</code> object, owner of the corresponding credential schema.</li>
 </ul>
-<h5 id="mod-perm-msg-12-1-slash-permission-trust-deposit-parameters"><a class="toc-anchor" href="#mod-perm-msg-12-1-slash-permission-trust-deposit-parameters" >§</a> [MOD-PERM-MSG-12-1] Slash Permission Trust Deposit parameters</h5>
+<h5 id="mod-pp-msg-12-1-slash-participant-trust-deposit-parameters"><a class="toc-anchor" href="#mod-pp-msg-12-1-slash-participant-trust-deposit-parameters" >§</a> [MOD-PP-MSG-12-1] Slash Participant Trust Deposit parameters</h5>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): id of the permission;</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): id of the <code>Participant</code> entry;</li>
 <li><code>amount</code> (number) (<em>mandatory</em>): the amount to slash</li>
 </ul>
-<h5 id="mod-perm-msg-12-2-slash-permission-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-12-2-slash-permission-trust-deposit-precondition-checks" >§</a> [MOD-PERM-MSG-12-2] Slash Permission Trust Deposit precondition checks</h5>
+<h5 id="mod-pp-msg-12-2-slash-participant-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-12-2-slash-participant-trust-deposit-precondition-checks" >§</a> [MOD-PP-MSG-12-2] Slash Participant Trust Deposit precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-12-2-1-slash-permission-trust-deposit-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-12-2-1-slash-permission-trust-deposit-basic-checks" >§</a> [MOD-PERM-MSG-12-2-1] Slash Permission Trust Deposit basic checks</h6>
+<h6 id="mod-pp-msg-12-2-1-slash-participant-trust-deposit-basic-checks"><a class="toc-anchor" href="#mod-pp-msg-12-2-1-slash-participant-trust-deposit-basic-checks" >§</a> [MOD-PP-MSG-12-2-1] Slash Participant Trust Deposit basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
 <li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>id</code> MUST be a valid uint64.</li>
-<li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>. If no entry found, abort.</li>
-<li><code>amount</code> MUST be lower or equal to <code>applicant_perm.deposit</code> else MUST abort.</li>
+<li>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>. If no entry found, abort.</li>
+<li><code>amount</code> MUST be lower or equal to <code>applicant_participant.deposit</code> else MUST abort.</li>
 </ul>
-<div id="note-88" class="notice note"><a class="notice-link" href="#note-88">NOTE</a><p>Even if the permission has expired or is revoked, it is still possible to slash it.</p>
+<div id="note-88" class="notice note"><a class="notice-link" href="#note-88">NOTE</a><p>Even if the <code>Participant</code> entry has expired or is revoked, it is still possible to slash it.</p>
 </div>
-<h6 id="mod-perm-msg-12-2-2-slash-permission-trust-deposit-validator-perms"><a class="toc-anchor" href="#mod-perm-msg-12-2-2-slash-permission-trust-deposit-validator-perms" >§</a> [MOD-PERM-MSG-12-2-2] Slash Permission Trust Deposit validator perms</h6>
+<h6 id="mod-pp-msg-12-2-2-slash-participant-trust-deposit-validator-perms"><a class="toc-anchor" href="#mod-pp-msg-12-2-2-slash-participant-trust-deposit-validator-perms" >§</a> [MOD-PP-MSG-12-2-2] Slash Participant Trust Deposit validator perms</h6>
 <p>Either Option #1, or #2 MUST return true, else abort.</p>
 <p><em>Option #1</em>: executed by a validator ancestor</p>
-<p>if <code>applicant_perm.validator_perm_id</code> is defined:</p>
+<p>if <code>applicant_participant.validator_participant_id</code> is defined:</p>
 <ul>
-<li>set <code>validator_perm</code> = <code>applicant_perm</code></li>
-<li>while <code>validator_perm.validator_perm_id</code> is defined,
+<li>set <code>validator_participant</code> = <code>applicant_participant</code></li>
+<li>while <code>validator_participant.validator_participant_id</code> is defined,
 <ul>
-<li>load <code>validator_perm</code> from <code>validator_perm.validator_perm_id</code>.</li>
-<li>if <code>validator_perm</code> is a <a class="term-reference" href="#term:active-permission">active permission</a> and <code>validator_perm.corporation</code> is who is running the method, =&gt; return true.</li>
+<li>load <code>validator_participant</code> from <code>validator_participant.validator_participant_id</code>.</li>
+<li>if <code>validator_participant</code> is a <a class="term-reference" href="#term:active-participant">active participant</a> and <code>validator_participant.corporation</code> is who is running the method, =&gt; return true.</li>
 </ul>
 </li>
 <li>end</li>
 <li>return false.</li>
 </ul>
-<p><em>Option #2</em>: executed by <code>TrustRegistry</code> controller</p>
+<p><em>Option #2</em>: executed by <code>Ecosystem</code> controller</p>
 <ul>
-<li>load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_perm.schema_id</code></li>
-<li>load <code>TrustRegistry</code> <code>tr</code> from <code>cs.tr_id</code></li>
-<li>if <code>corporation</code> running the method is <code>tr.corporation</code>, return true.</li>
+<li>load <code>CredentialSchema</code> <code>cs</code> from <code>applicant_participant.schema_id</code></li>
+<li>load <code>Ecosystem</code> <code>tr</code> from <code>cs.ecosystem_id</code></li>
+<li>if <code>corporation</code> running the method is <code>ecosystem.corporation</code>, return true.</li>
 <li>else return false.</li>
 </ul>
-<h6 id="mod-perm-msg-12-2-3-slash-permission-trust-deposit-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-12-2-3-slash-permission-trust-deposit-fee-checks" >§</a> [MOD-PERM-MSG-12-2-3] Slash Permission Trust Deposit fee checks</h6>
+<h6 id="mod-pp-msg-12-2-3-slash-participant-trust-deposit-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-12-2-3-slash-participant-trust-deposit-fee-checks" >§</a> [MOD-PP-MSG-12-2-3] Slash Participant Trust Deposit fee checks</h6>
 <p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h5 id="mod-perm-msg-12-3-slash-permission-trust-deposit-execution"><a class="toc-anchor" href="#mod-perm-msg-12-3-slash-permission-trust-deposit-execution" >§</a> [MOD-PERM-MSG-12-3] Slash Permission Trust Deposit execution</h5>
+<h5 id="mod-pp-msg-12-3-slash-participant-trust-deposit-execution"><a class="toc-anchor" href="#mod-pp-msg-12-3-slash-participant-trust-deposit-execution" >§</a> [MOD-PP-MSG-12-3] Slash Participant Trust Deposit execution</h5>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
@@ -3974,93 +4432,93 @@ else MUST abort.</p>
 <p>define <code>now</code>: current timestamp.</p>
 </li>
 <li>
-<p>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>.</p>
+<p>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>.</p>
 </li>
 <li>
-<p>Load <code>Permission</code> entry <code>validator_perm</code> from <code>applicant_perm.validator_perm_id</code>.</p>
+<p>Load <code>Participant</code> entry <code>validator_participant</code> from <code>applicant_participant.validator_participant_id</code>.</p>
 </li>
 <li>
-<p>set <code>applicant_perm.slashed</code> to <code>now</code></p>
+<p>set <code>applicant_participant.slashed</code> to <code>now</code></p>
 </li>
 <li>
-<p>set <code>applicant_perm.modified</code> to <code>now</code></p>
+<p>set <code>applicant_participant.modified</code> to <code>now</code></p>
 </li>
 <li>
-<p>set <code>applicant_perm.slashed_deposit</code> to <code>applicant_perm.slashed_deposit</code> + <code>amount</code></p>
+<p>set <code>applicant_participant.slashed_deposit</code> to <code>applicant_participant.slashed_deposit</code> + <code>amount</code></p>
 </li>
 </ul>
-<p>use <a href="#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit" >MOD-TD-MSG-7</a> to burn the slashed <code>amount</code> from the trust deposit of <code>applicant_perm.corporation</code>.</p>
-<p>Call <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a> Revoke VS Operator Authorization with <code>perm_id = applicant_perm.id</code> to remove any authorization record for this permission. The call is a no-op if no record exists.</p>
-<h4 id="mod-perm-msg-13-repay-permission-slashed-trust-deposit"><a class="toc-anchor" href="#mod-perm-msg-13-repay-permission-slashed-trust-deposit" >§</a> [MOD-PERM-MSG-13] Repay Permission Slashed Trust Deposit</h4>
-<p>This method can only be called by the <code>corporation</code> that want to repay the deposit of a slashed perm they own. This won’t make the perm re-usable: it will be needed for the <code>corporation</code> associated to this permission to request a new permission, as slashed permissions cannot be revived (same happen for revoked, etc…).</p>
-<p>Nevertheless, to get a new permission for a given ecosystem, it is needed, using this method, to repay the deposit of a slashed permission first.</p>
-<h5 id="mod-perm-msg-13-1-repay-permission-slashed-trust-deposit-parameters"><a class="toc-anchor" href="#mod-perm-msg-13-1-repay-permission-slashed-trust-deposit-parameters" >§</a> [MOD-PERM-MSG-13-1] Repay Permission Slashed Trust Deposit parameters</h5>
+<p>use <a href="#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit" >MOD-TD-MSG-7</a> to burn the slashed <code>amount</code> from the trust deposit of <code>applicant_participant.corporation</code>.</p>
+<p>Call <a href="#mod-de-msg-6-revoke-vs-operator-authorization" >[MOD-DE-MSG-6]</a> Revoke VS Operator Authorization with <code>participant_id = applicant_participant.id</code> to remove any authorization record for this <code>Participant</code> entry. The call is a no-op if no record exists.</p>
+<h4 id="mod-pp-msg-13-repay-participant-slashed-trust-deposit"><a class="toc-anchor" href="#mod-pp-msg-13-repay-participant-slashed-trust-deposit" >§</a> [MOD-PP-MSG-13] Repay Participant Slashed Trust Deposit</h4>
+<p>This method can only be called by the <code>corporation</code> that wants to repay the deposit of a slashed <code>Participant</code> entry they own. This won’t make the <code>Participant</code> entry re-usable: it will be needed for the <code>corporation</code> associated to this <code>Participant</code> entry to request a new <code>Participant</code> entry, as slashed <code>Participant</code> entries cannot be revived (same happens for revoked, etc.).</p>
+<p>Nevertheless, to get a new <code>Participant</code> entry for a given ecosystem, it is needed, using this method, to repay the deposit of a slashed <code>Participant</code> entry first.</p>
+<h5 id="mod-pp-msg-13-1-repay-participant-slashed-trust-deposit-parameters"><a class="toc-anchor" href="#mod-pp-msg-13-1-repay-participant-slashed-trust-deposit-parameters" >§</a> [MOD-PP-MSG-13-1] Repay Participant Slashed Trust Deposit parameters</h5>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): id of the permission</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): id of the <code>Participant</code> entry</li>
 </ul>
-<h5 id="mod-perm-msg-13-2-repay-permission-slashed-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-13-2-repay-permission-slashed-trust-deposit-precondition-checks" >§</a> [MOD-PERM-MSG-13-2] Repay Permission Slashed Trust Deposit precondition checks</h5>
+<h5 id="mod-pp-msg-13-2-repay-participant-slashed-trust-deposit-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-13-2-repay-participant-slashed-trust-deposit-precondition-checks" >§</a> [MOD-PP-MSG-13-2] Repay Participant Slashed Trust Deposit precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-13-2-1-repay-permission-slashed-trust-deposit-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-13-2-1-repay-permission-slashed-trust-deposit-basic-checks" >§</a> [MOD-PERM-MSG-13-2-1] Repay Permission Slashed Trust Deposit basic checks</h6>
+<h6 id="mod-pp-msg-13-2-1-repay-participant-slashed-trust-deposit-basic-checks"><a class="toc-anchor" href="#mod-pp-msg-13-2-1-repay-participant-slashed-trust-deposit-basic-checks" >§</a> [MOD-PP-MSG-13-2-1] Repay Participant Slashed Trust Deposit basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
 <li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
 <li><code>id</code> MUST be a valid uint64.</li>
-<li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>. If no entry found, abort.</li>
-<li>if <code>applicant_perm.corporation</code> is not equal to <code>corporation</code>, abort.</li>
+<li>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>. If no entry found, abort.</li>
+<li>if <code>applicant_participant.corporation</code> is not equal to <code>corporation</code>, abort.</li>
 </ul>
-<h6 id="mod-perm-msg-13-2-2-repay-permission-slashed-trust-deposit-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-13-2-2-repay-permission-slashed-trust-deposit-fee-checks" >§</a> [MOD-PERM-MSG-13-2-2] Repay Permission Slashed Trust Deposit fee checks</h6>
+<h6 id="mod-pp-msg-13-2-2-repay-participant-slashed-trust-deposit-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-13-2-2-repay-participant-slashed-trust-deposit-fee-checks" >§</a> [MOD-PP-MSG-13-2-2] Repay Participant Slashed Trust Deposit fee checks</h6>
 <ul>
 <li>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>;</li>
-<li><code>corporation</code> MUST have at least <code>applicant_perm.slashed_deposit</code> in its account balance, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</li>
+<li><code>corporation</code> MUST have at least <code>applicant_participant.slashed_deposit</code> in its account balance, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</li>
 </ul>
-<h5 id="mod-perm-msg-13-3-repay-permission-slashed-trust-deposit-execution"><a class="toc-anchor" href="#mod-perm-msg-13-3-repay-permission-slashed-trust-deposit-execution" >§</a> [MOD-PERM-MSG-13-3] Repay Permission Slashed Trust Deposit execution</h5>
+<h5 id="mod-pp-msg-13-3-repay-participant-slashed-trust-deposit-execution"><a class="toc-anchor" href="#mod-pp-msg-13-3-repay-participant-slashed-trust-deposit-execution" >§</a> [MOD-PP-MSG-13-3] Repay Participant Slashed Trust Deposit execution</h5>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>define <code>now</code>: current timestamp.</li>
 </ul>
-<p>use <a href="#mod-td-msg-1-adjust-trust-deposit" >Adjust Trust Deposit</a> to transfer <code>applicant_perm.slashed_deposit</code> to trust deposit of <code>applicant_perm.corporation</code>.</p>
+<p>use <a href="#mod-td-msg-1-adjust-trust-deposit" >Adjust Trust Deposit</a> to transfer <code>applicant_participant.slashed_deposit</code> to trust deposit of <code>applicant_participant.corporation</code>.</p>
 <ul>
-<li>Load <code>Permission</code> entry <code>applicant_perm</code> from <code>id</code>.</li>
-<li>set <code>applicant_perm.repaid</code> to <code>now</code></li>
-<li>set <code>applicant_perm.modified</code> to <code>now</code></li>
-<li>set <code>applicant_perm.repaid_deposit</code> to <code>applicant_perm.slashed_deposit</code>.</li>
+<li>Load <code>Participant</code> entry <code>applicant_participant</code> from <code>id</code>.</li>
+<li>set <code>applicant_participant.repaid</code> to <code>now</code></li>
+<li>set <code>applicant_participant.modified</code> to <code>now</code></li>
+<li>set <code>applicant_participant.repaid_deposit</code> to <code>applicant_participant.slashed_deposit</code>.</li>
 </ul>
-<h4 id="mod-perm-msg-14-self-create-permission"><a class="toc-anchor" href="#mod-perm-msg-14-self-create-permission" >§</a> [MOD-PERM-MSG-14] Self Create Permission</h4>
+<h4 id="mod-pp-msg-14-self-create-participant"><a class="toc-anchor" href="#mod-pp-msg-14-self-create-participant" >§</a> [MOD-PP-MSG-14] Self Create Participant</h4>
 <p>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</p>
-<p>This simple permission creation method can be used to self-create an ISSUER (resp. VERIFIER) permission if issuance mode (resp. verification mode) is set to <code>OPEN</code> for a given schema. As permissions are the anchor of ecosystem trust deposit operations, it is required for an issuer/verifier candidate to self-create a permission for being issuer or verifier of a given schema.</p>
-<div id="note-89" class="notice note"><a class="notice-link" href="#note-89">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their permission may be revoked by ecosystem governance authority and their deposit slashed.</p>
+<p>This simple <code>Participant</code>-creation method can be used to self-create an ISSUER (resp. VERIFIER) <code>Participant</code> entry if issuance mode (resp. verification mode) is set to <code>OPEN</code> for a given schema. As <code>Participant</code> entries are the anchor of ecosystem trust deposit operations, it is required for an issuer/verifier candidate to self-create a <code>Participant</code> entry for being issuer or verifier of a given schema.</p>
+<div id="note-89" class="notice note"><a class="notice-link" href="#note-89">NOTE</a><p>Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their <code>Participant</code> entry may be revoked by ecosystem governance authority and their deposit slashed.</p>
 </div>
-<h5 id="mod-perm-msg-14-1-self-create-permission-parameters"><a class="toc-anchor" href="#mod-perm-msg-14-1-self-create-permission-parameters" >§</a> [MOD-PERM-MSG-14-1] Self Create Permission parameters</h5>
+<h5 id="mod-pp-msg-14-1-self-create-participant-parameters"><a class="toc-anchor" href="#mod-pp-msg-14-1-self-create-participant-parameters" >§</a> [MOD-PP-MSG-14-1] Self Create Participant parameters</h5>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>type</code> (PermissionType) (<em>mandatory</em>): ISSUER or VERIFIER.</li>
-<li><code>validator_perm_id</code> (uint64) (<em>mandatory</em>): MUST be an ECOSYSTEM <a class="term-reference" href="#term:active-permission">active permission</a> or <a class="term-reference" href="#term:future-permission">future permission</a>.</li>
-<li><code>vs_operator</code> (account) (<em>optional</em>): the account we want to authorize to create permission sessions linked to this permission. <strong>Required</strong> for payment delegation.</li>
+<li><code>role</code> (ParticipantRole) (<em>mandatory</em>): ISSUER or VERIFIER.</li>
+<li><code>validator_participant_id</code> (uint64) (<em>mandatory</em>): MUST be an ECOSYSTEM <a class="term-reference" href="#term:active-participant">active participant</a> or <a class="term-reference" href="#term:future-participant">future participant</a>.</li>
+<li><code>vs_operator</code> (account) (<em>optional</em>): the account we want to authorize to create <code>ParticipantSession</code> entries linked to this <code>Participant</code> entry. <strong>Required</strong> for payment delegation.</li>
 <li><code>did</code> (string) (<em>mandatory</em>): <a class="term-reference" href="#term:did">DID</a> of the VS grantee service.</li>
 <li><code>effective_from</code> (timestamp) (<em>optional</em>): timestamp from when (exclusive) this Perm is effective. MUST be in the future.</li>
 <li><code>effective_until</code> (timestamp) (<em>optional</em>): timestamp until when (exclusive) this Perm is effective, null if it doesn’t expire. If not null, MUST be greater than <code>effective_from</code>.</li>
 <li><code>verification_fees</code> (number) (<em>optional</em>): price to pay by the verifier of a credential of this schema to the grantee of this ISSUER perm when a credential is verified, in the denom specified in the credential schema. Default to 0.</li>
-<li><code>validation_fees</code> (number) (<em>optional</em>): price to pay by the holder of a credential of this schema to the issuer when executing a validation process to obtain a credential, in the denom specified in the credential schema. Default to 0.</li>
+<li><code>validation_fees</code> (number) (<em>optional</em>): price to pay by the holder of a credential of this schema to the issuer when executing an onboarding process to obtain a credential, in the denom specified in the credential schema. Default to 0.</li>
 </ul>
-<p>The following VS Operator Authorization parameters are <strong>optional</strong> and collectively define the initial <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> for this permission. Presence of <code>vs_operator_authz_msg_types</code> is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is <strong>frozen at creation time</strong> and cannot be modified later; to change it, the permission MUST be revoked and re-created.</p>
+<p>The following VS Operator Authorization parameters are <strong>optional</strong> and collectively define the initial <a href="#participantauthorizationrecord" >ParticipantAuthorizationRecord</a> for this <code>Participant</code> entry. Presence of <code>vs_operator_authz_msg_types</code> is the trigger: if it is not provided, no authorization record is created and the <code>Participant</code> entry operates in manual mode. VSOA configuration is <strong>frozen at creation time</strong> and cannot be modified later; to change it, the <code>Participant</code> entry MUST be revoked and re-created.</p>
 <ul>
-<li><code>vs_operator_authz_msg_types[]</code> (msg_type[]) (<em>optional</em>): list of VPR delegable message types <code>vs_operator</code> is authorized to execute on behalf of <code>corporation</code> in the context of this permission. If provided, a <code>PermissionAuthorizationRecord</code> is created (see execution below) and <code>vs_operator</code> MUST be specified.</li>
-<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds <code>vs_operator</code> is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.</li>
-<li><code>vs_operator_authz_with_feegrant</code> (bool) (<em>optional</em>, default: false): if true, <code>corporation</code> pays transaction fees for <code>vs_operator</code> via an on-chain <code>FeeGrant</code> when executing authorized messages in the context of this permission.</li>
-<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of transaction fees that can be spent by <code>vs_operator</code> (paid by <code>corporation</code> via fee grant) in the context of this permission.</li>
-<li><code>vs_operator_authz_period</code> (duration) (<em>optional</em>): reset period for <code>vs_operator_authz_spend_limit</code> and <code>vs_operator_authz_fee_spend_limit</code> in the context of this permission.</li>
+<li><code>vs_operator_authz_msg_types[]</code> (msg_type[]) (<em>optional</em>): list of VPR delegable message types <code>vs_operator</code> is authorized to execute on behalf of <code>corporation</code> in the context of this <code>Participant</code> entry. If provided, a <code>ParticipantAuthorizationRecord</code> is created (see execution below) and <code>vs_operator</code> MUST be specified.</li>
+<li><code>vs_operator_authz_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum amount of funds <code>vs_operator</code> is allowed to spend in the context of this <code>Participant</code> entry as a direct consequence of executing authorized messages.</li>
+<li><code>vs_operator_authz_with_feegrant</code> (bool) (<em>optional</em>, default: false): if true, <code>corporation</code> pays transaction fees for <code>vs_operator</code> via an on-chain <code>FeeGrant</code> when executing authorized messages in the context of this <code>Participant</code> entry.</li>
+<li><code>vs_operator_authz_fee_spend_limit</code> (DenomAmount[]) (<em>optional</em>): maximum total amount of transaction fees that can be spent by <code>vs_operator</code> (paid by <code>corporation</code> via fee grant) in the context of this <code>Participant</code> entry.</li>
+<li><code>vs_operator_authz_period</code> (duration) (<em>optional</em>): reset period for <code>vs_operator_authz_spend_limit</code> and <code>vs_operator_authz_fee_spend_limit</code> in the context of this <code>Participant</code> entry.</li>
 </ul>
-<p>Permitted message types to be set in <code>vs_operator_authz_msg_types</code> depends on <code>type</code>.</p>
+<p>Permitted message types to be set in <code>vs_operator_authz_msg_types</code> depends on <code>role</code>.</p>
 <table>
 <thead>
 <tr>
-<th>Permission type</th>
+<th>Participant role</th>
 <th>Permitted Messages</th>
 </tr>
 </thead>
@@ -4071,294 +4529,294 @@ else MUST abort.</p>
 </tr>
 <tr>
 <td>ISSUER</td>
-<td>CreateOrUpdatePermissionSession, SetPermissionVPtoValidated</td>
+<td>CreateOrUpdateParticipantSession, SetParticipantOPtoValidated</td>
 </tr>
 <tr>
 <td>VERIFIER</td>
-<td>CreateOrUpdatePermissionSession</td>
+<td>CreateOrUpdateParticipantSession</td>
 </tr>
 </tbody>
 </table>
-<h5 id="mod-perm-msg-14-2-self-create-permission-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-14-2-self-create-permission-precondition-checks" >§</a> [MOD-PERM-MSG-14-2] Self Create Permission precondition checks</h5>
+<h5 id="mod-pp-msg-14-2-self-create-participant-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-14-2-self-create-participant-precondition-checks" >§</a> [MOD-PP-MSG-14-2] Self Create Participant precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-14-2-1-self-create-permission-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-14-2-1-self-create-permission-basic-checks" >§</a> [MOD-PERM-MSG-14-2-1] Self Create Permission basic checks</h6>
+<h6 id="mod-pp-msg-14-2-1-self-create-participant-basic-checks"><a class="toc-anchor" href="#mod-pp-msg-14-2-1-self-create-participant-basic-checks" >§</a> [MOD-PP-MSG-14-2-1] Self Create Participant basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<p>Load <code>Permission</code> <code>validator_perm</code> from <code>validator_perm_id</code>.</p>
+<p>Load <code>Participant</code> <code>validator_participant</code> from <code>validator_participant_id</code>.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
 <li><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</li>
-<li><code>type</code> (PermissionType) (<em>mandatory</em>): MUST be ISSUER or VERIFIER, else abort.</li>
-<li><code>validator_perm_id</code> (uint64) (<em>mandatory</em>): <code>validator_perm</code> MUST be an ECOSYSTEM <a class="term-reference" href="#term:active-permission">active permission</a> or <a class="term-reference" href="#term:future-permission">future permission</a>.</li>
+<li><code>role</code> (ParticipantRole) (<em>mandatory</em>): MUST be ISSUER or VERIFIER, else abort.</li>
+<li><code>validator_participant_id</code> (uint64) (<em>mandatory</em>): <code>validator_participant</code> MUST be an ECOSYSTEM <a class="term-reference" href="#term:active-participant">active participant</a> or <a class="term-reference" href="#term:future-participant">future participant</a>.</li>
 <li><code>vs_operator</code> (account) (<em>optional</em>): no check required.</li>
 <li><code>did</code>, MUST conform to the DID Syntax, as specified [<a class="spec-reference" href="#ref:DID-CORE">DID-CORE</a>].</li>
 <li><code>effective_from</code> MUST be in the future AND
 <ul>
-<li>MUST be greater or equal to <code>validator_perm.effective_from</code> AND</li>
-<li>if <code>validator_perm.effective_until</code> is not null, MUST be lower than <code>validator_perm.effective_until</code></li>
+<li>MUST be greater or equal to <code>validator_participant.effective_from</code> AND</li>
+<li>if <code>validator_participant.effective_until</code> is not null, MUST be lower than <code>validator_participant.effective_until</code></li>
 </ul>
 </li>
 <li><code>effective_until</code>:
 <ul>
-<li>if null, <code>validator_perm.effective_until</code> MUST be NULL</li>
-<li>else if not null, must be greater than <code>effective_from</code> AND if <code>validator_perm.effective_until</code> is not null, MUST be lower or equal to <code>validator_perm.effective_until</code></li>
+<li>if null, <code>validator_participant.effective_until</code> MUST be NULL</li>
+<li>else if not null, must be greater than <code>effective_from</code> AND if <code>validator_participant.effective_until</code> is not null, MUST be lower or equal to <code>validator_participant.effective_until</code></li>
 </ul>
 </li>
-<li><code>verification_fees</code> (number) (<em>optional</em>): If specified, MUST be &gt;= 0 and MUST be a ISSUER permission.</li>
-<li><code>validation_fees</code> (number) (<em>optional</em>): If specified, MUST be &gt;= 0 and MUST be a ISSUER permission.</li>
-<li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-perm-msg-14-1-self-create-permission-parameters" >MOD-PERM-MSG-14-1</a>.</li>
+<li><code>verification_fees</code> (number) (<em>optional</em>): If specified, MUST be &gt;= 0 and the <code>Participant</code> entry MUST be an ISSUER.</li>
+<li><code>validation_fees</code> (number) (<em>optional</em>): If specified, MUST be &gt;= 0 and the <code>Participant</code> entry MUST be an ISSUER.</li>
+<li>VS Operator Authorization parameters: if any of <code>vs_operator_authz_*</code> parameters is provided, <code>vs_operator_authz_msg_types</code> MUST also be provided and <code>vs_operator</code> MUST NOT be null, else abort. If <code>vs_operator_authz_msg_types</code> is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in <a href="#mod-pp-msg-14-1-self-create-participant-parameters" >MOD-PP-MSG-14-1</a>.</li>
 </ul>
-<h6 id="mod-perm-msg-14-2-2-self-create-permission-permission-checks"><a class="toc-anchor" href="#mod-perm-msg-14-2-2-self-create-permission-permission-checks" >§</a> [MOD-PERM-MSG-14-2-2] Self Create Permission permission checks</h6>
+<h6 id="mod-pp-msg-14-2-2-self-create-participant-permission-checks"><a class="toc-anchor" href="#mod-pp-msg-14-2-2-self-create-participant-permission-checks" >§</a> [MOD-PP-MSG-14-2-2] Self Create Participant permission checks</h6>
 <p>To execute this method, <a class="term-reference" href="#term:account">account</a> MUST match at least one these rules, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li>The related <code>CredentialSchema</code> entry is loaded with <code>validator_perm.schema_id</code>, and will be named <code>cs</code> in this section.</li>
-<li>if <code>type</code> is equal to ISSUER: if <code>cs.issuer_onboarding_mode</code> is not equal to OPEN, MUST abort.</li>
-<li>if <code>type</code> is equal to VERIFIER: if <code>cs.verifier_onboarding_mode</code> is not equal to OPEN, MUST abort.</li>
-<li>if <code>type</code> is equal to VERIFIER and <code>validation_fees</code> is specified and different than 0, MUST abort.</li>
-<li>if <code>type</code> is equal to VERIFIER and <code>verification_fees</code> is specified and different than 0, MUST abort.</li>
+<li>The related <code>CredentialSchema</code> entry is loaded with <code>validator_participant.schema_id</code>, and will be named <code>cs</code> in this section.</li>
+<li>if <code>role</code> is equal to ISSUER: if <code>cs.issuer_onboarding_mode</code> is not equal to OPEN, MUST abort.</li>
+<li>if <code>role</code> is equal to VERIFIER: if <code>cs.verifier_onboarding_mode</code> is not equal to OPEN, MUST abort.</li>
+<li>if <code>role</code> is equal to VERIFIER and <code>validation_fees</code> is specified and different than 0, MUST abort.</li>
+<li>if <code>role</code> is equal to VERIFIER and <code>verification_fees</code> is specified and different than 0, MUST abort.</li>
 </ul>
-<h6 id="mod-perm-msg-14-2-3-self-create-permission-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-14-2-3-self-create-permission-fee-checks" >§</a> [MOD-PERM-MSG-14-2-3] Self Create Permission fee checks</h6>
+<h6 id="mod-pp-msg-14-2-3-self-create-participant-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-14-2-3-self-create-participant-fee-checks" >§</a> [MOD-PP-MSG-14-2-3] Self Create Participant fee checks</h6>
 <p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> available.</p>
-<h6 id="mod-perm-msg-14-2-4-self-create-permission-overlap-checks"><a class="toc-anchor" href="#mod-perm-msg-14-2-4-self-create-permission-overlap-checks" >§</a> [MOD-PERM-MSG-14-2-4] Self Create Permission overlap checks</h6>
-<p>We want to make sure that 2 permissions cannot be active at the same time for the same <code>validator_perm_id</code>. If <code>corporation</code> wishes to create a new permission but existing active one never expires (or expire too far from now), <code>corporation</code> MUST use first the <a href="#mod-perm-msg-8-adjust-permission" >Extend Perm Msg</a> to set or adjust the <code>effective_until</code> value.</p>
-<p>Find all <a class="term-reference" href="#term:active-permissions">active permissions</a> <code>perms[]</code> (not revoked, not slashed, not repaid) for <code>cs.id</code>, <code>type</code>, <code>validator_perm_id</code>, <code>corporation</code>.</p>
-<p>for each <code>Permission</code> entry <code>p</code> from <code>perms[]</code>:</p>
+<h6 id="mod-pp-msg-14-2-4-self-create-participant-overlap-checks"><a class="toc-anchor" href="#mod-pp-msg-14-2-4-self-create-participant-overlap-checks" >§</a> [MOD-PP-MSG-14-2-4] Self Create Participant overlap checks</h6>
+<p>We want to make sure that 2 <code>Participant</code> entries cannot be active at the same time for the same <code>validator_participant_id</code>. If <code>corporation</code> wishes to create a new <code>Participant</code> entry but the existing one never expires (or expires too far from now), <code>corporation</code> MUST use first the <a href="#mod-pp-msg-8-set-participant-effective-until" >Set Participant Effective Until</a> to set or adjust the <code>effective_until</code> value.</p>
+<p>Find all <a class="term-reference" href="#term:active-participants">active participants</a> <code>participants[]</code> (not revoked, not slashed, not repaid) for <code>cs.id</code>, <code>role</code>, <code>validator_participant_id</code>, <code>corporation</code>.</p>
+<p>for each <code>Participant</code> entry <code>p</code> from <code>participants[]</code>:</p>
 <ul>
 <li>if <code>p.effective_until</code> is greater than <code>effective_from</code>, method execution MUST abort.</li>
 <li>if <code>p.effective_from</code> is lower than <code>effective_until</code>, method execution MUST abort.</li>
-<li>if <code>p.effective_until</code> is NULL (never expire), creation of a new permission doesn’t make any sense and method execution MUST abort.</li>
+<li>if <code>p.effective_until</code> is NULL (never expire), creation of a new <code>Participant</code> entry doesn’t make any sense and method execution MUST abort.</li>
 </ul>
 <blockquote>
 <p>note: this check was not present in v3.</p>
 </blockquote>
-<h5 id="mod-perm-msg-14-3-self-create-permission-execution"><a class="toc-anchor" href="#mod-perm-msg-14-3-self-create-permission-execution" >§</a> [MOD-PERM-MSG-14-3] Self Create Permission execution</h5>
+<h5 id="mod-pp-msg-14-3-self-create-participant-execution"><a class="toc-anchor" href="#mod-pp-msg-14-3-self-create-participant-execution" >§</a> [MOD-PP-MSG-14-3] Self Create Participant execution</h5>
 <p>If all precondition checks passed, method is executed.</p>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
 <li>define <code>now</code>: current timestamp.</li>
-<li>Load <code>Permission</code> <code>validator_perm</code> from <code>validator_perm_id</code>.</li>
+<li>Load <code>Participant</code> <code>validator_participant</code> from <code>validator_participant_id</code>.</li>
 </ul>
-<p>A new entry <code>Permission</code> <code>perm</code> MUST be created:</p>
+<p>A new entry <code>Participant</code> <code>perm</code> MUST be created:</p>
 <ul>
-<li><code>perm.id</code>: auto-incremented uint64.</li>
-<li><code>perm.validator_perm_id</code>: <code>validator_perm_id</code></li>
-<li><code>perm.schema_id</code>: <code>validator_perm.schema_id</code></li>
-<li><code>perm.modified</code> to <code>now</code>.</li>
-<li><code>perm.type</code>: <code>type</code>.</li>
-<li><code>perm.did</code>: <code>did</code>.</li>
-<li><code>perm.corporation</code>: <code>corporation</code>.</li>
-<li><code>perm.vs_operator</code>: <code>vs_operator</code>.</li>
-<li><code>perm.created</code>: <code>now</code></li>
-<li><code>perm.effective_from</code>: <code>effective_from</code></li>
-<li><code>perm.effective_until</code>: <code>effective_until</code></li>
-<li><code>perm.validation_fees</code>: <code>validation_fees</code> if specified and <code>type</code> is ISSUER, else 0.</li>
-<li><code>perm.issuance_fees</code>: 0</li>
-<li><code>perm.verification_fees</code>: <code>verification_fees</code> if specified and <code>type</code> is ISSUER, else 0.</li>
-<li><code>perm.deposit</code>: 0</li>
+<li><code>participant.id</code>: auto-incremented uint64.</li>
+<li><code>participant.validator_participant_id</code>: <code>validator_participant_id</code></li>
+<li><code>participant.schema_id</code>: <code>validator_participant.schema_id</code></li>
+<li><code>participant.modified</code> to <code>now</code>.</li>
+<li><code>participant.role</code>: <code>role</code>.</li>
+<li><code>participant.did</code>: <code>did</code>.</li>
+<li><code>participant.corporation</code>: <code>corporation</code>.</li>
+<li><code>participant.vs_operator</code>: <code>vs_operator</code>.</li>
+<li><code>participant.created</code>: <code>now</code></li>
+<li><code>participant.effective_from</code>: <code>effective_from</code></li>
+<li><code>participant.effective_until</code>: <code>effective_until</code></li>
+<li><code>participant.validation_fees</code>: <code>validation_fees</code> if specified and <code>role</code> is ISSUER, else 0.</li>
+<li><code>participant.issuance_fees</code>: 0</li>
+<li><code>participant.verification_fees</code>: <code>verification_fees</code> if specified and <code>role</code> is ISSUER, else 0.</li>
+<li><code>participant.deposit</code>: 0</li>
 </ul>
-<p>If <code>vs_operator_authz_msg_types</code> is provided, create the <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> in <strong>active</strong> state by calling <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a> Grant VS Operator Authorization with:</p>
+<p>If <code>vs_operator_authz_msg_types</code> is provided, create the <a href="#participantauthorizationrecord" >ParticipantAuthorizationRecord</a> in <strong>active</strong> state by calling <a href="#mod-de-msg-5-grant-vs-operator-authorization" >[MOD-DE-MSG-5]</a> Grant VS Operator Authorization with:</p>
 <ul>
 <li><code>corporation</code>: <code>corporation</code></li>
 <li><code>vs_operator</code>: <code>vs_operator</code></li>
 <li><code>record</code>:
 <ul>
-<li><code>record.perm_id</code>: <code>perm.id</code></li>
+<li><code>record.participant_id</code>: <code>participant.id</code></li>
 <li><code>record.msg_types</code>: <code>vs_operator_authz_msg_types</code></li>
 <li><code>record.spend_limit</code>: <code>vs_operator_authz_spend_limit</code></li>
 <li><code>record.fee_spend_limit</code>: <code>vs_operator_authz_fee_spend_limit</code></li>
 <li><code>record.with_feegrant</code>: <code>vs_operator_authz_with_feegrant</code> (default: false)</li>
-<li><code>record.expiration</code>: <code>perm.effective_until</code></li>
+<li><code>record.expiration</code>: <code>participant.effective_until</code></li>
 <li><code>record.period</code>: <code>vs_operator_authz_period</code></li>
 </ul>
 </li>
 </ul>
 <blockquote>
-<p>Note: unlike <a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1]</a>, the record is created with <code>expiration = perm.effective_until</code> and is therefore immediately active. If <code>with_feegrant</code> is true and <code>perm.effective_until &gt; now</code>, <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a> grants the on-chain <code>FeeGrant</code> as part of this execution.</p>
+<p>Note: unlike <a href="#mod-pp-msg-1-start-participant-op" >[MOD-PP-MSG-1]</a>, the record is created with <code>expiration = participant.effective_until</code> and is therefore immediately active. If <code>with_feegrant</code> is true and <code>participant.effective_until &gt; now</code>, <a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >[MOD-DE-MSG-5-5]</a> grants the on-chain <code>FeeGrant</code> as part of this execution.</p>
 </blockquote>
-<h4 id="mod-perm-msg-15-trigger-resolver"><a class="toc-anchor" href="#mod-perm-msg-15-trigger-resolver" >§</a> [MOD-PERM-MSG-15] Trigger Resolver</h4>
+<h4 id="mod-pp-msg-15-trigger-resolver"><a class="toc-anchor" href="#mod-pp-msg-15-trigger-resolver" >§</a> [MOD-PP-MSG-15] Trigger Resolver</h4>
 <p>This method CAN be executed by:</p>
 <ul>
-<li>the <code>vs_operator</code> of the permission, acting on behalf of <code>perm.corporation</code>; or</li>
-<li>any ancestor validator of the permission in the permission tree (from the direct parent up to the root permission). For an ancestor validator <code>v</code>, the method CAN be executed by the <code>vs_operator</code> defined in <code>v</code>, or by any <code>operator</code> authorized by <code>v.corporation</code> for this message type.</li>
+<li>the <code>vs_operator</code> of the <code>Participant</code> entry, acting on behalf of <code>participant.corporation</code>; or</li>
+<li>any ancestor validator of the <code>Participant</code> entry in the <code>Participant</code> tree (from the direct parent up to the root <code>Participant</code> entry). For an ancestor validator <code>v</code>, the method CAN be executed by the <code>vs_operator</code> defined in <code>v</code>, or by any <code>operator</code> authorized by <code>v.corporation</code> for this message type.</li>
 </ul>
-<p>This method is intended to be used by external services (such as the Verana indexer) to be notified that a trust resolution must be performed for the <code>did</code> registered in the permission. Typical use cases include:</p>
+<p>This method is intended to be used by external services (such as the Verana indexer) to be notified that a trust resolution must be performed for the <code>did</code> registered in the <code>Participant</code> entry. Typical use cases include:</p>
 <ul>
 <li>a new <a class="term-reference" href="#term:verifiable-service">verifiable service</a> has been onboarded and its credentials are now present in the DID Document, so trust can be (re-)evaluated;</li>
-<li>an issuer has revoked a credential issued to a holder: the issuer (acting as the validator of the corresponding HOLDER permission) notifies the trust resolver to re-evaluate trust for the revoked HOLDER permission;</li>
-<li>an issuer is no longer operating: a parent issuer grantor or root ecosystem permission triggers a re-evaluation.</li>
+<li>an issuer has revoked a credential issued to a holder: the issuer (acting as the validator of the corresponding HOLDER <code>Participant</code> entry) notifies the trust resolver to re-evaluate trust for the revoked HOLDER <code>Participant</code> entry;</li>
+<li>an issuer is no longer operating: a parent issuer grantor or root ecosystem <code>Participant</code> entry triggers a re-evaluation.</li>
 </ul>
 <p>The method does not modify the <a class="term-reference" href="#term:vpr">VPR</a> state; it only emits an event that off-chain components MAY consume.</p>
-<h5 id="mod-perm-msg-15-1-trigger-resolver-parameters"><a class="toc-anchor" href="#mod-perm-msg-15-1-trigger-resolver-parameters" >§</a> [MOD-PERM-MSG-15-1] Trigger Resolver parameters</h5>
+<h5 id="mod-pp-msg-15-1-trigger-resolver-parameters"><a class="toc-anchor" href="#mod-pp-msg-15-1-trigger-resolver-parameters" >§</a> [MOD-PP-MSG-15-1] Trigger Resolver parameters</h5>
 <ul>
 <li><code>corporation</code> (group): (Signer) the signing corporation on whose behalf this message is executed.</li>
 <li><code>operator</code> (account): (Signer) the account authorized by the <code>corporation</code> to run this Msg.</li>
-<li><code>id</code> (uint64) (<em>mandatory</em>): id of the permission for which a trust resolution must be triggered.</li>
+<li><code>id</code> (uint64) (<em>mandatory</em>): id of the <code>Participant</code> entry for which a trust resolution must be triggered.</li>
 </ul>
-<h5 id="mod-perm-msg-15-2-trigger-resolver-precondition-checks"><a class="toc-anchor" href="#mod-perm-msg-15-2-trigger-resolver-precondition-checks" >§</a> [MOD-PERM-MSG-15-2] Trigger Resolver precondition checks</h5>
+<h5 id="mod-pp-msg-15-2-trigger-resolver-precondition-checks"><a class="toc-anchor" href="#mod-pp-msg-15-2-trigger-resolver-precondition-checks" >§</a> [MOD-PP-MSG-15-2] Trigger Resolver precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h6 id="mod-perm-msg-15-2-1-trigger-resolver-basic-checks"><a class="toc-anchor" href="#mod-perm-msg-15-2-1-trigger-resolver-basic-checks" >§</a> [MOD-PERM-MSG-15-2-1] Trigger Resolver basic checks</h6>
+<h6 id="mod-pp-msg-15-2-1-trigger-resolver-basic-checks"><a class="toc-anchor" href="#mod-pp-msg-15-2-1-trigger-resolver-basic-checks" >§</a> [MOD-PP-MSG-15-2-1] Trigger Resolver basic checks</h6>
 <p>if a mandatory parameter is not present, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>corporation</code> (group): (Signer) signature must be verified.</li>
 <li><code>operator</code> (account): (Signer) signature must be verified.</li>
 <li><code>id</code> MUST be a valid uint64.</li>
-<li>Load <code>Permission</code> entry <code>perm</code> from <code>id</code>. If no entry found, abort.</li>
-<li><code>perm</code> MUST be an <a class="term-reference" href="#term:active-permission">active permission</a>, else abort.</li>
-<li><code>perm.did</code> MUST NOT be null, else abort.</li>
+<li>Load <code>Participant</code> entry <code>perm</code> from <code>id</code>. If no entry found, abort.</li>
+<li><code>perm</code> MUST be an <a class="term-reference" href="#term:active-participant">active participant</a>, else abort.</li>
+<li><code>participant.did</code> MUST NOT be null, else abort.</li>
 </ul>
-<h6 id="mod-perm-msg-15-2-2-trigger-resolver-authorization-checks"><a class="toc-anchor" href="#mod-perm-msg-15-2-2-trigger-resolver-authorization-checks" >§</a> [MOD-PERM-MSG-15-2-2] Trigger Resolver authorization checks</h6>
+<h6 id="mod-pp-msg-15-2-2-trigger-resolver-authorization-checks"><a class="toc-anchor" href="#mod-pp-msg-15-2-2-trigger-resolver-authorization-checks" >§</a> [MOD-PP-MSG-15-2-2] Trigger Resolver authorization checks</h6>
 <p>At least one of the two authorization paths below MUST pass, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<p><em>Path 1 — vs_operator of the target permission</em></p>
+<p><em>Path 1 — vs_operator of the target <code>Participant</code> entry</em></p>
 <ul>
-<li><code>corporation</code> MUST be equal to <code>perm.corporation</code>.</li>
-<li><code>operator</code> MUST be equal to <code>perm.vs_operator</code>.</li>
+<li><code>corporation</code> MUST be equal to <code>participant.corporation</code>.</li>
+<li><code>operator</code> MUST be equal to <code>participant.vs_operator</code>.</li>
 <li><a href="#authz-check-3-vs-operator-authorization-checks" >[AUTHZ-CHECK-3]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>perm</code>) tuple.</li>
 <li><a href="#authz-check-4-vs-operator-fee-grant-checks" >[AUTHZ-CHECK-4]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>, <code>perm</code>) tuple.</li>
 </ul>
-<p><em>Path 2 — ancestor validator in the permission tree</em></p>
+<p><em>Path 2 — ancestor validator in the <code>Participant</code> tree</em></p>
 <p>The target <code>perm</code> itself is excluded from this walk; only its ancestors (from the direct parent up to the root) are considered. Walk the tree:</p>
 <ul>
 <li>set <code>v</code> = <code>perm</code>.</li>
-<li>while <code>v.validator_perm_id</code> is defined:
+<li>while <code>v.validator_participant_id</code> is defined and != <code>participant.id</code> :
 <ul>
-<li>load <code>v</code> from <code>v.validator_perm_id</code>.</li>
-<li>if <code>v</code> is not an <a class="term-reference" href="#term:active-permission">active permission</a>, continue with the next iteration.</li>
-<li><code>corporation</code> MUST be equal to <code>v.corporation</code>.</li>
+<li>load <code>v</code> from <code>v.validator_participant_id</code>.</li>
+<li>if <code>v</code> is not an <a class="term-reference" href="#term:active-participant">active participant</a>, continue with the next iteration.</li>
+<li>if corporation != v.corporation, continue with the next iteration.</li>
 <li>if <a href="#authz-check-1-operator-authorization-checks" >AUTHZ-CHECK-1</a> pass for this (<code>corporation</code>, <code>operator</code>) tuple and message <code>TriggerResolver</code> AND <a href="#authz-check-2-fee-grant-checks" >AUTHZ-CHECK-2</a> pass for this (<code>corporation</code>, <code>operator</code>) tuple and message <code>TriggerResolver</code>, then authorization is granted =&gt; match.</li>
 </ul>
 </li>
 </ul>
 <p>If the walk terminates without a match, Path 2 fails.</p>
-<h6 id="mod-perm-msg-15-2-3-trigger-resolver-fee-checks"><a class="toc-anchor" href="#mod-perm-msg-15-2-3-trigger-resolver-fee-checks" >§</a> [MOD-PERM-MSG-15-2-3] Trigger Resolver fee checks</h6>
+<h6 id="mod-pp-msg-15-2-3-trigger-resolver-fee-checks"><a class="toc-anchor" href="#mod-pp-msg-15-2-3-trigger-resolver-fee-checks" >§</a> [MOD-PP-MSG-15-2-3] Trigger Resolver fee checks</h6>
 <p>Fee payer MUST have the required <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a> in its <a class="term-reference" href="#term:account">account</a>, else <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
-<h5 id="mod-perm-msg-15-3-trigger-resolver-execution"><a class="toc-anchor" href="#mod-perm-msg-15-3-trigger-resolver-execution" >§</a> [MOD-PERM-MSG-15-3] Trigger Resolver execution</h5>
+<h5 id="mod-pp-msg-15-3-trigger-resolver-execution"><a class="toc-anchor" href="#mod-pp-msg-15-3-trigger-resolver-execution" >§</a> [MOD-PP-MSG-15-3] Trigger Resolver execution</h5>
 <p>If all precondition checks passed, <a class="term-reference" href="#term:transaction">transaction</a> is executed.</p>
 <p>This method does not modify the state of the <a class="term-reference" href="#term:vpr">VPR</a>. It MUST emit an event signaling that a trust resolution has been triggered for <code>perm</code>. The event MUST include at least:</p>
 <ul>
-<li><code>perm_id</code>: equal to <code>id</code>.</li>
+<li><code>participant_id</code>: equal to <code>id</code>.</li>
 </ul>
 <blockquote>
-<p>Note: the identity of the signers (<code>corporation</code>, <code>operator</code>), the fee payer, the block height and timestamp, and the full Msg payload are already observable from the transaction itself. Indexers MAY use the <code>Permission</code> entry queried by <code>perm_id</code> to resolve <code>did</code>, <code>corporation</code>, <code>vs_operator</code>, and ancestor chain without duplicating them in the event payload.</p>
+<p>Note: the identity of the signers (<code>corporation</code>, <code>operator</code>), the fee payer, the block height and timestamp, and the full Msg payload are already observable from the transaction itself. Indexers MAY use the <code>Participant</code> entry queried by <code>participant_id</code> to resolve <code>did</code>, <code>corporation</code>, <code>vs_operator</code>, and ancestor chain without duplicating them in the event payload.</p>
 </blockquote>
-<h4 id="mod-perm-qry-1-list-permissions"><a class="toc-anchor" href="#mod-perm-qry-1-list-permissions" >§</a> [MOD-PERM-QRY-1] List Permissions</h4>
+<h4 id="mod-pp-qry-1-list-participants"><a class="toc-anchor" href="#mod-pp-qry-1-list-participants" >§</a> [MOD-PP-QRY-1] List Participants</h4>
 <p>Anyone CAN execute this method.</p>
 <p>Generic query used for (at least):</p>
 <ul>
-<li>find all permissions (all or limit to active) of a given schema;</li>
-<li>for a given validator, get PENDING validation processes;</li>
-<li>find all permissions of a given grantee;</li>
-<li>find all permissions of a given did;</li>
-<li>find all ISSUER_GRANTOR active permission, so that I can apply to an ISSUER permission;
+<li>find all <code>Participant</code> entries (all or limit to active) of a given schema;</li>
+<li>for a given validator, get PENDING onboarding processes;</li>
+<li>find all <code>Participant</code> entries of a given grantee;</li>
+<li>find all <code>Participant</code> entries of a given did;</li>
+<li>find all ISSUER_GRANTOR active participants, so that I can apply to an ISSUER <code>Participant</code> entry;
 …</li>
 </ul>
-<h5 id="mod-perm-qry-1-1-list-permissions-parameters"><a class="toc-anchor" href="#mod-perm-qry-1-1-list-permissions-parameters" >§</a> [MOD-PERM-QRY-1-1] List Permissions parameters</h5>
+<h5 id="mod-pp-qry-1-1-list-participants-parameters"><a class="toc-anchor" href="#mod-pp-qry-1-1-list-participants-parameters" >§</a> [MOD-PP-QRY-1-1] List Participants parameters</h5>
 <ul>
 <li><code>schema_id</code> (number) (<em>optional</em>): the schema id.</li>
 <li><code>grantee</code> (account) (<em>optional</em>): the grantee account.</li>
-<li><code>did</code> (string) (<em>optional</em>): the did the permission refers to.</li>
-<li><code>perm_id</code> (number) (<em>optional</em>): limit to permissions where the <code>validator_perm_id</code> is <code>perm_id</code>.</li>
-<li><code>type</code> (PermissionType) (<em>optional</em>): if we want to limit to a specific permission type.</li>
-<li><code>only_valid</code> (boolean) (<em>optional</em>): if set to true, only return active permissions.</li>
-<li><code>only_slashed</code> (boolean) (<em>optional</em>): if set to true, only return slashed permissions.</li>
-<li><code>only_repaid</code> (boolean) (<em>optional</em>): if set to true, only return repaid slashed permissions.</li>
-<li><code>modified_after</code> (timestamp) (<em>optional</em>): limit to permissions modified after (or equal to) <code>modified_after</code>.</li>
-<li><code>vp_state</code> (ValidationState) (<em>optional</em>): limit to permissions with a <code>vp_state</code> not null and equal to <code>vp_state</code>.</li>
+<li><code>did</code> (string) (<em>optional</em>): the did the <code>Participant</code> entry refers to.</li>
+<li><code>participant_id</code> (number) (<em>optional</em>): limit to <code>Participant</code> entries where the <code>validator_participant_id</code> is <code>participant_id</code>.</li>
+<li><code>role</code> (ParticipantRole) (<em>optional</em>): if we want to limit to a specific <code>Participant</code> role.</li>
+<li><code>only_valid</code> (boolean) (<em>optional</em>): if set to true, only return active participants.</li>
+<li><code>only_slashed</code> (boolean) (<em>optional</em>): if set to true, only return slashed <code>Participant</code> entries.</li>
+<li><code>only_repaid</code> (boolean) (<em>optional</em>): if set to true, only return repaid slashed <code>Participant</code> entries.</li>
+<li><code>modified_after</code> (timestamp) (<em>optional</em>): limit to <code>Participant</code> entries modified after (or equal to) <code>modified_after</code>.</li>
+<li><code>op_state</code> (OnboardingState) (<em>optional</em>): limit to <code>Participant</code> entries with a <code>op_state</code> not null and equal to <code>op_state</code>.</li>
 <li><code>response_max_size</code> (small number) (<em>optional</em>): limit to <code>response_max_size</code> results. Must be min 1, max 1,024. Default to 64.</li>
 <li><code>when</code> (timestamp) (<em>optional</em>): if set, query <em>at</em> <code>when</code>, else query <em>at</em> now(). Used to query the VPR state at a previous datetime.</li>
 </ul>
-<h5 id="mod-perm-qry-1-2-list-permissions-checks"><a class="toc-anchor" href="#mod-perm-qry-1-2-list-permissions-checks" >§</a> [MOD-PERM-QRY-1-2] List Permissions checks</h5>
+<h5 id="mod-pp-qry-1-2-list-participants-checks"><a class="toc-anchor" href="#mod-pp-qry-1-2-list-participants-checks" >§</a> [MOD-PP-QRY-1-2] List Participants checks</h5>
 <p>Basic type check arg SHOULD be applied.</p>
 <p>If any of these checks fail, <a class="term-reference" href="#term:query">query</a> MUST fail.</p>
 <ul>
 <li><code>response_max_size</code> must be between 1 and 1,024. Default to 64 if unspecified.</li>
 </ul>
-<h5 id="mod-perm-qry-1-3-list-permissions-execution"><a class="toc-anchor" href="#mod-perm-qry-1-3-list-permissions-execution" >§</a> [MOD-PERM-QRY-1-3] List Permissions execution</h5>
+<h5 id="mod-pp-qry-1-3-list-participants-execution"><a class="toc-anchor" href="#mod-pp-qry-1-3-list-participants-execution" >§</a> [MOD-PP-QRY-1-3] List Participants execution</h5>
 <p>return a list of found entries, or an empty list if nothing found. Ordered by <code>modified</code> asc.</p>
-<h4 id="mod-perm-qry-2-get-permission"><a class="toc-anchor" href="#mod-perm-qry-2-get-permission" >§</a> [MOD-PERM-QRY-2] Get Permission</h4>
+<h4 id="mod-pp-qry-2-get-participant"><a class="toc-anchor" href="#mod-pp-qry-2-get-participant" >§</a> [MOD-PP-QRY-2] Get Participant</h4>
 <p>Anyone CAN execute this method.</p>
-<h5 id="mod-perm-qry-2-1-get-permission-parameters"><a class="toc-anchor" href="#mod-perm-qry-2-1-get-permission-parameters" >§</a> [MOD-PERM-QRY-2-1] Get Permission parameters</h5>
+<h5 id="mod-pp-qry-2-1-get-participant-parameters"><a class="toc-anchor" href="#mod-pp-qry-2-1-get-participant-parameters" >§</a> [MOD-PP-QRY-2-1] Get Participant parameters</h5>
 <ul>
-<li><code>id</code> of the <a class="term-reference" href="#term:credential-schema-permission">credential schema permission</a> (<em>mandatory</em>);</li>
+<li><code>id</code> of the <a class="term-reference" href="#term:credential-schema-participant">credential schema participant</a> (<em>mandatory</em>);</li>
 </ul>
-<h5 id="mod-perm-qry-2-2-get-permission-checks"><a class="toc-anchor" href="#mod-perm-qry-2-2-get-permission-checks" >§</a> [MOD-PERM-QRY-2-2] Get Permission checks</h5>
+<h5 id="mod-pp-qry-2-2-get-participant-checks"><a class="toc-anchor" href="#mod-pp-qry-2-2-get-participant-checks" >§</a> [MOD-PP-QRY-2-2] Get Participant checks</h5>
 <ul>
 <li><code>id</code> must be a uint64.</li>
 </ul>
-<h5 id="mod-perm-qry-2-3-get-permission-execution"><a class="toc-anchor" href="#mod-perm-qry-2-3-get-permission-execution" >§</a> [MOD-PERM-QRY-2-3] Get Permission execution</h5>
+<h5 id="mod-pp-qry-2-3-get-participant-execution"><a class="toc-anchor" href="#mod-pp-qry-2-3-get-participant-execution" >§</a> [MOD-PP-QRY-2-3] Get Participant execution</h5>
 <p>return found entry (if any).</p>
-<h4 id="mod-perm-qry-3-void"><a class="toc-anchor" href="#mod-perm-qry-3-void" >§</a> [MOD-PERM-QRY-3] Void</h4>
-<p>Obsoleted by [MOD-PERM-QRY-1].</p>
-<h4 id="mod-perm-qry-4-find-beneficiaries"><a class="toc-anchor" href="#mod-perm-qry-4-find-beneficiaries" >§</a> [MOD-PERM-QRY-4] Find Beneficiaries</h4>
+<h4 id="mod-pp-qry-3-void"><a class="toc-anchor" href="#mod-pp-qry-3-void" >§</a> [MOD-PP-QRY-3] Void</h4>
+<p>Obsoleted by [MOD-PP-QRY-1].</p>
+<h4 id="mod-pp-qry-4-find-beneficiaries"><a class="toc-anchor" href="#mod-pp-qry-4-find-beneficiaries" >§</a> [MOD-PP-QRY-4] Find Beneficiaries</h4>
 <p>Anyone can execute this method.</p>
-<p>To calculate the fees required for paying the beneficiaries, it is needed to recurse all involved perms until the root of the permission tree (which is the trust registry perm), starting from the 2 branches <code>issuer_perm</code> and <code>verifier_perm</code>. As both branches may have common ancestors, we can create a Set (unordered collection with no duplicates), and recurse over the 2 branches, adding found perms. If <code>verifier_perm</code> is null, <code>issuer_perm</code> is never added to the set. If <code>verifier_perm</code> is NOT null, <code>issuer_perm</code> is added to the set if it exists but <code>verifier_perm</code> is not added to the set.</p>
-<p>Example 1: <code>verifier_perm</code>: is not set: it’s a credential offer, schema configured to have Issuer Grantors.</p>
-<img src="https://www.plantuml.com/plantuml/svg/dT312e9040RW-px5e8TEWX1efp12eaC9hXqwoUgEPRXkk2C9qRkd1dhpq6d-WU4RPW93eg5MLIoOaib5XQ141nlNXLSfwSvqzi2Sm0ht4R_o93m1TfYtf1iGTOvc24zib0N203LWhujCPXwy6O2G4XG2QIXqMyjqc4iD4ljCx97pInYdXtXtJg9uoIvl_zcpELDW-vxlenmbgUiLBNciN-qus_uwLewXxrc0jHo_zwjV" alt="uml diagram">
-<p>Example 2: <code>verifier_perm</code>: is not set: it’s a credential offer. Schema configured to NOT have Issuer Grantors.</p>
-<img src="https://www.plantuml.com/plantuml/svg/VSyn2y8m40NWFR_YqGvE1K5edQGW7Hn4C3eubJIvOgLD9BbYGVplsWfrSxetF3xUvO6LvxvhHJwde5LBwDI0zNA9HsFuAbnr8ys8Ykr1NkIfs8C6qZqx3sKrXJ7SoNSHL01xnAkwCbMAfm2KCUW8x52xtffox9M1MBncTYVbkJZ-p9bg46Tfbf6P9EFiWlzvGZH8airdWSZ9ckclxtq3" alt="uml diagram">
-<p>Example 3: <code>verifier_perm</code> is set, it’s a presentation request. Schema configured to have Verifier and Issuer Grantors.</p>
-<img src="https://www.plantuml.com/plantuml/svg/dT91IyCm60RWUtx5otRmD1W8goUfI9KUvg2TWgUI9byrOqqa-Ledud-tgzWgWdEUyduXFBmaYGDBpqsz5V6GWf9RGYrtE9lFyMmqFmfNRaWn9idbAh_FryaI9LcgZ3BIlq1QHO6TnnFvUW8Pm1xJqwhKvGAl0f1QeoQmG-KQgulzkI8GYxT1JlFyDicAw-pYPhtA3l3cuN_yDtRK_eeDsbsIfLVfbxgq8zNiA_xisXxTzLCVrH73D5f44UdUqiwUyA-5kukQpSwxvn2c3zqisc6lxKCt2n6JrVqt-5ZV0G00" alt="uml diagram">
-<h5 id="mod-perm-qry-4-1-find-beneficiaries-parameters"><a class="toc-anchor" href="#mod-perm-qry-4-1-find-beneficiaries-parameters" >§</a> [MOD-PERM-QRY-4-1] Find Beneficiaries parameters</h5>
+<p>To calculate the fees required for paying the beneficiaries, it is needed to recurse all involved perms until the root of the <code>Participant</code> tree (which is the ecosystem perm), starting from the 2 branches <code>issuer_participant</code> and <code>verifier_participant</code>. As both branches may have common ancestors, we can create a Set (unordered collection with no duplicates), and recurse over the 2 branches, adding found perms. If <code>verifier_participant</code> is null, <code>issuer_participant</code> is never added to the set. If <code>verifier_participant</code> is NOT null, <code>issuer_participant</code> is added to the set if it exists but <code>verifier_participant</code> is not added to the set.</p>
+<p>Example 1: <code>verifier_participant</code>: is not set: it’s a credential offer, schema configured to have Issuer Grantors.</p>
+<img src="https://www.plantuml.com/plantuml/svg/fP2n2i8m48RtFCLH1oUX85WdgKWH1osqEZYLD3arOfAINB4WlhknWcuYEDrto_VV_QadxgZL5vQ-oGj-GT2yWsaSmrL9EZ5Rdr4GHDaYB_VbDbi3TYXQiWwu4UYVqA3J4N0Fv60mFjIodi2D0N0fGIEGXODjZQoQaAE4QhYXoYEn-zk-AijTLbJBOhxPviMt27NyA-AZ_XXXa4oI16KlbDOCwGSj2uUCHhFmCbCzX9sbQ6HVwMi-0000" alt="uml diagram">
+<p>Example 2: <code>verifier_participant</code>: is not set: it’s a credential offer. Schema configured to NOT have Issuer Grantors.</p>
+<img src="https://www.plantuml.com/plantuml/svg/ZSz12u9040NW-_wAXnuw2KAWdK883nqYo3fqadLtf0tT5NSa8VhlcO5TEyqxVUzDvbdsFBIDo9RabMm8hHonYMCyZEQRSDMT52F8TyVYMfpp0sWaDR3h8QqY_maTzMq0wS4zmdLTwIh1Km1IQxG4TgZTO7NPJJr6cKvQBZsnU2twlYWk-Ub7Bw91c2PfIde6jRCh_eCLmY2AjjCUaP7LyvVV-mO0" alt="uml diagram">
+<p>Example 3: <code>verifier_participant</code> is set, it’s a presentation request. Schema configured to have Verifier and Issuer Grantors.</p>
+<img src="https://www.plantuml.com/plantuml/svg/fP9FQy8m68Vl-HGlUl0a28BTQLIaIWzEQDrWfv8cRpLYavAyhOwnxxwimzQnm_vuokyDv7b-90aTSKjrUMHXbvpWHuIId-5kCe6JahHd9Z-W81X4Yqtwd6wZDUIeiL12SVi2N0jqP2nKQCi1S0TaOJWjSfdFu9K1S2cXH203XQcrp2glycShhYbpIEoj4yHf-XWbsIgPFsmtoGyMjRl9yeNUG__8xA1FKH8luwloU4PHVnJ-thpvR_EBf8VtJ1W6io10sIAbqIFwJNr_YUFnlNynfjhWPzPqUqqR_CnOY5gsF-LpVGS0" alt="uml diagram">
+<h5 id="mod-pp-qry-4-1-find-beneficiaries-parameters"><a class="toc-anchor" href="#mod-pp-qry-4-1-find-beneficiaries-parameters" >§</a> [MOD-PP-QRY-4-1] Find Beneficiaries parameters</h5>
 <ul>
-<li><code>issuer_perm_id</code> (uint64) (<em>optional</em>): id of issuer permission.</li>
-<li><code>verifier_perm_id</code> (uint64) (<em>optional</em>): id of verifier permission.</li>
+<li><code>issuer_participant_id</code> (uint64) (<em>optional</em>): id of issuer <code>Participant</code> entry.</li>
+<li><code>verifier_participant_id</code> (uint64) (<em>optional</em>): id of verifier <code>Participant</code> entry.</li>
 </ul>
-<h5 id="mod-perm-qry-4-2-find-beneficiaries-checks"><a class="toc-anchor" href="#mod-perm-qry-4-2-find-beneficiaries-checks" >§</a> [MOD-PERM-QRY-4-2] Find Beneficiaries checks</h5>
+<h5 id="mod-pp-qry-4-2-find-beneficiaries-checks"><a class="toc-anchor" href="#mod-pp-qry-4-2-find-beneficiaries-checks" >§</a> [MOD-PP-QRY-4-2] Find Beneficiaries checks</h5>
 <ul>
-<li>if <code>issuer_perm_id</code> and <code>verifier_perm_id</code> are unset then MUST abort.</li>
-<li>if <code>issuer_perm_id</code> is specified, load <code>issuer_perm</code> from <code>issuer_perm_id</code>, Permission MUST exist and MUST be a <a class="term-reference" href="#term:active-permission">active permission</a>.</li>
-<li>if <code>verifier_perm_id</code> is specified, load <code>verifier_perm</code> from <code>verifier_perm_id</code>, Permission MUST exist and MUST be a <a class="term-reference" href="#term:active-permission">active permission</a>.</li>
+<li>if <code>issuer_participant_id</code> and <code>verifier_participant_id</code> are unset then MUST abort.</li>
+<li>if <code>issuer_participant_id</code> is specified, load <code>issuer_participant</code> from <code>issuer_participant_id</code>, Participant MUST exist and MUST be a <a class="term-reference" href="#term:active-participant">active participant</a>.</li>
+<li>if <code>verifier_participant_id</code> is specified, load <code>verifier_participant</code> from <code>verifier_participant_id</code>, Participant MUST exist and MUST be a <a class="term-reference" href="#term:active-participant">active participant</a>.</li>
 </ul>
-<h5 id="mod-perm-qry-4-3-find-beneficiaries-execution"><a class="toc-anchor" href="#mod-perm-qry-4-3-find-beneficiaries-execution" >§</a> [MOD-PERM-QRY-4-3] Find Beneficiaries execution</h5>
-<p>Example: Let’s build the set. Revoked and slashed permissions will not be added to the set. Expired permissions, if not revoked/slashed, will be considered.</p>
+<h5 id="mod-pp-qry-4-3-find-beneficiaries-execution"><a class="toc-anchor" href="#mod-pp-qry-4-3-find-beneficiaries-execution" >§</a> [MOD-PP-QRY-4-3] Find Beneficiaries execution</h5>
+<p>Example: Let’s build the set. Revoked and slashed <code>Participant</code> entries will not be added to the set. Expired <code>Participant</code> entries, if not revoked/slashed, will be considered.</p>
 <ul>
 <li>
-<p>create Set <code>found_perm_set</code>.</p>
+<p>create Set <code>found_participant_set</code>.</p>
 </li>
 <li>
-<p>define permission <code>current_perm</code> as null.</p>
+<p>define <code>current_participant</code> as null.</p>
 </li>
 <li>
-<p>load perms <code>issuer_perm</code> and optional <code>verifier_perm</code> as specified in basic checks above.</p>
+<p>load perms <code>issuer_participant</code> and optional <code>verifier_participant</code> as specified in basic checks above.</p>
 </li>
 </ul>
-<p>if <code>issuer_perm</code> is not null:</p>
+<p>if <code>issuer_participant</code> is not null:</p>
 <ul>
-<li>set <code>current_perm</code> = <code>issuer_perm</code></li>
-<li>while <code>current_perm.validator_perm_id</code> is not null:
+<li>set <code>current_participant</code> = <code>issuer_participant</code></li>
+<li>while <code>current_participant.validator_participant_id</code> is not null:
 <ul>
-<li>current_perm = load(<code>current_perm.validator_perm_id</code>)</li>
-<li>if <code>current_perm.revoked</code> is NULL AND <code>current_perm.slashed</code> is NULL, Add <code>current_perm</code> to <code>found_perm_set</code>.</li>
+<li>current_participant = load(<code>current_participant.validator_participant_id</code>)</li>
+<li>if <code>current_participant.revoked</code> is NULL AND <code>current_participant.slashed</code> is NULL, Add <code>current_participant</code> to <code>found_participant_set</code>.</li>
 </ul>
 </li>
 </ul>
-<p>Additionally, if <code>verifier_perm</code> is not null:</p>
+<p>Additionally, if <code>verifier_participant</code> is not null:</p>
 <ul>
-<li>if <code>issuer_perm</code> is not null, add <code>issuer_perm</code> to <code>found_perm_set</code></li>
-<li>set <code>current_perm</code> = <code>verifier_perm</code></li>
-<li>while <code>current_perm.validator_perm_id</code> != null:
+<li>if <code>issuer_participant</code> is not null, add <code>issuer_participant</code> to <code>found_participant_set</code></li>
+<li>set <code>current_participant</code> = <code>verifier_participant</code></li>
+<li>while <code>current_participant.validator_participant_id</code> != null:
 <ul>
-<li>current_perm = load(<code>current_perm.validator_perm_id</code>)</li>
-<li>if <code>current_perm.revoked</code> is NULL AND <code>current_perm.slashed</code> is NULL, Add <code>current_perm</code> to <code>found_perm_set</code>.</li>
+<li>current_participant = load(<code>current_participant.validator_participant_id</code>)</li>
+<li>if <code>current_participant.revoked</code> is NULL AND <code>current_participant.slashed</code> is NULL, Add <code>current_participant</code> to <code>found_participant_set</code>.</li>
 </ul>
 </li>
 </ul>
 <p>return <code>found_perms</code>.</p>
 <div id="note-90" class="notice note"><a class="notice-link" href="#note-90">NOTE</a><p>This works even is schema is open to any issuer or open to any verifier.</p>
 </div>
-<h4 id="mod-perm-qry-5-get-permissionsession"><a class="toc-anchor" href="#mod-perm-qry-5-get-permissionsession" >§</a> [MOD-PERM-QRY-5] Get PermissionSession</h4>
-<h5 id="mod-perm-qry-5-1-get-permissionsession-parameters"><a class="toc-anchor" href="#mod-perm-qry-5-1-get-permissionsession-parameters" >§</a> [MOD-PERM-QRY-5-1] Get PermissionSession parameters</h5>
+<h4 id="mod-pp-qry-5-get-participantsession"><a class="toc-anchor" href="#mod-pp-qry-5-get-participantsession" >§</a> [MOD-PP-QRY-5] Get ParticipantSession</h4>
+<h5 id="mod-pp-qry-5-1-get-participantsession-parameters"><a class="toc-anchor" href="#mod-pp-qry-5-1-get-participantsession-parameters" >§</a> [MOD-PP-QRY-5-1] Get ParticipantSession parameters</h5>
 <ul>
-<li><code>id</code> (uuid) (<em>mandatory</em>): the id of the <code>PermissionSession</code>.</li>
+<li><code>id</code> (uuid) (<em>mandatory</em>): the id of the <code>ParticipantSession</code>.</li>
 </ul>
-<h5 id="mod-perm-qry-5-2-get-permissionsession-checks"><a class="toc-anchor" href="#mod-perm-qry-5-2-get-permissionsession-checks" >§</a> [MOD-PERM-QRY-5-2] Get PermissionSession checks</h5>
-<h5 id="mod-perm-qry-5-3-get-permissionsession-execution"><a class="toc-anchor" href="#mod-perm-qry-5-3-get-permissionsession-execution" >§</a> [MOD-PERM-QRY-5-3] Get PermissionSession execution</h5>
-<p>return <code>PermissionSession</code> entry if found, else return not found.</p>
-<h5 id="mod-perm-qry-6-list-permission-module-parameters"><a class="toc-anchor" href="#mod-perm-qry-6-list-permission-module-parameters" >§</a> [MOD-PERM-QRY-6] List Permission Module Parameters</h5>
-<h5 id="mod-perm-qry-6-2-list-permission-module-parameters-parameters"><a class="toc-anchor" href="#mod-perm-qry-6-2-list-permission-module-parameters-parameters" >§</a> [MOD-PERM-QRY-6-2] List Permission Module Parameters parameters</h5>
-<h5 id="mod-perm-qry-6-2-list-permission-module-parameters-query-checks"><a class="toc-anchor" href="#mod-perm-qry-6-2-list-permission-module-parameters-query-checks" >§</a> [MOD-PERM-QRY-6-2] List Permission Module Parameters query checks</h5>
-<h5 id="mod-perm-qry-6-3-list-permission-module-parameters-execution-of-the-query"><a class="toc-anchor" href="#mod-perm-qry-6-3-list-permission-module-parameters-execution-of-the-query" >§</a> [MOD-PERM-QRY-6-3] List Permission Module Parameters execution of the query</h5>
+<h5 id="mod-pp-qry-5-2-get-participantsession-checks"><a class="toc-anchor" href="#mod-pp-qry-5-2-get-participantsession-checks" >§</a> [MOD-PP-QRY-5-2] Get ParticipantSession checks</h5>
+<h5 id="mod-pp-qry-5-3-get-participantsession-execution"><a class="toc-anchor" href="#mod-pp-qry-5-3-get-participantsession-execution" >§</a> [MOD-PP-QRY-5-3] Get ParticipantSession execution</h5>
+<p>return <code>ParticipantSession</code> entry if found, else return not found.</p>
+<h5 id="mod-pp-qry-6-list-participant-module-parameters"><a class="toc-anchor" href="#mod-pp-qry-6-list-participant-module-parameters" >§</a> [MOD-PP-QRY-6] List Participant Module Parameters</h5>
+<h5 id="mod-pp-qry-6-2-list-participant-module-parameters-parameters"><a class="toc-anchor" href="#mod-pp-qry-6-2-list-participant-module-parameters-parameters" >§</a> [MOD-PP-QRY-6-2] List Participant Module Parameters parameters</h5>
+<h5 id="mod-pp-qry-6-2-list-participant-module-parameters-query-checks"><a class="toc-anchor" href="#mod-pp-qry-6-2-list-participant-module-parameters-query-checks" >§</a> [MOD-PP-QRY-6-2] List Participant Module Parameters query checks</h5>
+<h5 id="mod-pp-qry-6-3-list-participant-module-parameters-execution-of-the-query"><a class="toc-anchor" href="#mod-pp-qry-6-3-list-participant-module-parameters-execution-of-the-query" >§</a> [MOD-PP-QRY-6-3] List Participant Module Parameters execution of the query</h5>
 <p>Return the list of the existing parameters and their values.</p>
-<h5 id="mod-perm-qry-6-4-list-permission-module-parameters-api-result-example"><a class="toc-anchor" href="#mod-perm-qry-6-4-list-permission-module-parameters-api-result-example" >§</a> [MOD-PERM-QRY-6-4] List Permission Module Parameters API result example</h5>
+<h5 id="mod-pp-qry-6-4-list-participant-module-parameters-api-result-example"><a class="toc-anchor" href="#mod-pp-qry-6-4-list-participant-module-parameters-api-result-example" >§</a> [MOD-PP-QRY-6-4] List Participant Module Parameters API result example</h5>
 <pre class="language-json"><code class="language-json"><span class="token punctuation">{</span>
   <span class="token property">"params"</span><span class="token operator">:</span> <span class="token punctuation">{</span>
     <span class="token property">"key1"</span><span class="token operator">:</span> <span class="token string">"value1"</span><span class="token punctuation">,</span>
@@ -4372,10 +4830,10 @@ else MUST abort.</p>
 <h5 id="getting-a-credential-from-an-authorized-issuer"><a class="toc-anchor" href="#getting-a-credential-from-an-authorized-issuer" >§</a> Getting a Credential from an Authorized Issuer</h5>
 <p><em>This section is non-normative.</em></p>
 <p>Example of an Applicant that would like to get issued a credential (HOLDER):</p>
-<img src="https://www.plantuml.com/plantuml/svg/ZLJHRk8m47pFLwpWeL01gdHIEI4E5G6LaEu1SPHtnzw0TOxjivro_FsjKqX2uTgY817PCpkpkyEJ3yo58bU9vqmXvEmlV7zuW8CKOPym7eo3rjHQ9JdJeGNCG_K6v_CjKr8m-bcUpnQ99Kx9fOsNMbjqCfCi9VPLaH8KrhYJFhXZUNsxMaFxMvQAz35XHJ2wo5Caqd5c2CsDCkx7NNluE1oYk9kCqqd75HfAsP1Zs1lHRIMrfdv_qgGSmSmX2mWdZT9eM6Yg3Hsc1LXs18T_2kbGmCOLFi0pekyEcb9yC3Q9dED-FtAFOEgzt6ceV4E7leL7iCwyIa5SrT4brGUkaEJyrrLLUUEOzjJsw8ERt2eCL2rQQHZ4qY0lZOih9r-JmutMo8E7O626DCwCb9pR9yEnMM_xwse4iyK8_9uv12d0PB12bqlgcj5NUYvTHk2Q9e8q2kecGUbXd9k2BaIVy-KSp46ZytjfeKCB5Hj7u-ZUaX2xMbzvO_IGQ4ChOLv9GeNf4G3QY_8pWiwziT4RK_TTsX1BhOImHyYCKkOWzGv8ZrGGcF_jwqdSCFDiN0wPLAeljU-LsrPx4uONEOtBtz1-mb19bnFmj5h-p41Zhz23mU1pI--blfy3tOsbQo5LX9RU5nY39AYOPEghAns3AYDMr3jzgd8HqHShRaLqqD2odVvSpgURnRpNqF4cJFGWeyn2YD78qCKeqz9M2RpEyXDj1Vtb_GC0" alt="uml diagram">
+<img src="https://www.plantuml.com/plantuml/svg/ZLJHRk8m47pFLwpWeL01gdHIEI4E5G6LaEu1SPHtnzw0TOxjivro_FsjKqX2uTgY817PEpkpEyEJ3yo58bU9vqmXvEmlV7zuW8CKOPym7eo3rjHQ9JdJeGNCG_K6v_CjKr8m-bcUpnQ99Kp9fOsNMbjqCfCi9VHLaL8fh74dVN37ylfsjORsjomLwMF2Yc1qaQT8eEFCK3KtohWVT-tXut28ucuoJYSTLsWeQKEEOMz4jvNKdFhzIHDo13E7B22SE4gZOQ6fDtIO5c3P4Hp-AQH30HjN-03FYBuxQ5BnmTWaOexx_OWzWgdtSgUXqWqT-XOUmJhpAWLXLKUNK1-eGgBpNrLLvurZsjFOemvkSgimKBSefI4GIu6y52wkb7oD3ZTQ8myUWe4PqZepOd8Udmp7Ph_jhwiLp1OZy7lc4AG0ay6gTiGLeKkPiN9DAq7Q1OsJQkbXd9k2BaIXy-KSp46ZytjfeKEEYfEZVNHlSOXZhQ-y8Nf8j25Fc5UYKDNqg03QY_8pWiwziL4SK_TTieYbMKBO8sH6ANEGUWV4Hoe8pF_szIfkY7asBeTCAjMNslTAkzNQXE55JlloDxYVQgYbowdmv2r_Hg2zLzM3mU1pIU-fljy3tOsjQo9LXfRU5nYJ9AYPPEghdev9bR5MrAO-TRd8w8iLjp8wQ73PJdykvzFDOjvhy7WZ9dgGKMWXn6naw6AMoRLL1A_3_4IkeF-yVm00" alt="uml diagram">
 <h5 id="add-a-did-to-the-list-of-granted-issuers-of-a-credential-schema"><a class="toc-anchor" href="#add-a-did-to-the-list-of-granted-issuers-of-a-credential-schema" >§</a> Add a DID to the List of Granted Issuers of a Credential Schema</h5>
 <p><em>This section is non-normative.</em></p>
-<img src="https://www.plantuml.com/plantuml/svg/hLPTQzim57tthxYq3sjBQWg3CSe-cgrb1CPMagum21J5lav4PScJv6RzzpkIxSHjkiqTAtcedVjnxZb7LpbpNbXVbofncL1CfVX9hqzEQ2rplqf4vesblN5LAPa9xUVwG3fNioKyvJ8NdW_dUfnbfjP-ZuIZJMZxaWRMk9xH1slMZkt3CkrBIhewrqA576EtTPOMWSR6AZ5x4tCz6vJM7s0JsBvCaWe4oKnMY4OTjhAGOW6gBki5CDAKbz9vUzzaNqvf_sMno1UlacI7Y-FZTo7Yb6Q1TBfaMmABD1flav3wvlYu2SWiWnUgjX6iqIFThRb9UHpRriX7SotmUgavZp7fNJVXJNYyaJaLrfGqcSs-NKnlFat7Nww-JdlbNAzh9qUSPCio01kjEVFa3Mtg4qGzdvnJ0Q0vIKqFEwSGVwuNBL2fboH2-4TJbbqvTD_j7IVkzzvD8eQjeOvRSJu4_OJMGLs0hwp964ojfLyrTCdyRPgcIIz-DryPqP3Rv3Kfu1rZtmN3t9DVCVpXJ2Q39hyJGZgoNB2rWGsWANd0-9P_r9WtG3S5uGCUl3Lghl5_R2Iw6YHQrno0780BjZWSm8zZ16zJjgtQUWDGDYc8vogOakvDJS9o9AO5hDX6p2ql6oUFe8-tDKP4qXDoxlHQhsIsYjRBJMpKgMlZMKKAZghGr2o2zqC9GC4_sy2oC-gEO-UW_PAXIhsWMxvt_oAaMMksRYMhI4jWAbJ670kOASyv7YhCqHpT_WRu7_eEWJnCLTgYVwIbDjXo1cTaP-EF-ere_oB-dTB1aQc2CuGwEWHX5JP7B5sWaLc7OmCxIaLUk5i726Mb6CW6Z386x0YV55pYPHaMSEkGkRwqG4dIZmWBgv1AXLQ5iQKRHVR2OswokeHZNTWNVoSTSeK2dUnGCu8EoS-cvVdZVZUrZL8zCMzAanTAaJRhxY9wqcH07nYpcwqYcaFIMvQFRhxkRiGDo8_kls3hDernBJXylzq3ATOvK8IGyUV9-VZgudokqtXbFg2rRNUAIpbZ2S4QgnNCJrrYEvo0zh2hUoCsfsmpQ1XkhiCXH9t8JoGii9H3U2cKQxoEHUwo5PSYJSxW3lo--WK0" alt="uml diagram">
+<img src="https://www.plantuml.com/plantuml/svg/hLPhQzim5FtkNt7PFgmjgIaCnYXxPMiPWR65f2iC0frYNoUYikH9ShF--nt9Tk8sOVF6GZx4vhxEEVUHTyuBw-jI9IuJYgaKF-dbsHbjPExNYSYyiVHaN5LAPaBxXJwIpjLi2K-vp8NduuKUPvcfjNz2mj7Mj7r90sDSp-czDHl7zc6OzYKbNPnheOAFiRiuAmj3OsEKwBsrkPuFSki3s1gsBvEa0a4oanMi4OUjBAHOWgfflKIDDEELTDxUDzxJ6JrzNYppvOiasUFYzFHDi3YdUI2Tfht0NwP9y7rrUjfOP9P137tlsNmdriYJxiVTUXqmRoFbeuKMpicLvfnwYDAx3kzDx-sDpAcmfgJ9VFxrSdRpSJR-VFLbTY2-PDShg5Ch0js903X6QyuyUKFRX0JDBoONL013JbBJmL9IjCX2BriSKgz81AyFfYoxgDBe_H8Y9_qIzfs8qVpGqAqv7m9YGfiW5J1KrcGC8ZVIhn-mAVFNQPecFRVzCCe8IC2sRDmR5wW34kv2TzsJNpEQoPbC1kM6oIKTMIxOsa0HIYnv02UMVzGW8U0n1U4BShmrQg7nkvzMTA58j3rt1E9GSUYeum7SEORnpcMNiOqteDZ61VPSXNwcUrEJi1pPQkjMR6FfBKjHup048sZdRGsaS3eWzLwkpLfcwzYTkOc9EkLjd7QuODY5fcQLl1rA00B-lZSiEwFkE6OE3R5YY5ClwPRltR_eQJQQhLlBAj8Ic0gHWME93ijpZdC77CsS7zmV_qFe8RKFavTsC1w9gWtsfS44xHsFKJyHFRsCdtCwEZ5LQ16XJex1N8Nr4aCNI6GsOOpGbrAH5-xMeOIoKepA1a0Pe-nOFYcqYvTbMELjgopqrA9Aadv4s6g5L2gaAemjtIYo5nvpazKb-7TXc_oPT6oJ4A3J7xB6eeFpNzFozt2_cTf6gGxWJMdoJ2dIPjETjDzt6s04wknspuXcR7exzT4rxUujhYe_lgcXqri_nXLnCDYjXXJR7_K4a_6doSNuwl9YeTDuXXyGtEOxnwNFM4AwfkaAFdZwzjY1066d7mBRJE0MSe2vq6504J1I5ZaCnELma4AvflsnwrssvbAaoJiq3Fwz_G80" alt="uml diagram">
 <h3 id="trust-deposit-module"><a class="toc-anchor" href="#trust-deposit-module" >§</a> Trust deposit module</h3>
 <h4 id="trust-deposit-module-overview"><a class="toc-anchor" href="#trust-deposit-module-overview" >§</a> Trust deposit module overview</h4>
 <p><em>This section is non-normative.</em></p>
@@ -4498,7 +4956,7 @@ else MUST abort.</p>
 </li>
 <li>else
 <ul>
-<li>if <code>augend</code> is negative and <code>td.claimable</code> - <code>augend</code> is greater than <code>td.deposit</code> transaction MUST abort. (<code>td.claimable</code> trust deposit cannot be greater than <code>td.deposit</code>).</li>
+<li>if <code>augend</code> is negative and <code>td.refunded</code> - <code>augend</code> is greater than <code>td.deposit</code> transaction MUST abort. (<code>td.refunded</code> trust deposit cannot be greater than <code>td.deposit</code>).</li>
 </ul>
 </li>
 </ul>
@@ -4518,7 +4976,7 @@ else MUST abort.</p>
 <ul>
 <li>if <code>augend</code> is positive:
 <ul>
-<li>calculate <code>needed_deposit</code> = <code>augend</code> - <code>td.claimable</code>.</li>
+<li>calculate <code>needed_deposit</code> = <code>augend</code> - <code>td.refunded</code>.</li>
 <li>if <code>needed_deposit</code> &lt; 0: <code>needed_deposit</code> = 0.</li>
 </ul>
 </li>
@@ -4544,7 +5002,7 @@ else MUST abort.</p>
 <li>set <code>td.corporation</code> to <code>corporation</code>;</li>
 <li>set <code>td.deposit</code> to <code>augend</code>;</li>
 <li>set <code>td.share</code> to <code>augend_share</code>;</li>
-<li>set <code>td.claimable</code> to 0.</li>
+<li>set <code>td.refunded</code> to 0.</li>
 <li>set <code>td.slashed_deposit</code> to 0.</li>
 <li>set <code>td.repaid_deposit</code> to 0.</li>
 <li>set <code>td.slash_count</code> to 0.</li>
@@ -4557,20 +5015,20 @@ else MUST abort.</p>
 <p>else if <code>augend</code> &gt; 0:</p>
 <ul>
 <li>
-<p>if <code>td.claimable</code> &gt; 0:</p>
+<p>if <code>td.refunded</code> &gt; 0:</p>
 <ul>
-<li>if <code>td.claimable</code> &gt;= <code>augend</code> :
+<li>if <code>td.refunded</code> &gt;= <code>augend</code> :
 <ul>
-<li>set <code>td.claimable</code> to <code>td.claimable</code> - <code>augend</code></li>
+<li>set <code>td.refunded</code> to <code>td.refunded</code> - <code>augend</code></li>
 </ul>
 </li>
 <li>else
 <ul>
-<li>use bank? to transfer <code>augend</code> - <code>td.claimable</code> from corporation account to corporation <code>TrustDeposit</code> account.</li>
-<li>set <code>td.deposit</code> to <code>td.deposit</code> + <code>augend</code> - <code>td.claimable</code></li>
-<li>set <code>td.claimable</code> to 0</li>
-<li>calculate <code>missing_augend_share</code> from missing tokens :  <code>missing_augend_share</code> = (<code>augend</code> - <code>td.claimable</code>) / <code>GlobalVariables.trust_deposit_share_value</code>.</li>
+<li>use bank? to transfer <code>augend</code> - <code>td.refunded</code> from corporation account to corporation <code>TrustDeposit</code> account.</li>
+<li>set <code>td.deposit</code> to <code>td.deposit</code> + <code>augend</code> - <code>td.refunded</code></li>
+<li>calculate <code>missing_augend_share</code> from missing tokens :  <code>missing_augend_share</code> = (<code>augend</code> - <code>td.refunded</code>) / <code>GlobalVariables.trust_deposit_share_value</code>.</li>
 <li>set <code>td.share</code> to <code>td.share</code> + <code>missing_augend_share</code></li>
+<li>set <code>td.refunded</code> to 0</li>
 </ul>
 </li>
 </ul>
@@ -4589,11 +5047,11 @@ else MUST abort.</p>
 <li>
 <p>else if <code>augend</code> &lt; 0:</p>
 <ul>
-<li>set <code>td.claimable</code> to <code>td.claimable</code> - <code>augend</code></li>
+<li>set <code>td.refunded</code> to <code>td.refunded</code> - <code>augend</code></li>
 </ul>
 </li>
 </ul>
-<p>The last case, <code>augend</code> &lt; 0, is to free trust deposit (ej when canceling a validation process).</p>
+<p>The last case, <code>augend</code> &lt; 0, is to refund trust deposit (e.g. when canceling an onboarding process). The refunded amount is added to <code>td.refunded</code> and is reused for the next trust deposit spending.</p>
 <h4 id="mod-td-msg-2-reclaim-trust-deposit-yield"><a class="toc-anchor" href="#mod-td-msg-2-reclaim-trust-deposit-yield" >§</a> [MOD-TD-MSG-2] Reclaim Trust Deposit Yield</h4>
 <p>This method is used to reclaim yield. If trust deposit has been slashed and not repaid, method execution MUST abort.</p>
 <p>For a given <code>TrustDeposit</code> entry <code>td</code>, claimable yield is calculated like this:</p>
@@ -4654,7 +5112,7 @@ else MUST abort.</p>
 <h4 id="mod-td-msg-5-slash-trust-deposit"><a class="toc-anchor" href="#mod-td-msg-5-slash-trust-deposit" >§</a> [MOD-TD-MSG-5] Slash Trust Deposit</h4>
 <p>This method is used by the network governance authority to <strong>globally slash</strong> a corporation <code>account</code> trust deposit.</p>
 <p>This method can only be called by a governance proposal. A globally slashed account MUST repay the slashed deposit in order to continue to use the services provided by the VPR. When and account is slashed, and while slashed deposit has not been repaid, all account linked permissions MUST be considered non trustable.</p>
-<p>This method is for network governance authority slash. For ecosystem slash, see <a href="#mod-perm-msg-12-slash-permission-trust-deposit" >Slash Permission Trust Deposit</a>.</p>
+<p>This method is for network governance authority slash. For ecosystem slash, see <a href="#mod-pp-msg-12-slash-participant-trust-deposit" >Slash Participant Trust Deposit</a>.</p>
 <h5 id="mod-td-msg-5-1-slash-trust-deposit-method-parameters"><a class="toc-anchor" href="#mod-td-msg-5-1-slash-trust-deposit-method-parameters" >§</a> [MOD-TD-MSG-5-1] Slash Trust Deposit method parameters</h5>
 <ul>
 <li><code>corporation</code> (group) (<em>mandatory</em>): corporation we want to slash.</li>
@@ -4805,6 +5263,7 @@ The decision between this method and specifying the amount directly is left to i
 <li><code>expiration</code> (timestamp): if specified, MUST be in the future</li>
 <li><code>spend_limit</code> (DenomAmount[]) if specified, MUST be a list of valid DenomAmounts</li>
 <li><code>period</code> (duration): if specified MUST be a valid period.</li>
+<li>if <code>period</code> is specified, <code>expiration</code> MUST also be specified.</li>
 </ul>
 <h5 id="mod-de-msg-1-3-grant-fee-allowance-fee-checks"><a class="toc-anchor" href="#mod-de-msg-1-3-grant-fee-allowance-fee-checks" >§</a> [MOD-DE-MSG-1-3] Grant Fee Allowance fee checks</h5>
 <ul>
@@ -4819,7 +5278,8 @@ The decision between this method and specifying the amount directly is left to i
 <li>set <code>feegrant.msg_types</code> to <code>msg_types</code></li>
 <li>set <code>feegrant.expiration</code> to <code>expiration</code></li>
 <li>set <code>feegrant.spend_limit</code> to <code>spend_limit</code></li>
-<li>set <code>feegrant.period</code> to `period``</li>
+<li>if <code>spend_limit</code> is set, set <code>feegrant.remaining_spend</code> to <code>spend_limit</code></li>
+<li>set <code>feegrant.period</code> to <code>period</code></li>
 </ul>
 <h4 id="mod-de-msg-2-revoke-fee-allowance"><a class="toc-anchor" href="#mod-de-msg-2-revoke-fee-allowance" >§</a> [MOD-DE-MSG-2] Revoke Fee Allowance</h4>
 <p>This method can only be called directly by the following methods:</p>
@@ -4876,7 +5336,7 @@ The decision between this method and specifying the amount directly is left to i
 <p><a href="#authz-check-common-authorization-and-fee-grant-precondition-checks" >[AUTHZ-CHECK]</a> MUST pass for this (<code>corporation</code>, <code>operator</code>) pair and this message type.</p>
 </li>
 <li>
-<p><code>msg_types</code> (Msg[]) (<em>mandatory</em>): MUST be a list of <strong>VPR delegable messages only</strong>, excepted <code>CreateOrUpdatePermissionSession</code> which is not allowed.</p>
+<p><code>msg_types</code> (Msg[]) (<em>mandatory</em>): MUST be a list of <strong>VPR delegable messages only</strong>, excepted <code>CreateOrUpdateParticipantSession</code> which is not allowed.</p>
 </li>
 <li>
 <p><code>expiration</code> (timestamp): if specified, MUST be in the future</p>
@@ -4894,10 +5354,13 @@ The decision between this method and specifying the amount directly is left to i
 <p><code>feegrant_spend_limit_period</code> (duration): if specified MUST be a valid period. Ignored if <code>feegrant_spend_limit</code> is not set or if <code>with_feegrant</code> is false.</p>
 </li>
 <li>
+<p>if <code>authz_spend_limit_period</code> or <code>feegrant_spend_limit_period</code> is specified, <code>expiration</code> MUST also be specified.</p>
+</li>
+<li>
 <p>Check if a <strong>VS Operator Authorization</strong> exists for <code>corporation</code> and <code>grantee</code>. If this is the case, MUST abort.</p>
 </li>
 </ul>
-<div id="warning-52" class="notice warning"><a class="notice-link" href="#warning-52">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>perm.corporation</code> and <code>perm.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
+<div id="warning-52" class="notice warning"><a class="notice-link" href="#warning-52">WARNING</a><p>An <strong>Operator Authorization</strong> CAN be granted ONLY IF no <strong>VS Operator Authorization</strong> exists for <code>participant.corporation</code> and <code>participant.vs_operator</code>. <strong>Operator Authorization</strong> and <strong>VS Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
 <h5 id="mod-de-msg-3-3-grant-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-3-3-grant-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-3-3] Grant Operator Authorization fee checks</h5>
 <ul>
@@ -4912,6 +5375,7 @@ The decision between this method and specifying the amount directly is left to i
 <li>set <code>authz.msg_types</code> to <code>msg_types</code></li>
 <li>set <code>authz.expiration</code> to <code>expiration</code></li>
 <li>set <code>authz.spend_limit</code> to <code>authz_spend_limit</code></li>
+<li>if <code>authz_spend_limit</code> is set, set <code>authz.remaining_spend</code> to <code>authz_spend_limit</code></li>
 <li>set <code>authz.period</code> to <code>authz_spend_limit_period</code></li>
 </ul>
 <p>if <code>with_feegrant</code> is false:</p>
@@ -4951,26 +5415,27 @@ The decision between this method and specifying the amount directly is left to i
 <li>revoke Fee Allowance (<code>corporation</code>, <code>grantee</code>).</li>
 </ul>
 <h4 id="mod-de-msg-5-grant-vs-operator-authorization"><a class="toc-anchor" href="#mod-de-msg-5-grant-vs-operator-authorization" >§</a> [MOD-DE-MSG-5] Grant VS Operator Authorization</h4>
-<p>This method can only be called directly by the following Permission module methods, with no signer check:</p>
+<p>This method can only be called directly by the following Participant module methods, with no signer check:</p>
 <ul>
-<li><a href="#mod-perm-msg-1-start-permission-vp" >Start Permission VP</a></li>
-<li><a href="#mod-perm-msg-14-self-create-permission" >Self Create Permission</a></li>
+<li><a href="#mod-pp-msg-1-start-participant-op" >Start Participant OP</a></li>
+<li><a href="#mod-pp-msg-14-self-create-participant" >Self Create Participant</a></li>
 </ul>
-<p>It creates a new <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> inside <code>VSOperatorAuthorization[corporation, vs_operator]</code> and, if the record enables a fee grant and its <code>expiration</code> is in the future, synchronises the on-chain <code>FeeGrant</code> for the containing VSOA.</p>
-<p>This method does NOT read <code>Permission</code> state. All authorization configuration is provided by the caller.</p>
+<p>It creates a new <a href="#participantauthorizationrecord" >ParticipantAuthorizationRecord</a> inside <code>VSOperatorAuthorization[corporation, vs_operator]</code> and, if the record enables a fee grant and its <code>expiration</code> is in the future, synchronises the on-chain <code>FeeGrant</code> for the containing VSOA.</p>
+<p>This method does NOT read <code>Participant</code> state. All authorization configuration is provided by the caller.</p>
 <h5 id="mod-de-msg-5-1-grant-vs-operator-authorization-method-parameters"><a class="toc-anchor" href="#mod-de-msg-5-1-grant-vs-operator-authorization-method-parameters" >§</a> [MOD-DE-MSG-5-1] Grant VS Operator Authorization method parameters</h5>
 <ul>
 <li><code>corporation</code> (group) (<em>mandatory</em>): the corporation delegating the authorization.</li>
 <li><code>vs_operator</code> (account) (<em>mandatory</em>): the account receiving the authorization.</li>
-<li><code>record</code> (<a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a>) (<em>mandatory</em>): the full record to store.</li>
+<li><code>record</code> (<a href="#participantauthorizationrecord" >ParticipantAuthorizationRecord</a>) (<em>mandatory</em>): the full record to store.</li>
 </ul>
 <h5 id="mod-de-msg-5-2-grant-vs-operator-authorization-basic-checks"><a class="toc-anchor" href="#mod-de-msg-5-2-grant-vs-operator-authorization-basic-checks" >§</a> [MOD-DE-MSG-5-2] Grant VS Operator Authorization basic checks</h5>
 <p>If any of these conditions is not satisfied, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
 <li><code>corporation</code> and <code>vs_operator</code> MUST NOT be null.</li>
-<li><code>record.perm_id</code> MUST NOT match an existing <code>PermissionAuthorizationRecord</code> anywhere in the store (each record is globally unique by <code>perm_id</code>).</li>
+<li><code>record.participant_id</code> MUST NOT match an existing <code>ParticipantAuthorizationRecord</code> anywhere in the store (each record is globally unique by <code>participant_id</code>).</li>
 <li><code>record.msg_types</code> MUST be non-empty and MUST contain only VPR delegable message types.</li>
 <li>No <code>OperatorAuthorization</code> <code>oauthz</code> where <code>oauthz.corporation</code> = <code>corporation</code> and <code>oauthz.operator</code> = <code>vs_operator</code> MUST exist.</li>
+<li>No other <code>VSOperatorAuthorization</code> <code>vsoauthz'</code> where <code>vsoauthz'.vs_operator</code> = <code>vs_operator</code> AND <code>vsoauthz'.corporation</code> != <code>corporation</code> MUST exist. In other words, a vs-agent VPR account cannot be controlled by multiple corporations.</li>
 </ul>
 <div id="warning-53" class="notice warning"><a class="notice-link" href="#warning-53">WARNING</a><p>A <strong>VS Operator Authorization</strong> record CAN be granted ONLY IF no <strong>OperatorAuthorization</strong> exists for the same <code>(corporation, vs_operator)</code> pair. <strong>VS Operator Authorization</strong> and <strong>Operator Authorization</strong> are mutually exclusive for a given grantee.</p>
 </div>
@@ -4981,6 +5446,12 @@ The decision between this method and specifying the amount directly is left to i
 <h5 id="mod-de-msg-5-4-grant-vs-operator-authorization-execution-of-the-method"><a class="toc-anchor" href="#mod-de-msg-5-4-grant-vs-operator-authorization-execution-of-the-method" >§</a> [MOD-DE-MSG-5-4] Grant VS Operator Authorization execution of the method</h5>
 <p>Method execution MUST perform the following tasks in a <a class="term-reference" href="#term:transaction">transaction</a>, and rollback if any error occurs.</p>
 <ul>
+<li>Initialize the runtime balances on <code>record</code>:
+<ul>
+<li>if <code>record.spend_limit</code> is set, set <code>record.remaining_spend := record.spend_limit</code>.</li>
+<li>if <code>record.fee_spend_limit</code> is set, set <code>record.remaining_fee_spend := record.fee_spend_limit</code>.</li>
+</ul>
+</li>
 <li>Load <code>VSOperatorAuthorization</code> <code>vsoa</code> with <code>(corporation, vs_operator)</code>. If it does not exist, create a new <code>vsoa</code> with <code>vsoa.corporation = corporation</code>, <code>vsoa.vs_operator = vs_operator</code>, <code>vsoa.records = []</code>.</li>
 <li>Append <code>record</code> to <code>vsoa.records</code>.</li>
 <li>Call <strong><a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >Recompute VS Operator Fee Allowance</a></strong> for <code>vsoa</code>.</li>
@@ -5007,24 +5478,24 @@ The decision between this method and specifying the amount directly is left to i
 <p>Note: <code>max_expire</code> is bounded by the farthest <code>record.expiration</code> among feegrant-enabled records. The chain-level <code>FeeGrant</code> <code>msg_types</code> is the union of all such records’ <code>msg_types</code>. Per-record spend limits are enforced at <a href="#authz-check-4-vs-operator-fee-grant-checks" >[AUTHZ-CHECK-4]</a> time; they are not replicated on the <code>FeeGrant</code> object.</p>
 </blockquote>
 <h4 id="mod-de-msg-6-revoke-vs-operator-authorization"><a class="toc-anchor" href="#mod-de-msg-6-revoke-vs-operator-authorization" >§</a> [MOD-DE-MSG-6] Revoke VS Operator Authorization</h4>
-<p>This method can only be called directly by the following Permission module methods, with no signer check:</p>
+<p>This method can only be called directly by the following Participant module methods, with no signer check:</p>
 <ul>
-<li><a href="#mod-perm-msg-6-cancel-permission-vp-last-request" >Cancel Permission VP Last Request</a> (only when the cancellation terminates the permission)</li>
-<li><a href="#mod-perm-msg-9-revoke-permission" >Revoke Permission</a></li>
-<li><a href="#mod-perm-msg-12-slash-permission-trust-deposit" >Slash Permission Trust Deposit</a></li>
+<li><a href="#mod-pp-msg-6-cancel-participant-op-last-request" >Cancel Participant OP Last Request</a> (only when the cancellation terminates the permission)</li>
+<li><a href="#mod-pp-msg-9-revoke-participant" >Revoke Participant</a></li>
+<li><a href="#mod-pp-msg-12-slash-participant-trust-deposit" >Slash Participant Trust Deposit</a></li>
 </ul>
-<p>It removes the unique <a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a> identified by <code>perm_id</code> and recomputes the on-chain <code>FeeGrant</code> of its containing VSOA. No-op if no such record exists.</p>
-<p>This method does NOT read <code>Permission</code> state.</p>
+<p>It removes the unique <a href="#participantauthorizationrecord" >ParticipantAuthorizationRecord</a> identified by <code>participant_id</code> and recomputes the on-chain <code>FeeGrant</code> of its containing VSOA. No-op if no such record exists.</p>
+<p>This method does NOT read <code>Participant</code> state.</p>
 <h5 id="mod-de-msg-6-1-revoke-vs-operator-authorization-method-parameters"><a class="toc-anchor" href="#mod-de-msg-6-1-revoke-vs-operator-authorization-method-parameters" >§</a> [MOD-DE-MSG-6-1] Revoke VS Operator Authorization method parameters</h5>
 <ul>
-<li><code>perm_id</code> (uint64) (<em>mandatory</em>): id of the permission whose authorization record must be removed.</li>
+<li><code>participant_id</code> (uint64) (<em>mandatory</em>): id of the permission whose authorization record must be removed.</li>
 </ul>
 <h5 id="mod-de-msg-6-2-revoke-vs-operator-authorization-basic-checks"><a class="toc-anchor" href="#mod-de-msg-6-2-revoke-vs-operator-authorization-basic-checks" >§</a> [MOD-DE-MSG-6-2] Revoke VS Operator Authorization basic checks</h5>
 <ul>
-<li><code>perm_id</code> MUST be a valid uint64.</li>
+<li><code>participant_id</code> MUST be a valid uint64.</li>
 </ul>
 <blockquote>
-<p>Note: absence of a record for <code>perm_id</code> is NOT an error. The method is a no-op in that case (the permission was never VS-operator-authorized, or was already revoked).</p>
+<p>Note: absence of a record for <code>participant_id</code> is NOT an error. The method is a no-op in that case (the permission was never VS-operator-authorized, or was already revoked).</p>
 </blockquote>
 <h5 id="mod-de-msg-6-3-revoke-vs-operator-authorization-fee-checks"><a class="toc-anchor" href="#mod-de-msg-6-3-revoke-vs-operator-authorization-fee-checks" >§</a> [MOD-DE-MSG-6-3] Revoke VS Operator Authorization fee checks</h5>
 <ul>
@@ -5032,32 +5503,32 @@ The decision between this method and specifying the amount directly is left to i
 </ul>
 <h5 id="mod-de-msg-6-4-revoke-vs-operator-authorization-execution-of-the-method"><a class="toc-anchor" href="#mod-de-msg-6-4-revoke-vs-operator-authorization-execution-of-the-method" >§</a> [MOD-DE-MSG-6-4] Revoke VS Operator Authorization execution of the method</h5>
 <ul>
-<li>Locate the unique <code>PermissionAuthorizationRecord</code> <code>record</code> with <code>record.perm_id = perm_id</code>. If none exists, EXIT (no-op).</li>
+<li>Locate the unique <code>ParticipantAuthorizationRecord</code> <code>record</code> with <code>record.participant_id = participant_id</code>. If none exists, EXIT (no-op).</li>
 <li>Let <code>vsoa</code> = the <code>VSOperatorAuthorization</code> that contains <code>record</code>.</li>
 <li>Remove <code>record</code> from <code>vsoa.records</code>.</li>
 <li>Call <strong><a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >Recompute VS Operator Fee Allowance</a></strong> for <code>vsoa</code>.</li>
 <li>If <code>vsoa.records</code> is now empty, delete <code>vsoa</code>.</li>
 </ul>
 <h4 id="mod-de-msg-9-update-vs-operator-authorization-expiration"><a class="toc-anchor" href="#mod-de-msg-9-update-vs-operator-authorization-expiration" >§</a> [MOD-DE-MSG-9] Update VS Operator Authorization Expiration</h4>
-<p>This method can only be called directly by the following Permission module methods, with no signer check:</p>
+<p>This method can only be called directly by the following Participant module methods, with no signer check:</p>
 <ul>
-<li><a href="#mod-perm-msg-3-set-permission-vp-to-validated" >Set Permission VP to Validated</a></li>
-<li><a href="#mod-perm-msg-8-adjust-permission" >Adjust Permission</a></li>
+<li><a href="#mod-pp-msg-3-set-participant-op-to-validated" >Set Participant OP to Validated</a></li>
+<li><a href="#mod-pp-msg-8-set-participant-effective-until" >Set Participant Effective Until</a></li>
 </ul>
-<p>It updates the <code>expiration</code> of the unique record identified by <code>perm_id</code> and recomputes the on-chain <code>FeeGrant</code> of its containing VSOA. No-op if no record exists for <code>perm_id</code>.</p>
-<p>This method does NOT read <code>Permission</code> state; the caller supplies the new expiration value directly.</p>
+<p>It updates the <code>expiration</code> of the unique record identified by <code>participant_id</code> and recomputes the on-chain <code>FeeGrant</code> of its containing VSOA. No-op if no record exists for <code>participant_id</code>.</p>
+<p>This method does NOT read <code>Participant</code> state; the caller supplies the new expiration value directly.</p>
 <h5 id="mod-de-msg-9-1-update-vs-operator-authorization-expiration-method-parameters"><a class="toc-anchor" href="#mod-de-msg-9-1-update-vs-operator-authorization-expiration-method-parameters" >§</a> [MOD-DE-MSG-9-1] Update VS Operator Authorization Expiration method parameters</h5>
 <ul>
-<li><code>perm_id</code> (uint64) (<em>mandatory</em>): id of the permission whose authorization record’s <code>expiration</code> must be updated.</li>
+<li><code>participant_id</code> (uint64) (<em>mandatory</em>): id of the permission whose authorization record’s <code>expiration</code> must be updated.</li>
 <li><code>new_expiration</code> (timestamp) (<em>mandatory</em>): the new value of <code>record.expiration</code>.</li>
 </ul>
 <h5 id="mod-de-msg-9-2-update-vs-operator-authorization-expiration-basic-checks"><a class="toc-anchor" href="#mod-de-msg-9-2-update-vs-operator-authorization-expiration-basic-checks" >§</a> [MOD-DE-MSG-9-2] Update VS Operator Authorization Expiration basic checks</h5>
 <ul>
-<li><code>perm_id</code> MUST be a valid uint64.</li>
+<li><code>participant_id</code> MUST be a valid uint64.</li>
 <li><code>new_expiration</code> MUST be a valid timestamp.</li>
 </ul>
 <blockquote>
-<p>Note: absence of a record for <code>perm_id</code> is NOT an error. The method is a no-op in that case (the permission does not enable VS operator authorization).</p>
+<p>Note: absence of a record for <code>participant_id</code> is NOT an error. The method is a no-op in that case (the permission does not enable VS operator authorization).</p>
 </blockquote>
 <h5 id="mod-de-msg-9-3-update-vs-operator-authorization-expiration-fee-checks"><a class="toc-anchor" href="#mod-de-msg-9-3-update-vs-operator-authorization-expiration-fee-checks" >§</a> [MOD-DE-MSG-9-3] Update VS Operator Authorization Expiration fee checks</h5>
 <ul>
@@ -5065,7 +5536,7 @@ The decision between this method and specifying the amount directly is left to i
 </ul>
 <h5 id="mod-de-msg-9-4-update-vs-operator-authorization-expiration-execution-of-the-method"><a class="toc-anchor" href="#mod-de-msg-9-4-update-vs-operator-authorization-expiration-execution-of-the-method" >§</a> [MOD-DE-MSG-9-4] Update VS Operator Authorization Expiration execution of the method</h5>
 <ul>
-<li>Locate the unique <code>PermissionAuthorizationRecord</code> <code>record</code> with <code>record.perm_id = perm_id</code>. If none exists, EXIT (no-op).</li>
+<li>Locate the unique <code>ParticipantAuthorizationRecord</code> <code>record</code> with <code>record.participant_id = participant_id</code>. If none exists, EXIT (no-op).</li>
 <li>Set <code>record.expiration = new_expiration</code>.</li>
 <li>Call <strong><a href="#mod-de-msg-5-5-recompute-vs-operator-fee-allowance" >Recompute VS Operator Fee Allowance</a></strong> for the VSOA containing <code>record</code>.</li>
 </ul>
@@ -5104,7 +5575,7 @@ The decision between this method and specifying the amount directly is left to i
 <h4 id="mod-di-msg-1-store-digest"><a class="toc-anchor" href="#mod-di-msg-1-store-digest" >§</a> [MOD-DI-MSG-1] Store Digest</h4>
 <ul>
 <li>Any authorized <code>operator</code> CAN execute this method on behalf of a <code>corporation</code>.</li>
-<li>This method can be called directly by <a href="#mod-perm-msg-10-create-or-update-permission-session" >Create or Update Permission Session</a> module with no checks.</li>
+<li>This method can be called directly by <a href="#mod-pp-msg-10-create-or-update-participant-session" >Create or Update Participant Session</a> module with no checks.</li>
 </ul>
 <h5 id="mod-di-msg-1-1-store-digest-method-parameters"><a class="toc-anchor" href="#mod-di-msg-1-1-store-digest-method-parameters" >§</a> [MOD-DI-MSG-1-1] Store Digest method parameters</h5>
 <ul>
@@ -5279,23 +5750,39 @@ The decision between this method and specifying the amount directly is left to i
 <li><code>xr.updated</code> = block timestamp</li>
 </ul>
 <h4 id="mod-xr-msg-2-update-exchange-rate"><a class="toc-anchor" href="#mod-xr-msg-2-update-exchange-rate" >§</a> [MOD-XR-MSG-2] Update Exchange Rate</h4>
-<p>Only an authorized operator that has an ExchangeRateAuthorization can execute this method.</p>
+<p>The <strong>Update Exchange Rate</strong> method allows an operator authorized by network governance (via an <code>ExchangeRateAuthorization</code>) to push a fresh <code>rate</code> for a given <code>ExchangeRate</code> entry.</p>
+<ul>
+<li>Only the <code>operator</code> designated in an <code>ExchangeRateAuthorization</code> matching the target <code>ExchangeRate</code> CAN execute this method.</li>
+</ul>
 <h5 id="mod-xr-msg-2-update-exchange-rate-method-parameters"><a class="toc-anchor" href="#mod-xr-msg-2-update-exchange-rate-method-parameters" >§</a> [MOD-XR-MSG-2] Update Exchange Rate method parameters</h5>
 <ul>
-<li><code>id</code> (uint64, <em>mandatory</em>)</li>
-<li><code>rate</code> (string, <em>mandatory</em>)</li>
+<li><code>operator</code> (account) (<em>mandatory</em>): (Signer) the account pushing the new rate.</li>
+<li><code>id</code> (uint64, <em>mandatory</em>): id of the target <code>ExchangeRate</code> entry.</li>
+<li><code>rate</code> (string, <em>mandatory</em>): the new fixed-point integer rate value.</li>
 </ul>
 <h5 id="mod-xr-msg-2-update-exchange-rate-precondition-checks"><a class="toc-anchor" href="#mod-xr-msg-2-update-exchange-rate-precondition-checks" >§</a> [MOD-XR-MSG-2] Update Exchange Rate precondition checks</h5>
 <p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <h6 id="mod-xr-msg-2-update-exchange-rate-basic-checks"><a class="toc-anchor" href="#mod-xr-msg-2-update-exchange-rate-basic-checks" >§</a> [MOD-XR-MSG-2] Update Exchange Rate basic checks</h6>
 <p>If any of the following conditions is not satisfied, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
 <ul>
-<li><strong>Authorization</strong></li>
-</ul>
-<p>Only an authorized operator that has an ExchangeRateAuthorization can execute this method.</p>
+<li>
+<p><code>operator</code> (account): (Signer) signature MUST be verified.</p>
+</li>
+<li>
+<p><code>id</code> (uint64, <em>mandatory</em>) MUST refer to an existing <code>ExchangeRate</code> entry <code>xr</code> with <code>xr.state</code> = true.</p>
+</li>
+<li>
+<p><code>rate</code> MUST be strictly greater than <code>&quot;0&quot;</code>.</p>
+</li>
+<li>
+<p><strong>Authorization</strong>:</p>
 <ul>
-<li><code>id</code> (uint64, <em>mandatory</em>) must refer to an existing <code>ExchangeRate</code> entry <code>xr</code> with <code>xr.active</code> = true</li>
-<li><code>rate</code> MUST be strictly greater than <code>&quot;0&quot;</code>.</li>
+<li>An <code>ExchangeRateAuthorization</code> <code>xrauthz</code> MUST exist where <code>xrauthz.xr_id</code> = <code>id</code> and <code>xrauthz.operator</code> = <code>operator</code>.</li>
+<li><code>xrauthz.expiration</code> MUST be in the future (<code>now() &lt; xrauthz.expiration</code>).</li>
+<li>If <code>xrauthz.min_interval</code> is set, then <code>now() - xr.updated</code> MUST be greater than or equal to <code>xrauthz.min_interval</code>.</li>
+<li>If <code>xrauthz.max_deviation_bps</code> is set, then <code>|rate - xr.rate| * 10000</code> MUST be less than or equal to <code>xrauthz.max_deviation_bps * xr.rate</code> (i.e., the relative change between the new <code>rate</code> and <code>xr.rate</code> MUST NOT exceed <code>xrauthz.max_deviation_bps</code> basis points). Both values share the same <code>xr.rate_scale</code>, since <code>MOD-XR-MSG-2</code> does not update the scale.</li>
+</ul>
+</li>
 </ul>
 <h6 id="mod-xr-msg-2-update-exchange-rate-fee-checks"><a class="toc-anchor" href="#mod-xr-msg-2-update-exchange-rate-fee-checks" >§</a> [MOD-XR-MSG-2] Update Exchange Rate fee checks</h6>
 <p>Fee payer MUST have sufficient <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</p>
@@ -5303,7 +5790,7 @@ The decision between this method and specifying the amount directly is left to i
 <p>Load <code>ExchangeRate</code> <code>xr</code>.</p>
 <ul>
 <li><code>xr.rate</code> = <code>rate</code></li>
-<li><code>xr.expires</code> = block time + <code>validity_duration</code></li>
+<li><code>xr.expires</code> = block time + <code>xr.validity_duration</code></li>
 <li><code>xr.updated</code> = block time</li>
 </ul>
 <h4 id="mod-xr-msg-3-toggle-exchange-rate-state"><a class="toc-anchor" href="#mod-xr-msg-3-toggle-exchange-rate-state" >§</a> [MOD-XR-MSG-3] Toggle Exchange Rate State</h4>
@@ -5335,6 +5822,74 @@ The decision between this method and specifying the amount directly is left to i
 <ul>
 <li>set <code>xr.state</code> to !<code>xr.state</code>.</li>
 <li>set <code>xr.updated</code> to block time</li>
+</ul>
+<h4 id="mod-xr-msg-4-grant-exchange-rate-authorization"><a class="toc-anchor" href="#mod-xr-msg-4-grant-exchange-rate-authorization" >§</a> [MOD-XR-MSG-4] Grant Exchange Rate Authorization</h4>
+<p>The <strong>Grant Exchange Rate Authorization</strong> method creates (or updates) an <code>ExchangeRateAuthorization</code> record designating a network-level operator allowed to push fresh rates for a given <code>ExchangeRate</code> via <a href="#mod-xr-msg-2-update-exchange-rate" >[MOD-XR-MSG-2]</a>.</p>
+<ul>
+<li>Only a governance proposal CAN execute this method.</li>
+</ul>
+<h5 id="mod-xr-msg-4-grant-exchange-rate-authorization-method-parameters"><a class="toc-anchor" href="#mod-xr-msg-4-grant-exchange-rate-authorization-method-parameters" >§</a> [MOD-XR-MSG-4] Grant Exchange Rate Authorization method parameters</h5>
+<ul>
+<li><code>xr_id</code> (uint64) (<em>mandatory</em>): id of the target <code>ExchangeRate</code>.</li>
+<li><code>operator</code> (account) (<em>mandatory</em>): the account receiving the authorization.</li>
+<li><code>expiration</code> (timestamp) (<em>mandatory</em>): authorization end-of-life.</li>
+<li><code>min_interval</code> (duration) (<em>optional</em>): minimum time between two successive <a href="#mod-xr-msg-2-update-exchange-rate" >[MOD-XR-MSG-2]</a> calls under this authorization.</li>
+<li><code>max_deviation_bps</code> (uint32) (<em>optional</em>): maximum relative change per update, in basis points.</li>
+</ul>
+<h5 id="mod-xr-msg-4-grant-exchange-rate-authorization-precondition-checks"><a class="toc-anchor" href="#mod-xr-msg-4-grant-exchange-rate-authorization-precondition-checks" >§</a> [MOD-XR-MSG-4] Grant Exchange Rate Authorization precondition checks</h5>
+<p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<h6 id="mod-xr-msg-4-grant-exchange-rate-authorization-basic-checks"><a class="toc-anchor" href="#mod-xr-msg-4-grant-exchange-rate-authorization-basic-checks" >§</a> [MOD-XR-MSG-4] Grant Exchange Rate Authorization basic checks</h6>
+<p>If any of the following conditions is not satisfied, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<ul>
+<li><strong>Authorization</strong>
+<ul>
+<li>Only a governance proposal can grant an <code>ExchangeRateAuthorization</code>.</li>
+</ul>
+</li>
+<li><code>xr_id</code> MUST refer to an existing <code>ExchangeRate</code> entry.</li>
+<li><code>operator</code> MUST be a valid account.</li>
+<li><code>expiration</code> MUST be in the future.</li>
+<li><code>min_interval</code>, if specified, MUST be a valid, strictly positive duration.</li>
+<li><code>max_deviation_bps</code>, if specified, MUST be strictly greater than <code>0</code> and less than or equal to <code>10000</code>.</li>
+</ul>
+<h6 id="mod-xr-msg-4-grant-exchange-rate-authorization-fee-checks"><a class="toc-anchor" href="#mod-xr-msg-4-grant-exchange-rate-authorization-fee-checks" >§</a> [MOD-XR-MSG-4] Grant Exchange Rate Authorization fee checks</h6>
+<p>Fee payer MUST have sufficient <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</p>
+<h5 id="mod-xr-msg-4-grant-exchange-rate-authorization-execution-of-the-method"><a class="toc-anchor" href="#mod-xr-msg-4-grant-exchange-rate-authorization-execution-of-the-method" >§</a> [MOD-XR-MSG-4] Grant Exchange Rate Authorization execution of the method</h5>
+<p>Create (or update if it already exists) <code>ExchangeRateAuthorization</code> <code>xrauthz</code> keyed by (<code>xr_id</code>, <code>operator</code>):</p>
+<ul>
+<li><code>xrauthz.xr_id</code> = <code>xr_id</code></li>
+<li><code>xrauthz.operator</code> = <code>operator</code></li>
+<li><code>xrauthz.expiration</code> = <code>expiration</code></li>
+<li><code>xrauthz.min_interval</code> = <code>min_interval</code> (if provided, else unset)</li>
+<li><code>xrauthz.max_deviation_bps</code> = <code>max_deviation_bps</code> (if provided, else unset)</li>
+</ul>
+<h4 id="mod-xr-msg-5-revoke-exchange-rate-authorization"><a class="toc-anchor" href="#mod-xr-msg-5-revoke-exchange-rate-authorization" >§</a> [MOD-XR-MSG-5] Revoke Exchange Rate Authorization</h4>
+<p>The <strong>Revoke Exchange Rate Authorization</strong> method deletes an existing <code>ExchangeRateAuthorization</code> record, immediately preventing the designated operator from executing further <a href="#mod-xr-msg-2-update-exchange-rate" >[MOD-XR-MSG-2]</a> calls on the target <code>ExchangeRate</code>.</p>
+<ul>
+<li>Only a governance proposal CAN execute this method.</li>
+</ul>
+<h5 id="mod-xr-msg-5-revoke-exchange-rate-authorization-method-parameters"><a class="toc-anchor" href="#mod-xr-msg-5-revoke-exchange-rate-authorization-method-parameters" >§</a> [MOD-XR-MSG-5] Revoke Exchange Rate Authorization method parameters</h5>
+<ul>
+<li><code>xr_id</code> (uint64) (<em>mandatory</em>): id of the target <code>ExchangeRate</code>.</li>
+<li><code>operator</code> (account) (<em>mandatory</em>): the account whose authorization is revoked.</li>
+</ul>
+<h5 id="mod-xr-msg-5-revoke-exchange-rate-authorization-precondition-checks"><a class="toc-anchor" href="#mod-xr-msg-5-revoke-exchange-rate-authorization-precondition-checks" >§</a> [MOD-XR-MSG-5] Revoke Exchange Rate Authorization precondition checks</h5>
+<p>If any of these precondition checks fail, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<h6 id="mod-xr-msg-5-revoke-exchange-rate-authorization-basic-checks"><a class="toc-anchor" href="#mod-xr-msg-5-revoke-exchange-rate-authorization-basic-checks" >§</a> [MOD-XR-MSG-5] Revoke Exchange Rate Authorization basic checks</h6>
+<p>If any of the following conditions is not satisfied, <a class="term-reference" href="#term:transaction">transaction</a> MUST abort.</p>
+<ul>
+<li><strong>Authorization</strong>
+<ul>
+<li>Only a governance proposal can revoke an <code>ExchangeRateAuthorization</code>.</li>
+</ul>
+</li>
+<li>An <code>ExchangeRateAuthorization</code> entry MUST exist for (<code>xr_id</code>, <code>operator</code>).</li>
+</ul>
+<h6 id="mod-xr-msg-5-revoke-exchange-rate-authorization-fee-checks"><a class="toc-anchor" href="#mod-xr-msg-5-revoke-exchange-rate-authorization-fee-checks" >§</a> [MOD-XR-MSG-5] Revoke Exchange Rate Authorization fee checks</h6>
+<p>Fee payer MUST have sufficient <a class="term-reference" href="#term:estimated-transaction-fees">estimated transaction fees</a>.</p>
+<h5 id="mod-xr-msg-5-revoke-exchange-rate-authorization-execution-of-the-method"><a class="toc-anchor" href="#mod-xr-msg-5-revoke-exchange-rate-authorization-execution-of-the-method" >§</a> [MOD-XR-MSG-5] Revoke Exchange Rate Authorization execution of the method</h5>
+<ul>
+<li>Delete <code>ExchangeRateAuthorization</code> entry for (<code>xr_id</code>, <code>operator</code>).</li>
 </ul>
 <h4 id="mod-xr-qry-1-get-exchange-rate"><a class="toc-anchor" href="#mod-xr-qry-1-get-exchange-rate" >§</a> [MOD-XR-QRY-1] Get Exchange Rate</h4>
 <p>Any <a class="term-reference" href="#term:account">account</a> CAN run this <a class="term-reference" href="#term:query">query</a>.</p>
@@ -5518,7 +6073,7 @@ rate_scale       = S</p>
 <li><a href="#about-this-document" >About this Document</a></li>
 <li><a href="#introduction" >Introduction</a>
 <ul>
-<li><a href="#what-is-a-trust-registry" >What is a Trust Registry?</a></li>
+<li><a href="#what-is-an-ecosystem" >What is an Ecosystem?</a></li>
 <li><a href="#what-is-a-verifiable-public-registry" >What is a Verifiable Public Registry?</a></li>
 <li><a href="#conformance" >Conformance</a></li>
 </ul>
@@ -5532,14 +6087,14 @@ rate_scale       = S</p>
 </li>
 <li><a href="#features-of-a-verifiable-public-registry-vpr" >Features of a Verifiable Public Registry (VPR)</a>
 <ul>
-<li><a href="#trust-registry-management" >Trust Registry Management</a></li>
-<li><a href="#credential-schemas-and-permissions" >Credential Schemas and Permissions</a></li>
+<li><a href="#ecosystem-management" >Ecosystem Management</a></li>
+<li><a href="#credential-schemas-and-participants" >Credential Schemas and Participants</a></li>
+<li><a href="#corporation-management" >Corporation Management</a></li>
 <li><a href="#did-indexing" >DID Indexing</a></li>
 <li><a href="#business-models" >Business models</a>
 <ul>
 <li><a href="#trust-deposit" >Trust Deposit</a></li>
-<li><a href="#object-creation" >Object creation</a></li>
-<li><a href="#validation-process-trust-fees" >Validation process trust fees</a></li>
+<li><a href="#onboarding-process-trust-fees" >Onboarding Process Trust Fees</a></li>
 <li><a href="#pay-per-trust-fees" >“Pay-Per” trust fees</a></li>
 </ul>
 </li>
@@ -5548,22 +6103,24 @@ rate_scale       = S</p>
 <li><a href="#governance-of-a-vpr" >Governance of a VPR</a></li>
 <li><a href="#data-model" >Data model</a>
 <ul>
-<li><a href="#trustregistry" >TrustRegistry</a></li>
+<li><a href="#corporation" >Corporation</a></li>
+<li><a href="#ecosystem" >Ecosystem</a></li>
 <li><a href="#governanceframeworkversion" >GovernanceFrameworkVersion</a></li>
 <li><a href="#governanceframeworkdocument" >GovernanceFrameworkDocument</a></li>
 <li><a href="#credentialschema" >CredentialSchema</a></li>
 <li><a href="#schemaauthorizationpolicy" >SchemaAuthorizationPolicy</a></li>
-<li><a href="#permission" >Permission</a></li>
-<li><a href="#permissionsession" >PermissionSession</a></li>
-<li><a href="#permissionsessionrecord" >PermissionSessionRecord</a></li>
+<li><a href="#participant" >Participant</a></li>
+<li><a href="#participantsession" >ParticipantSession</a></li>
+<li><a href="#participantsessionrecord" >ParticipantSessionRecord</a></li>
 <li><a href="#trustdeposit" >TrustDeposit</a></li>
 <li><a href="#denomamount" >DenomAmount</a></li>
 <li><a href="#digest" >Digest</a></li>
 <li><a href="#operatorauthorization" >OperatorAuthorization</a></li>
 <li><a href="#feegrant" >FeeGrant</a></li>
 <li><a href="#vsoperatorauthorization" >VSOperatorAuthorization</a></li>
-<li><a href="#permissionauthorizationrecord" >PermissionAuthorizationRecord</a></li>
+<li><a href="#participantauthorizationrecord" >ParticipantAuthorizationRecord</a></li>
 <li><a href="#exchangerate" >ExchangeRate</a></li>
+<li><a href="#exchangerateauthorization" >ExchangeRateAuthorization</a></li>
 <li><a href="#globalvariables" >GlobalVariables</a></li>
 </ul>
 </li>
@@ -5580,17 +6137,34 @@ rate_scale       = S</p>
 </ul>
 </li>
 <li><a href="#method-list" >Method List</a></li>
-<li><a href="#trust-registry-module" >Trust Registry Module</a>
+<li><a href="#corporation-module" >Corporation Module</a>
 <ul>
-<li><a href="#mod-tr-msg-1-create-new-trust-registry" >[MOD-TR-MSG-1] Create New Trust Registry</a></li>
-<li><a href="#mod-tr-msg-2-add-governance-framework-document" >[MOD-TR-MSG-2] Add Governance Framework Document</a></li>
-<li><a href="#mod-tr-msg-3-increase-active-governance-framework-version" >[MOD-TR-MSG-3] Increase Active Governance Framework Version</a></li>
-<li><a href="#mod-tr-msg-4-update-trust-registry" >[MOD-TR-MSG-4] Update Trust Registry</a></li>
-<li><a href="#mod-tr-msg-5-archive-trust-registry" >[MOD-TR-MSG-5] Archive Trust Registry</a></li>
-<li><a href="#mod-tr-msg-6-update-module-parameters" >[MOD-TR-MSG-6] Update Module Parameters</a></li>
-<li><a href="#mod-tr-qry-1-get-trust-registry" >[MOD-TR-QRY-1] Get Trust Registry</a></li>
-<li><a href="#mod-tr-qry-2-list-trust-registries" >[MOD-TR-QRY-2] List Trust Registries</a></li>
-<li><a href="#mod-tr-qry-3-list-module-parameters" >[MOD-TR-QRY-3] List Module Parameters</a></li>
+<li><a href="#mod-co-msg-1-create-new-corporation" >[MOD-CO-MSG-1] Create New Corporation</a></li>
+<li><a href="#mod-co-msg-2-update-corporation" >[MOD-CO-MSG-2] Update Corporation</a></li>
+<li><a href="#mod-co-msg-3-archive-corporation" >[MOD-CO-MSG-3] Archive Corporation</a></li>
+<li><a href="#mod-co-msg-4-update-module-parameters" >[MOD-CO-MSG-4] Update Module Parameters</a></li>
+<li><a href="#mod-co-qry-1-get-corporation" >[MOD-CO-QRY-1] Get Corporation</a></li>
+<li><a href="#mod-co-qry-2-list-corporations" >[MOD-CO-QRY-2] List Corporations</a></li>
+<li><a href="#mod-co-qry-3-list-module-parameters" >[MOD-CO-QRY-3] List Module Parameters</a></li>
+</ul>
+</li>
+<li><a href="#ecosystem-module" >Ecosystem Module</a>
+<ul>
+<li><a href="#mod-es-msg-1-create-new-ecosystem" >[MOD-ES-MSG-1] Create New Ecosystem</a></li>
+<li><a href="#mod-es-msg-2-update-ecosystem" >[MOD-ES-MSG-2] Update Ecosystem</a></li>
+<li><a href="#mod-es-msg-3-archive-ecosystem" >[MOD-ES-MSG-3] Archive Ecosystem</a></li>
+<li><a href="#mod-es-msg-4-update-module-parameters" >[MOD-ES-MSG-4] Update Module Parameters</a></li>
+<li><a href="#mod-es-qry-1-get-ecosystem" >[MOD-ES-QRY-1] Get Ecosystem</a></li>
+<li><a href="#mod-es-qry-2-list-ecosystems" >[MOD-ES-QRY-2] List Ecosystems</a></li>
+<li><a href="#mod-es-qry-3-list-module-parameters" >[MOD-ES-QRY-3] List Module Parameters</a></li>
+</ul>
+</li>
+<li><a href="#governance-framework-module" >Governance Framework Module</a>
+<ul>
+<li><a href="#mod-gf-msg-1-add-governance-framework-document" >[MOD-GF-MSG-1] Add Governance Framework Document</a></li>
+<li><a href="#mod-gf-msg-2-increase-active-governance-framework-version" >[MOD-GF-MSG-2] Increase Active Governance Framework Version</a></li>
+<li><a href="#mod-gf-qry-1-get-governance-framework-version" >[MOD-GF-QRY-1] Get Governance Framework Version</a></li>
+<li><a href="#mod-gf-qry-2-list-governance-framework-versions" >[MOD-GF-QRY-2] List Governance Framework Versions</a></li>
 </ul>
 </li>
 <li><a href="#credential-schema-module" >Credential Schema Module</a>
@@ -5610,30 +6184,30 @@ rate_scale       = S</p>
 <li><a href="#mod-cs-qry-6-list-schema-authorization-policies" >[MOD-CS-QRY-6] List Schema Authorization Policies</a></li>
 </ul>
 </li>
-<li><a href="#permission-module" >Permission Module</a>
+<li><a href="#participant-module" >Participant Module</a>
 <ul>
-<li><a href="#permission-module-overview" >Permission Module Overview</a></li>
-<li><a href="#mod-perm-msg-1-start-permission-vp" >[MOD-PERM-MSG-1] Start Permission VP</a></li>
+<li><a href="#participant-module-overview" >Participant Module Overview</a></li>
+<li><a href="#mod-pp-msg-1-start-participant-op" >[MOD-PP-MSG-1] Start Participant OP</a></li>
 <li><a href="#connecting-to-the-vs-of-the-validator" >Connecting to the VS of the Validator</a></li>
-<li><a href="#mod-perm-msg-2-renew-permission-vp" >[MOD-PERM-MSG-2] Renew Permission VP</a></li>
-<li><a href="#mod-perm-msg-3-set-permission-vp-to-validated" >[MOD-PERM-MSG-3] Set Permission VP to Validated</a></li>
-<li><a href="#mod-perm-msg-4-void" >[MOD-PERM-MSG-4] Void</a></li>
-<li><a href="#mod-perm-msg-5-void" >[MOD-PERM-MSG-5] Void</a></li>
-<li><a href="#mod-perm-msg-6-cancel-permission-vp-last-request" >[MOD-PERM-MSG-6] Cancel Permission VP Last Request</a></li>
-<li><a href="#mod-perm-msg-7-create-root-permission" >[MOD-PERM-MSG-7] Create Root Permission</a></li>
-<li><a href="#mod-perm-msg-8-adjust-permission" >[MOD-PERM-MSG-8] Adjust Permission</a></li>
-<li><a href="#mod-perm-msg-9-revoke-permission" >[MOD-PERM-MSG-9] Revoke Permission</a></li>
-<li><a href="#mod-perm-msg-10-create-or-update-permission-session" >[MOD-PERM-MSG-10] Create or Update Permission Session</a></li>
-<li><a href="#mod-perm-msg-11-update-permission-module-parameters" >[MOD-PERM-MSG-11] Update Permission Module Parameters</a></li>
-<li><a href="#mod-perm-msg-12-slash-permission-trust-deposit" >[MOD-PERM-MSG-12] Slash Permission Trust Deposit</a></li>
-<li><a href="#mod-perm-msg-13-repay-permission-slashed-trust-deposit" >[MOD-PERM-MSG-13] Repay Permission Slashed Trust Deposit</a></li>
-<li><a href="#mod-perm-msg-14-self-create-permission" >[MOD-PERM-MSG-14] Self Create Permission</a></li>
-<li><a href="#mod-perm-msg-15-trigger-resolver" >[MOD-PERM-MSG-15] Trigger Resolver</a></li>
-<li><a href="#mod-perm-qry-1-list-permissions" >[MOD-PERM-QRY-1] List Permissions</a></li>
-<li><a href="#mod-perm-qry-2-get-permission" >[MOD-PERM-QRY-2] Get Permission</a></li>
-<li><a href="#mod-perm-qry-3-void" >[MOD-PERM-QRY-3] Void</a></li>
-<li><a href="#mod-perm-qry-4-find-beneficiaries" >[MOD-PERM-QRY-4] Find Beneficiaries</a></li>
-<li><a href="#mod-perm-qry-5-get-permissionsession" >[MOD-PERM-QRY-5] Get PermissionSession</a></li>
+<li><a href="#mod-pp-msg-2-renew-participant-op" >[MOD-PP-MSG-2] Renew Participant OP</a></li>
+<li><a href="#mod-pp-msg-3-set-participant-op-to-validated" >[MOD-PP-MSG-3] Set Participant OP to Validated</a></li>
+<li><a href="#mod-pp-msg-4-void" >[MOD-PP-MSG-4] Void</a></li>
+<li><a href="#mod-pp-msg-5-void" >[MOD-PP-MSG-5] Void</a></li>
+<li><a href="#mod-pp-msg-6-cancel-participant-op-last-request" >[MOD-PP-MSG-6] Cancel Participant OP Last Request</a></li>
+<li><a href="#mod-pp-msg-7-create-root-participant" >[MOD-PP-MSG-7] Create Root Participant</a></li>
+<li><a href="#mod-pp-msg-8-set-participant-effective-until" >[MOD-PP-MSG-8] Set Participant Effective Until</a></li>
+<li><a href="#mod-pp-msg-9-revoke-participant" >[MOD-PP-MSG-9] Revoke Participant</a></li>
+<li><a href="#mod-pp-msg-10-create-or-update-participant-session" >[MOD-PP-MSG-10] Create or Update Participant Session</a></li>
+<li><a href="#mod-pp-msg-11-update-participant-module-parameters" >[MOD-PP-MSG-11] Update Participant Module Parameters</a></li>
+<li><a href="#mod-pp-msg-12-slash-participant-trust-deposit" >[MOD-PP-MSG-12] Slash Participant Trust Deposit</a></li>
+<li><a href="#mod-pp-msg-13-repay-participant-slashed-trust-deposit" >[MOD-PP-MSG-13] Repay Participant Slashed Trust Deposit</a></li>
+<li><a href="#mod-pp-msg-14-self-create-participant" >[MOD-PP-MSG-14] Self Create Participant</a></li>
+<li><a href="#mod-pp-msg-15-trigger-resolver" >[MOD-PP-MSG-15] Trigger Resolver</a></li>
+<li><a href="#mod-pp-qry-1-list-participants" >[MOD-PP-QRY-1] List Participants</a></li>
+<li><a href="#mod-pp-qry-2-get-participant" >[MOD-PP-QRY-2] Get Participant</a></li>
+<li><a href="#mod-pp-qry-3-void" >[MOD-PP-QRY-3] Void</a></li>
+<li><a href="#mod-pp-qry-4-find-beneficiaries" >[MOD-PP-QRY-4] Find Beneficiaries</a></li>
+<li><a href="#mod-pp-qry-5-get-participantsession" >[MOD-PP-QRY-5] Get ParticipantSession</a></li>
 <li><a href="#validation-examples" >Validation Examples</a></li>
 </ul>
 </li>
@@ -5664,6 +6238,8 @@ rate_scale       = S</p>
 <li><a href="#mod-xr-msg-1-create-exchange-rate" >[MOD-XR-MSG-1] Create Exchange Rate</a></li>
 <li><a href="#mod-xr-msg-2-update-exchange-rate" >[MOD-XR-MSG-2] Update Exchange Rate</a></li>
 <li><a href="#mod-xr-msg-3-toggle-exchange-rate-state" >[MOD-XR-MSG-3] Toggle Exchange Rate State</a></li>
+<li><a href="#mod-xr-msg-4-grant-exchange-rate-authorization" >[MOD-XR-MSG-4] Grant Exchange Rate Authorization</a></li>
+<li><a href="#mod-xr-msg-5-revoke-exchange-rate-authorization" >[MOD-XR-MSG-5] Revoke Exchange Rate Authorization</a></li>
 <li><a href="#mod-xr-qry-1-get-exchange-rate" >[MOD-XR-QRY-1] Get Exchange Rate</a></li>
 <li><a href="#mod-xr-qry-2-list-exchange-rates" >[MOD-XR-QRY-2] List Exchange Rates</a></li>
 <li><a href="#mod-xr-qry-3-get-price" >[MOD-XR-QRY-3] Get Price</a></li>

--- a/spec.md
+++ b/spec.md
@@ -1282,7 +1282,7 @@ csp "1" --- "0..n" da: vs_operator_fee_spend_limit
 
 
 tr "1" --- "0..n" gfv: versions (ecosystem_id)
-corp "1" --- "0..n" gfv: versions (corporation_id)
+corp "1" --- "0..n" gfv: versions (corporation)
 gfv "1" --- "1..n" gfd: documents
 
 group "1" --- "1" corp
@@ -1332,17 +1332,17 @@ A `Corporation` is the VPR-level entity that extends a Cosmos SDK [[ref: group]]
 
 ### GovernanceFrameworkVersion
 
-A `GovernanceFrameworkVersion` represents a single version of either an [[ref: EGF]] or a [[ref: CGF]]. Its owning subject is identified by exactly one of `ecosystem_id` or `corporation_id` (XOR).
+A `GovernanceFrameworkVersion` represents a single version of either an [[ref: EGF]] or a [[ref: CGF]]. Its owning subject is identified by exactly one of `ecosystem_id` or `corporation` (XOR).
 
 `GovernanceFrameworkVersion`:
 
 - `id` (uint64) (*mandatory*): the id of the GFV.
-- `ecosystem_id` (uint64) (*conditional*): the id of the [[ref: ecosystem]] that controls this `GovernanceFrameworkVersion` entry. MUST be set if `corporation_id` is null.
-- `corporation_id` (uint64) (*conditional*): the id of the [[ref: corporation]] that controls this `GovernanceFrameworkVersion` entry. MUST be set if `ecosystem_id` is null.
+- `ecosystem_id` (uint64) (*conditional*): the id of the [[ref: ecosystem]] that controls this `GovernanceFrameworkVersion` entry. MUST be set if `corporation` is null.
+- `corporation` (group) (*conditional*): the [[ref: corporation]] that controls this `GovernanceFrameworkVersion` entry, identified by its underlying [[ref: group]]. MUST be set if `ecosystem_id` is null.
 - `created` (timestamp) (*mandatory*): timestamp this GovernanceFrameworkVersion has been created.
 - `version` (int) (*mandatory*): version of this GF. MUST Starts with 1.
 
-> Constraint: exactly one of `ecosystem_id` and `corporation_id` MUST be set.
+> Constraint: exactly one of `ecosystem_id` and `corporation` MUST be set.
 
 ### GovernanceFrameworkDocument
 
@@ -1987,7 +1987,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - `gfv.id`: auto-incremented uint64
 - `gfv.ecosystem_id`: null
-- `gfv.corporation_id`: id of the signing [[ref: group]] (i.e., the key of `co`)
+- `gfv.corporation`: the signing [[ref: group]] (i.e., the key of `co`)
 - `gfv.created`: current timestamp
 - `gfv.version`: 1
 - `gfv.active_since`: current timestamp
@@ -2241,7 +2241,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - `gfv.id`: auto-incremented uint64
 - `gfv.ecosystem_id`: `ecosystem.id`
-- `gfv.corporation_id`: null
+- `gfv.corporation`: null
 - `gfv.created`: current timestamp
 - `gfv.version`: 1
 - `gfv.active_since`: current timestamp
@@ -2436,7 +2436,7 @@ Return the list of the existing parameters and their values.
 
 ### Governance Framework Module
 
-This module handles [[ref: governance framework]] documents and version activation for both [[ref: ecosystems]] and [[ref: corporations]]. Methods are polymorphic over the owning subject: every message specifies exactly one of `ecosystem_id` or `corporation_id` to designate whose governance framework is being modified.
+This module handles [[ref: governance framework]] documents and version activation for both [[ref: ecosystems]] and [[ref: corporations]]. Methods are polymorphic over the owning subject: every message specifies exactly one of `ecosystem_id` or `subject_corporation` to designate whose governance framework is being modified.
 
 The initial `GovernanceFrameworkVersion` and its first `GovernanceFrameworkDocument` are created atomically by [Create New Ecosystem](#mod-es-msg-1-create-new-ecosystem) (and, by parallel construction, by [Create New Corporation](#mod-co-msg-1-create-new-corporation)). After that, subsequent versions and documents are added through this module.
 
@@ -2448,8 +2448,8 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]] whose governance framework will be modified. MUST be set if `corporation_id` is null.
-- `corporation_id` (uint64) (*conditional*): id of the target [[ref: corporation]] whose governance framework will be modified. MUST be set if `ecosystem_id` is null.
+- `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]] whose governance framework will be modified. MUST be set if `subject_corporation` is null.
+- `subject_corporation` (group) (*conditional*): the target [[ref: corporation]] whose governance framework will be modified, identified by its underlying [[ref: group]]. MUST be set if `ecosystem_id` is null.
 - `doc_language` (string) (*mandatory*): language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of the governance framework document.
 - `doc_url` (string) (*mandatory*): URL where the document is published.
 - `doc_digest_sri` (string) (*mandatory*): digest_sri of the document.
@@ -2468,11 +2468,11 @@ if a mandatory parameter is not present, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- Exactly one of `ecosystem_id` and `corporation_id` MUST be set; if both are set or both are null, method MUST abort.
+- Exactly one of `ecosystem_id` and `subject_corporation` MUST be set; if both are set or both are null, method MUST abort.
 - Define `subject` as:
   - if `ecosystem_id` is set: the `Ecosystem` entry with this id. The entry MUST exist and `subject.corporation` MUST be equal to the `corporation` executing the method.
-  - if `corporation_id` is set: the `Corporation` entry keyed by `corporation_id` (i.e., the Corporation whose underlying [[ref: group]] has id `corporation_id`). The entry MUST exist, and `corporation_id` MUST equal the [[ref: group]] id of the signing `corporation` (a Corporation may only edit its own governance framework).
-- `version`: there MUST exist a `GovernanceFrameworkVersion` entry `gfv` whose owner matches `subject` (i.e., `gfv.ecosystem_id = ecosystem_id` if subject is an Ecosystem, else `gfv.corporation_id = corporation_id`) and `gfv.version = version`, OR `version` MUST be exactly equal to the biggest `gfv.version` + 1 of all `GovernanceFrameworkVersion` entries owned by `subject`. `version` MUST be greater than `subject.active_version`.
+  - if `subject_corporation` is set: the `Corporation` entry whose underlying [[ref: group]] is `subject_corporation`. The entry MUST exist, and `subject_corporation` MUST be equal to the signing `corporation` (a Corporation may only edit its own governance framework).
+- `version`: there MUST exist a `GovernanceFrameworkVersion` entry `gfv` whose owner matches `subject` (i.e., `gfv.ecosystem_id = ecosystem_id` if subject is an Ecosystem, else `gfv.corporation = subject_corporation`) and `gfv.version = version`, OR `version` MUST be exactly equal to the biggest `gfv.version` + 1 of all `GovernanceFrameworkVersion` entries owned by `subject`. `version` MUST be greater than `subject.active_version`.
 - `doc_language` (string) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 - `doc_url` (string) (*mandatory*): MUST be a valid URL.
 - `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
@@ -2490,7 +2490,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - if a `GovernanceFrameworkVersion` entry `gfv` matching `subject` and `version` does not exist, create and persist a new one:
   - `gfv.id`: auto-incremented uint64
   - `gfv.ecosystem_id`: `ecosystem_id` (or null if subject is a Corporation)
-  - `gfv.corporation_id`: `corporation_id` (or null if subject is an Ecosystem)
+  - `gfv.corporation`: `subject_corporation` (or null if subject is an Ecosystem)
   - `gfv.created`: current timestamp
   - `gfv.version`: `version`
 
@@ -2514,8 +2514,8 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]]. MUST be set if `corporation_id` is null.
-- `corporation_id` (uint64) (*conditional*): id of the target [[ref: corporation]]. MUST be set if `ecosystem_id` is null.
+- `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]]. MUST be set if `subject_corporation` is null.
+- `subject_corporation` (group) (*conditional*): the target [[ref: corporation]], identified by its underlying [[ref: group]]. MUST be set if `ecosystem_id` is null.
 
 ##### [MOD-GF-MSG-2-2] Increase Active Governance Framework Version precondition checks
 
@@ -2528,11 +2528,11 @@ If any of these precondition checks fail, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- Exactly one of `ecosystem_id` and `corporation_id` MUST be set; if both are set or both are null, method MUST abort.
+- Exactly one of `ecosystem_id` and `subject_corporation` MUST be set; if both are set or both are null, method MUST abort.
 - Define `subject` as:
   - if `ecosystem_id` is set: the `Ecosystem` entry with this id. The entry MUST exist and `subject.corporation` MUST be equal to the `corporation` executing the method.
-  - if `corporation_id` is set: the `Corporation` entry keyed by `corporation_id` (i.e., the Corporation whose underlying [[ref: group]] has id `corporation_id`). The entry MUST exist, and `corporation_id` MUST equal the [[ref: group]] id of the signing `corporation`.
-- Find a `GovernanceFrameworkVersion` entry `gfv` owned by `subject` (matching `gfv.ecosystem_id` or `gfv.corporation_id` as appropriate) whose `gfv.version` is equal to `subject.active_version` + 1. If none is found, transaction MUST abort.
+  - if `subject_corporation` is set: the `Corporation` entry whose underlying [[ref: group]] is `subject_corporation`. The entry MUST exist, and `subject_corporation` MUST be equal to the signing `corporation`.
+- Find a `GovernanceFrameworkVersion` entry `gfv` owned by `subject` (matching `gfv.ecosystem_id` or `gfv.corporation` as appropriate) whose `gfv.version` is equal to `subject.active_version` + 1. If none is found, transaction MUST abort.
 - Find a `GovernanceFrameworkDocument` `gfd` for `gfd.gfv_id` = `gfv.id` and `gfd.language` = `subject.language`. If no document is found (and thus no document exists for the default language of this version for this subject), transaction MUST abort.
 
 ###### [MOD-GF-MSG-2-2-2] Increase Active Governance Framework Version fee checks
@@ -2569,7 +2569,7 @@ If any of these checks fail, [[ref: query]] MUST fail.
 
 ##### [MOD-GF-QRY-1-3] Get Governance Framework Version execution
 
-Return the `GovernanceFrameworkVersion` entry with `id`, including its owning subject reference (`ecosystem_id` or `corporation_id`) and its nested `GovernanceFrameworkDocument` entries (filtered by `preferred_language` if set).
+Return the `GovernanceFrameworkVersion` entry with `id`, including its owning subject reference (`ecosystem_id` or `corporation`) and its nested `GovernanceFrameworkDocument` entries (filtered by `preferred_language` if set).
 
 #### [MOD-GF-QRY-2] List Governance Framework Versions
 
@@ -2577,10 +2577,10 @@ Anyone CAN execute this method.
 
 ##### [MOD-GF-QRY-2-1] List Governance Framework Versions query parameters
 
-Exactly one of `ecosystem_id` and `corporation_id` MUST be set:
+Exactly one of `ecosystem_id` and `corporation` MUST be set:
 
-- `ecosystem_id` (uint64) (*conditional*): filter by ecosystem. MUST be set if `corporation_id` is null.
-- `corporation_id` (uint64) (*conditional*): filter by corporation. MUST be set if `ecosystem_id` is null.
+- `ecosystem_id` (uint64) (*conditional*): filter by ecosystem. MUST be set if `corporation` is null.
+- `corporation` (group) (*conditional*): filter by corporation (identified by its underlying [[ref: group]]). MUST be set if `ecosystem_id` is null.
 - `active_only` (boolean) (*optional*): if true, return only the entry corresponding to the subject's `active_version`.
 - `preferred_language` (string) (*optional*): if set, return only one document per version, preferring `preferred_language`.
 - `response_max_size` (small number) (*optional*): default to 64. Max 1,024.
@@ -2589,7 +2589,7 @@ Exactly one of `ecosystem_id` and `corporation_id` MUST be set:
 
 If any of these checks fail, [[ref: query]] MUST fail.
 
-- Exactly one of `ecosystem_id` and `corporation_id` MUST be set.
+- Exactly one of `ecosystem_id` and `corporation` MUST be set.
 - `response_max_size` must be between 1 and 1,024. Default to 64 if unspecified.
 
 ##### [MOD-GF-QRY-2-3] List Governance Framework Versions execution

--- a/spec.md
+++ b/spec.md
@@ -3120,39 +3120,42 @@ issuer --> holder: granted schema permission
 
 ```
 
-The ECOSYSTEM type participants are created by the Credential Schema owner. All other participants are created by running an Onboarding Process (or by any account: - for `ISSUER` permissions if issuer_onboarding_mode is equal to `OPEN`, - for `VERIFIER` permissions if verifier_onboarding_mode is equal to `OPEN`).
+`ECOSYSTEM` Participants are created directly by the [[ref: credential schema]] owner. All other Participants are created by running an [[ref: onboarding process]] — except for permissions whose onboarding mode is `OPEN`, which any account CAN create directly:
 
-An Onboarding Process (OP) is a process which involves an [[ref: applicant]] (which is the [[ref: corporation]] of a given Participant entry), and a [[ref: validator]] Participant, and optional validation fees plus transaction fees.
+- `ISSUER` permissions when `issuer_onboarding_mode` is `OPEN`;
+- `VERIFIER` permissions when `verifier_onboarding_mode` is `OPEN`.
 
-Onboarding is used by [[ref: applicants]] that want to:
+An [[ref: onboarding process]] (OP) involves an [[ref: applicant]] (the [[ref: corporation]] of a given Participant entry) and a [[ref: validator]] Participant. It MAY require the applicant to pay `validation_fees` in addition to [[ref: transaction fees]].
+
+An [[ref: onboarding process]] is run by [[ref: applicants]] that want to:
 
 - be an [[ref: issuer]] of a specific [[ref: credential schema]];
 - be a [[ref: verifier]] of a specific [[ref: credential schema]];
 - be an [[ref: issuer grantor]] of a specific [[ref: credential schema]];
 - be a [[ref: verifier grantor]] of a specific [[ref: credential schema]];
 - get issued a credential of a specific [[ref: credential schema]];
-- obtain a HOLDER participant entry from a issuer of a specific [[ref: credential schema]] and get issued a verifiable credential of this schema (HOLDER participant provide credential status (revoked, etc...));
+- obtain a `HOLDER` Participant entry from an [[ref: issuer]] of a specific [[ref: credential schema]] and be issued a verifiable credential of that schema (the `HOLDER` Participant entry carries credential status — revoked, etc.).
 
-In all cases, the process is very similar. Example execution of an onboarding process:
+In all cases, the process is very similar. Example execution of an [[ref: onboarding process]]:
 
-1. Applicant starts an onboarding process by running the [start new validation] [[ref: transaction]]. Onboarding process may be subject to paying validation fees, as defined in validator Participant entry.
-2. Onboarding process requires that [[ref: applicant]] connects to a validation [[ref: VS]] identified by its [[ref: DID]], and execute a some validation steps, required for the onboarding process to conclude.
-3. If [[ref: applicant]] qualifies, [[ref: validator]] updates the participant entry by running the [set to validated] [[ref: transaction]], and [[ref: applicant]] is granted new permissions, and/or gets issued a credential.
+1. The [[ref: applicant]] starts an [[ref: onboarding process]] by running [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op). The process MAY be subject to paying `validation_fees`, as defined in the [[ref: validator]]'s Participant entry.
+2. The [[ref: applicant]] connects to the [[ref: validator]]'s [[ref: VS]] (identified by its [[ref: DID]]) and executes the validation steps required for the [[ref: onboarding process]] to conclude.
+3. If the [[ref: applicant]] qualifies, the [[ref: validator]] runs [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-op-to-validated) to update the Participant entry; the [[ref: applicant]] is then granted the new permissions and/or issued a credential.
 
-Validation is valid for a specific period, for example 365 days, as configured in the [[ref: credential schema]] for credential schema related validations, or set by ecosystem for user-agent validation.
+Once in the `VALIDATED` state, a Participant entry remains valid for a specific period (e.g., 365 days), configured in the [[ref: credential schema]] for credential-schema-related onboarding, or set by the [[ref: ecosystem]] for user-agent onboarding.
 
 :::note
-In some cases, even if the validation is valid for a period of time, the resulting created permission or issued credential might have a shorter expiration timestamp because the validated attribute(s) might expire before validation expiration: in this case, the [[ref: applicant]] must provide updated information to the [[ref: validator]] before attribute expiration, in order to get issued an updated new permission and/or an updated credential.
+Even when the Participant entry remains in the `VALIDATED` state for the configured period, the resulting permission or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the [[ref: applicant]] MUST provide updated information to the [[ref: validator]] before attribute expiration in order to be issued an updated permission and/or credential.
 :::
 
-If validation is set to expire, [[ref: applicant]] that wishes to extend the expiration timestamp must renew its validation.
+If the `VALIDATED` state is set to expire, an [[ref: applicant]] that wishes to extend the expiration timestamp MUST renew its [[ref: onboarding process]] (see [[MOD-PP-MSG-2]](#mod-pp-msg-2-renew-participant-op)).
 
-At any time, [[ref: applicant]] can cancel the onboarding process.
+At any time, the [[ref: applicant]] CAN cancel the [[ref: onboarding process]] (see [[MOD-PP-MSG-6]](#mod-pp-msg-6-cancel-participant-op-last-request)).
 
-Some special unexpected situation may arise and must be mitigated. Examples:
+Some unexpected situations may arise and MUST be mitigated. Examples:
 
-- if selected validator Participant entry is revoked while applicant's validation is in PENDING state: Applicant CAN cancel the onboarding process [MOD-PP-MSG-6].
-- if selected validator Participant entry is revoked while applicant is in VALIDATED state: Applicant CAN renew the onboarding process by choosing a new validator [MOD-PP-MSG-2].
+- if the selected [[ref: validator]] Participant entry is revoked while the [[ref: applicant]] is in `PENDING` state: applicant CAN cancel the [[ref: onboarding process]] (see [[MOD-PP-MSG-6]](#mod-pp-msg-6-cancel-participant-op-last-request));
+- if the selected [[ref: validator]] Participant entry is revoked while the [[ref: applicant]] is in `VALIDATED` state: applicant CAN renew the [[ref: onboarding process]] by choosing a new validator (see [[MOD-PP-MSG-2]](#mod-pp-msg-2-renew-participant-op)).
 
 #### [MOD-PP-MSG-1] Start Participant OP
 

--- a/spec.md
+++ b/spec.md
@@ -1771,6 +1771,14 @@ If the [[ref: transaction]] fees are paid by the `corporation` account (via fee 
 2. The cycle / expiration check from [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) step 4 has already been performed against the same `record`; `record.remaining_fee_spend` is therefore current.
 3. If `record.fee_spend_limit` is set, `record.remaining_fee_spend` MUST be sufficient for the [[ref: estimated transaction fees]]. After successful execution, the consumed fee amount MUST be deducted from `record.remaining_fee_spend` (per matching `denom` entry).
 
+##### [AUTHZ-CHECK-5] Corporation Registration check
+
+A `Corporation` entry with `id` equal to the id of the signing `corporation` MUST exist. If none exists, the [[ref: transaction]] MUST abort with an error indicating that the underlying [[ref: group]] has not yet been registered as a [[ref: corporation]] (see [[MOD-CO-MSG-1]](#mod-co-msg-1-create-new-corporation)).
+
+> Exception: this check MUST NOT be applied for [[MOD-CO-MSG-1]](#mod-co-msg-1-create-new-corporation), whose explicit purpose is to register a Cosmos SDK [[ref: group]] as a new `Corporation`. That method enforces the inverse precondition (the entry MUST NOT yet exist) in its own basic checks.
+
+This check applies to every delegable message that invokes [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks). As a result, all Create-* methods (and every other delegable Msg) implicitly require the signing `corporation` to be a registered `Corporation`.
+
 #### Example
 
 A corporation group `corporationABC` wants to authorize an operator account `accountABC` to execute the  

--- a/spec.md
+++ b/spec.md
@@ -1797,6 +1797,13 @@ As a result, `accountABC` is authorized to:
 
 | Module                         | Method Name                             | Relative REST API path           | Type   |Requirements      | Signers |
 |--------------------------------|-----------------------------------------|----------------------------------|--------|------------------|---|
+| Corporation               | Create New Corporation                       | N/A (Tx)                         | Msg    | [[MOD-CO-MSG-1]](#mod-co-msg-1-create-new-corporation)   | corporation + operator |
+|                                | Update Corporation                           | N/A (Tx)                         | Msg    | [[MOD-CO-MSG-2]](#mod-co-msg-2-update-corporation)   | corporation + operator |
+|                                | Archive Corporation                          | N/A (Tx)                         | Msg    | [[MOD-CO-MSG-3]](#mod-co-msg-3-archive-corporation)   | corporation + operator |
+|                                | Update Corporation Module Parameters         | N/A (Tx)                         | Msg    | [[MOD-CO-MSG-4]](#mod-co-msg-4-update-module-parameters)   | governance proposal |
+|                                | Get Corporation                              | /co/v1/get                       | Query  | [[MOD-CO-QRY-1]](#mod-co-qry-1-get-corporation)   | N/A |
+|                                | List Corporations                            | /co/v1/list                      | Query  | [[MOD-CO-QRY-2]](#mod-co-qry-2-list-corporations)   | N/A |
+|                                | List Corporation Module Parameters           | /co/v1/params                    | Query  | [[MOD-CO-QRY-3]](#mod-co-qry-3-list-module-parameters)   | N/A |
 | Ecosystem                 | Create an Ecosystem                 |    N/A (Tx)                    | Msg    | [[MOD-ES-MSG-1]](#mod-es-msg-1-create-new-ecosystem)   | corporation + operator |
 |                                | Update Ecosystem                   |       N/A (Tx)                   | Msg    | [[MOD-ES-MSG-2]](#mod-es-msg-2-update-ecosystem)   |corporation + operator |
 |                                | Archive Ecosystem                  |        N/A (Tx)                 | Msg    | [[MOD-ES-MSG-3]](#mod-es-msg-3-archive-ecosystem)   |corporation + operator |
@@ -1869,6 +1876,265 @@ As a result, `accountABC` is authorized to:
 :::note
 Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.
 :::
+
+### Corporation Module
+
+This module manages [[ref: corporation]] entries — the VPR-level entity that extends a Cosmos SDK [[ref: group]] with a DID, a governance framework, and lifecycle attributes. A `Corporation` entry MUST exist before its underlying group can be referenced as the `corporation` (Corporation) in any other VPR Create-* method (see [[MOD-CO-MSG-1]](#mod-co-msg-1-create-new-corporation)).
+
+#### [MOD-CO-MSG-1] Create New Corporation
+
+Any authorized `operator` CAN execute this method on behalf of a Cosmos SDK [[ref: group]] to register a new `Corporation` entry for that group.
+
+##### [MOD-CO-MSG-1-1] Create New Corporation parameters
+
+An authorized `operator` that would like to register a Cosmos SDK [[ref: group]] as a `Corporation` MUST call this method by specifying:
+
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed. For this method specifically, the `id` of `corporation` refers to the id of the underlying Cosmos SDK [[ref: group]] that wants to register itself — no `Corporation` entry exists for that id yet.
+- `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
+- `did` (string) (*mandatory*): the DID of the Corporation.
+- `aka` (string) (*optional*): optional additional URI of this Corporation.
+- `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this Corporation.
+- `doc_url` (string) (*mandatory*): URL where the v1 [[ref: CGF]] document is published.
+- `doc_digest_sri` (string) (*mandatory*): digest_sri of the v1 [[ref: CGF]] document.
+
+Provided document MUST be of the same language as the primary `language` of the Corporation.
+
+##### [MOD-CO-MSG-1-2] Create New Corporation precondition checks
+
+If any of these precondition checks fail, method MUST abort.
+
+###### [MOD-CO-MSG-1-2-1] Create New Corporation basic checks
+
+- if a mandatory parameter is not present, method MUST abort.
+
+- `corporation` (Corporation): (Signer) signature must be verified.
+- `operator` (account): (Signer) signature must be verified.
+- [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
+- A `Corporation` entry with `id` equal to the id of the signing group MUST NOT exist; if one exists, method MUST abort (a group MAY register itself as a `Corporation` at most once).
+- `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
+- `aka` (string) (*optional*): if specified, MUST be an [[ref: URI]].
+- `language` (string(17)) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
+- `doc_url` (string) (*mandatory*): MUST be a valid URL.
+- `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
+
+###### [MOD-CO-MSG-1-2-2] Create New Corporation fee checks
+
+Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]].
+
+##### [MOD-CO-MSG-1-3] Create New Corporation execution
+
+If all precondition checks passed, method is executed.
+
+Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
+
+- create and persist a new `Corporation` entry `co`:
+
+- `co.id`: id of the signing Cosmos SDK [[ref: group]] (1:1)
+- `co.did`: `did`
+- `co.created`: current timestamp
+- `co.modified`: `co.created`
+- `co.archived`: null
+- `co.aka`: `aka`
+- `co.language`: `language`
+- `co.active_version`: 1
+
+- create and persist a new `GovernanceFrameworkVersion` entry `gfv`:
+
+- `gfv.id`: auto-incremented uint64
+- `gfv.ecosystem_id`: null
+- `gfv.corporation_id`: `co.id`
+- `gfv.created`: current timestamp
+- `gfv.version`: 1
+- `gfv.active_since`: current timestamp
+
+- create and persist a new `GovernanceFrameworkDocument` entry `gfd`:
+
+- `gfd.id`: auto-incremented uint64
+- `gfd.gfv_id`: `gfv.id`
+- `gfd.created`: current timestamp
+- `gfd.language`: `language`
+- `gfd.url`: `doc_url`
+- `gfd.digest_sri`: `doc_digest_sri`
+
+> Subsequent governance framework documents and version activations for this `Corporation` MUST be managed through [[MOD-GF-MSG-1]](#mod-gf-msg-1-add-governance-framework-document) and [[MOD-GF-MSG-2]](#mod-gf-msg-2-increase-active-governance-framework-version).
+
+#### [MOD-CO-MSG-2] Update Corporation
+
+Any authorized `operator` CAN execute this method on behalf of a `corporation`.
+
+##### [MOD-CO-MSG-2-1] Update Corporation parameters
+
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
+- `did` (string) (*mandatory*): the new DID of the Corporation.
+- `aka` (string) (*optional*): optional additional URI of this Corporation. If null, it means replace existing value with null.
+- `language` (string) (*mandatory*): primary language tag of this Corporation.
+
+##### [MOD-CO-MSG-2-2] Update Corporation precondition checks
+
+If any of these precondition checks fail, method MUST abort.
+
+###### [MOD-CO-MSG-2-2-1] Update Corporation basic checks
+
+- if a mandatory parameter is not present, method MUST abort.
+
+- `corporation` (Corporation): (Signer) signature must be verified.
+- `operator` (account): (Signer) signature must be verified.
+- [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
+- A `Corporation` entry `co` with `co.id` equal to the id of the signing `corporation` MUST exist; if none exists, method MUST abort.
+- `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
+- `aka` (string) (*optional*): if specified, MUST be an [[ref: URI]] or null.
+- `language` (string(17)) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
+
+###### [MOD-CO-MSG-2-2-2] Update Corporation fee checks
+
+Fee payer MUST have available balance in its [[ref: account]] to cover the required [[ref: transaction fees]].
+
+##### [MOD-CO-MSG-2-3] Update Corporation execution
+
+If all precondition checks passed, method is executed.
+
+Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
+
+- load `Corporation` entry `co` from the id of the signing `corporation` and set:
+
+- `co.did`: `did`
+- `co.aka`: `aka`
+- `co.language`: `language`
+- `co.modified`: current timestamp
+
+#### [MOD-CO-MSG-3] Archive Corporation
+
+Any authorized `operator` CAN execute this method on behalf of a `corporation`.
+
+##### [MOD-CO-MSG-3-1] Archive Corporation parameters
+
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
+- `archive` (boolean) (*mandatory*): true means archive, false means unarchive.
+
+##### [MOD-CO-MSG-3-2] Archive Corporation precondition checks
+
+If any of these precondition checks fail, method MUST abort.
+
+###### [MOD-CO-MSG-3-2-1] Archive Corporation basic checks
+
+- if a mandatory parameter is not present, method MUST abort.
+
+- `corporation` (Corporation): (Signer) signature must be verified.
+- `operator` (account): (Signer) signature must be verified.
+- [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
+- load `Corporation` `co` from the id of the signing `corporation`. If none exists, MUST abort.
+- `archive` (boolean) (*mandatory*) MUST be a boolean.
+  - If `archive` is true and `co.archived` is not null, MUST abort as `Corporation` is already archived.
+  - If `archive` is false and `co.archived` is null, MUST abort as `Corporation` is already not archived.
+
+###### [MOD-CO-MSG-3-2-2] Archive Corporation fee checks
+
+Fee payer MUST have an available balance in its [[ref: account]] to cover the required [[ref: transaction fees]].
+
+##### [MOD-CO-MSG-3-3] Archive Corporation execution
+
+If all precondition checks passed, method is executed.
+
+Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
+
+- update `Corporation` entry `co`:
+- if `archive` is true: set `co.archived` to current timestamp.
+- if `archive` is false: set `co.archived` to null.
+- `co.modified`: current timestamp
+
+#### [MOD-CO-MSG-4] Update Module Parameters
+
+Update Module Parameters.
+
+Can only be executed through a governance proposal.
+
+##### [MOD-CO-MSG-4-1] Update Module Parameters parameters
+
+- `params` (KeySet<String, String>): the parameters to update and their values.
+
+##### [MOD-CO-MSG-4-2] Update Module Parameters precondition checks
+
+If any of these precondition checks fail, [[ref: transaction]] MUST abort.
+
+###### [MOD-CO-MSG-4-2-1] Update Module Parameters basic checks
+
+- `params`: size of `params` MUST be greater than 0. For each `param` <`key`, `value`>, `key` MUST exist, else abort.
+
+###### [MOD-CO-MSG-4-2-2] Update Module Parameters fee checks
+
+provided transaction fees MUST be sufficient for execution.
+
+##### [MOD-CO-MSG-4-3] Update Module Parameters execution
+
+If all precondition checks passed, [[ref: transaction]] is executed.
+
+Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
+
+for each parameter `param` <`key`, `value`> in `parameters`:
+
+- update parameter set value = `value` where key = `key`.
+
+#### [MOD-CO-QRY-1] Get Corporation
+
+Anyone CAN execute this method.
+
+##### [MOD-CO-QRY-1-1] Get Corporation query parameters
+
+- `id` (uint64) (*mandatory*): the id of the Corporation.
+- `active_gf_only` (boolean) (*optional*): if true, include only current governance framework data. If false or null, returns everything.
+- `preferred_language` (string) (*optional*): if set, return only one document per version, preferring `preferred_language`.
+
+##### [MOD-CO-QRY-1-2] Get Corporation query checks
+
+If any of these checks fail, [[ref: query]] MUST fail.
+
+- `id` (uint64) (*mandatory*): MUST be a valid uint64.
+
+##### [MOD-CO-QRY-1-3] Get Corporation execution
+
+Return found `Corporation` entry (if any), as well as *all its nested* `GovernanceFrameworkVersion` and `GovernanceFrameworkDocument` entries. If `active_gf_only` is true, return only nested `GovernanceFrameworkVersion` and `GovernanceFrameworkDocument` entries for the active version.
+
+#### [MOD-CO-QRY-2] List Corporations
+
+##### [MOD-CO-QRY-2-1] List Corporations query parameters
+
+The following parameters are optional:
+
+- `modified_after` (timestamp) (*optional*): if specified, returns only `Corporation` entries with `Corporation.modified` greater than `modified_after`.
+- `active_gf_only` (boolean) (*optional*): if true, include only current governance framework data. If false or null, returns everything.
+- `preferred_language` (string) (*optional*): if set, return only one document per version, preferring `preferred_language`.
+- `response_max_size` (small number) (*optional*): default to 64. Max 1,024.
+
+##### [MOD-CO-QRY-2-2] List Corporations query checks
+
+If any of these checks fail, [[ref: query]] MUST fail.
+
+- `response_max_size` must be between 1 and 1,024. Default to 64 if unspecified.
+
+##### [MOD-CO-QRY-2-3] List Corporations execution
+
+If all precondition checks passed, [[ref: query]] is executed and result (may be empty) returned. If `modified_after` is specified, order by `modified` desc.
+
+#### [MOD-CO-QRY-3] List Module Parameters
+
+Anyone CAN run this [[ref: query]].
+
+##### [MOD-CO-QRY-3-3] List Module Parameters execution
+
+Return the list of parameters of this module as a json file:
+
+```json
+{
+  "params": {
+    "key1": "value1",
+    "key2": "value2",
+    ...
+    ...
+  }
+}
+```
 
 ### Ecosystem Module
 

--- a/spec.md
+++ b/spec.md
@@ -951,7 +951,6 @@ entity "Ecosystem" as tr {
   +created: timestamp
   +modified: timestamp
   +archived: timestamp
-  +aka: string
   +active_version: int
   +language: string
 }
@@ -962,7 +961,6 @@ entity "Corporation" as corp {
   +created: timestamp
   +modified: timestamp
   +archived: timestamp
-  +aka: string
   +active_version: int
   +language: string
 }
@@ -1255,20 +1253,6 @@ corp --o td: corporation
 
 ```
 
-### Ecosystem
-
-`Ecosystem`:
-
-- `id` (uint64) (*mandatory*): the id of the ecosystem.
-- `did` (string) (*mandatory*): the did of the ecosystem.
-- `corporation` (Corporation) (*mandatory*): [[ref: corporation]] that controls this entry.
-- `created` (timestamp) (*mandatory*): timestamp this Ecosystem has been created.
-- `modified` (timestamp) (*mandatory*): timestamp this Ecosystem has been modified.
-- `archived` (timestamp) (*mandatory*): timestamp this Ecosystem has been archived.
-- `aka` (string) (*optional*): optional additional URI of this ecosystem.
-- `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this ecosystem.
-- `active_version` (int): (*mandatory*) active governance framework version.
-
 ### Corporation
 
 A `Corporation` is the VPR-level entity that extends a Cosmos SDK [[ref: group]] with a DID, a governance framework, and lifecycle attributes. A Corporation may control [[ref: participants]] in zero or more [[ref: ecosystems]] and may itself be the controller of zero or more [[ref: ecosystems]].
@@ -1280,11 +1264,23 @@ A `Corporation` is the VPR-level entity that extends a Cosmos SDK [[ref: group]]
 - `created` (timestamp) (*mandatory*): timestamp this Corporation has been created.
 - `modified` (timestamp) (*mandatory*): timestamp this Corporation has been modified.
 - `archived` (timestamp) (*optional*): timestamp this Corporation has been archived.
-- `aka` (string) (*optional*): optional additional URI of this Corporation.
 - `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this Corporation.
 - `active_version` (int) (*mandatory*): active [[ref: CGF]] version.
 
 > Note: members and policies of a Corporation are managed by the underlying Cosmos SDK group module. The Corporation entry adds VPR-level attributes only (DID, governance framework, lifecycle).
+
+### Ecosystem
+
+`Ecosystem`:
+
+- `id` (uint64) (*mandatory*): the id of the ecosystem.
+- `did` (string) (*mandatory*): the did of the ecosystem.
+- `corporation` (Corporation) (*mandatory*): [[ref: corporation]] that controls this entry.
+- `created` (timestamp) (*mandatory*): timestamp this Ecosystem has been created.
+- `modified` (timestamp) (*mandatory*): timestamp this Ecosystem has been modified.
+- `archived` (timestamp) (*mandatory*): timestamp this Ecosystem has been archived.
+- `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this ecosystem.
+- `active_version` (int): (*mandatory*) active governance framework version.
 
 ### GovernanceFrameworkVersion
 
@@ -1555,7 +1551,6 @@ Get an `Ecosystem`
 "ecosystem": {
   {
     "active_version": 0,
-    "aka": "string",
     "corporation": "string",
     "created": "2025-01-14T19:40:37.967Z",
     "deposit": "string",
@@ -1589,7 +1584,6 @@ Get an `Ecosystem`
 "ecosystems": [ {
   {
     "active_version": 0,
-    "aka": "string",
     "corporation": "string",
     "created": "2025-01-14T19:40:37.967Z",
     "deposit": "string",
@@ -1618,7 +1612,6 @@ Get an `Ecosystem`
     ]  
   }, {
     "active_version": 0,
-    "aka": "string",
     "corporation": "string",
     "created": "2025-01-14T19:40:37.967Z",
     "deposit": "string",
@@ -1900,7 +1893,6 @@ An authorized `operator` that would like to register a Cosmos SDK [[ref: group]]
 - `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed. For this method specifically, the `id` of `corporation` refers to the id of the underlying Cosmos SDK [[ref: group]] that wants to register itself — no `Corporation` entry exists for that id yet.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `did` (string) (*mandatory*): the DID of the Corporation.
-- `aka` (string) (*optional*): optional additional URI of this Corporation.
 - `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this Corporation.
 - `doc_url` (string) (*mandatory*): URL where the v1 [[ref: CGF]] document is published.
 - `doc_digest_sri` (string) (*mandatory*): digest_sri of the v1 [[ref: CGF]] document.
@@ -1920,7 +1912,6 @@ If any of these precondition checks fail, method MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - A `Corporation` entry with `id` equal to the id of the signing group MUST NOT exist; if one exists, method MUST abort (a group MAY register itself as a `Corporation` at most once).
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- `aka` (string) (*optional*): if specified, MUST be an [[ref: URI]].
 - `language` (string(17)) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 - `doc_url` (string) (*mandatory*): MUST be a valid URL.
 - `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
@@ -1942,7 +1933,6 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - `co.created`: current timestamp
 - `co.modified`: `co.created`
 - `co.archived`: null
-- `co.aka`: `aka`
 - `co.language`: `language`
 - `co.active_version`: 1
 
@@ -1975,7 +1965,6 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 - `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `did` (string) (*mandatory*): the new DID of the Corporation.
-- `aka` (string) (*optional*): optional additional URI of this Corporation. If null, it means replace existing value with null.
 - `language` (string) (*mandatory*): primary language tag of this Corporation.
 
 ##### [MOD-CO-MSG-2-2] Update Corporation precondition checks
@@ -1991,7 +1980,6 @@ If any of these precondition checks fail, method MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - A `Corporation` entry `co` with `co.id` equal to the id of the signing `corporation` MUST exist; if none exists, method MUST abort.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- `aka` (string) (*optional*): if specified, MUST be an [[ref: URI]] or null.
 - `language` (string(17)) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 
 ###### [MOD-CO-MSG-2-2-2] Update Corporation fee checks
@@ -2007,7 +1995,6 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - load `Corporation` entry `co` from the id of the signing `corporation` and set:
 
 - `co.did`: `did`
-- `co.aka`: `aka`
 - `co.language`: `language`
 - `co.modified`: current timestamp
 
@@ -2157,7 +2144,6 @@ An authorized `operator` that would like to create a [[ref: ecosystem]] MUST cal
 - `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `did` (string) (*mandatory*): the did of the ecosystem that is creating the ecosystem.
-- `aka` (string) (*optional*): optional additional URI of this ecosystem.
 - `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this ecosystem.
 - `doc_url` (string) (*mandatory*): URL where the document is published.
 - `doc_digest_sri` (string) (*mandatory*): digest_sri of the document.
@@ -2176,7 +2162,6 @@ If any of these precondition checks fail, method MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- `aka` (string) (*optional*): optional additional URI of this ecosystem. MUST be an [[ref: URI]].
 - `language` (string(17)) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 - `doc_url` (string) (*mandatory*): MUST be a valid URL .
 - `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
@@ -2202,7 +2187,6 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - `ecosystem.corporation`: `corporation`
 - `ecosystem.created`: current timestamp
 - `ecosystem.modified`: `ecosystem.created`
-- `ecosystem.aka`: `aka`
 - `ecosystem.language`: `language`
 - `ecosystem.active_version`: 1
 
@@ -2236,7 +2220,6 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): the id of the ecosystem.
 - `did` (string) (*mandatory*): the did of the ecosystem.
-- `aka` (string) (*optional*): optional additional URI of this ecosystem. If null, it means replace existing value with null.
 
 ##### [MOD-ES-MSG-2-2] Update Ecosystem precondition checks
 
@@ -2251,7 +2234,6 @@ If any of these precondition checks fail, method MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` (uint64) (*mandatory*): a `Ecosystem` entry `tr` with id `id` MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry `tr`.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- `aka` (string) (*optional*): optional additional URI of this ecosystem. MUST be an [[ref: URI]] or null.
 
 ###### [MOD-ES-MSG-2-2-2] Update Ecosystem fee checks
 
@@ -2266,7 +2248,6 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - load `Ecosystem` entry `tr` from `id` and set:
 
 - `ecosystem.did`: `did`
-- `ecosystem.aka`: `aka`
 - `ecosystem.modified`: current timestamp
 
 #### [MOD-ES-MSG-3] Archive Ecosystem

--- a/spec.md
+++ b/spec.md
@@ -135,8 +135,8 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 [[def: credential schema, credential schemas]]:
 ~ An [[ref: VPR]] resource which represents a verifiable credential definition and the associated permissions and business rules for issuing, verifying or holding a credential linked to this credential schema.
 
-[[def: credential schema permission, credential schema permissions, CSP]]:
-~ A permission, linked to a [[ref: credential schema]], that represent, in a given [[ref: ecosystem]], a grant for being [[ref: issuer]], [[ref: verifier]], [[ref: issuer grantor]], or [[ref: verifier grantor]] of a [[ref: credential schema]].
+[[def: credential schema participant, credential schema participants, CSP]]:
+~ A `Participant` entry, linked to a [[ref: credential schema]], that represents, in a given [[ref: ecosystem]], a grant for being [[ref: issuer]], [[ref: verifier]], [[ref: issuer grantor]], or [[ref: verifier grantor]] of a [[ref: credential schema]].
 
 [[def: decentralized identifier, DID, DIDs]]:
 ~ A decentralized identifier, as specified in [[spec-norm:DID-CORE]].
@@ -1420,8 +1420,8 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 - `op_current_fees` (number) (*mandatory*): current action escrowed fees that will be paid to [[ref: validator]] upon onboarding process completion, in [[ref: denom]].
 - `op_current_deposit` (number) (*mandatory*): current action trust deposit, in [[ref: denom]].
 - `op_summary_digest` (string) (*optional*): an optional digest SRI, set by [[ref: validator]], of a summary of the information, proofs... provided by the [[ref: applicant]].
-- `issuance_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_ONBOARDING_PROCESS mode) or an ISSUER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
-- `verification_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_ONBOARDING_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
+- `issuance_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR or ISSUER `Participant` entry (if GRANTOR_ONBOARDING_PROCESS mode) or to an ISSUER `Participant` entry (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated issuance fees for the subtree of `Participant` entries. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
+- `verification_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR or VERIFIER `Participant` entry (if GRANTOR_ONBOARDING_PROCESS mode) and/or to a VERIFIER `Participant` entry (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated fees for the subtree of `Participant` entries. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 
 > Note: VS operator authorization settings (spend limits, feegrant, expiration, authorized message types) are no longer stored on `Participant`. They live in `ParticipantAuthorizationRecord` entries inside [VSOperatorAuthorization](#vsoperatorauthorization), keyed by `Participant.id`. See [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) and [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks).
 
@@ -1509,13 +1509,13 @@ A `ParticipantAuthorizationRecord` carries the per-permission authorization conf
 
 - `participant_id` (uint64) (*mandatory*): id of the `Participant` this authorization record applies to. Globally unique across all `ParticipantAuthorizationRecord` entries.
 - `msg_types` (msg_type[]) (*mandatory*): list of delegable message types for which the `vs_operator` is authorized on behalf of `corporation` when acting in the context of `participant_id`. Declared by the applicant at record creation time (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant)). Frozen after creation.
-- `spend_limit` (DenomAmount[]) (*optional*): maximum amount the `vs_operator` is allowed to spend, in the context of this permission, as a direct consequence of executing authorized messages.
+- `spend_limit` (DenomAmount[]) (*optional*): maximum amount the `vs_operator` is allowed to spend, in the context of this `Participant` entry, as a direct consequence of executing authorized messages.
 - `remaining_spend` (DenomAmount[]) (*conditional*): runtime balance for `spend_limit`. Present iff `spend_limit` is set. Initialized to `spend_limit` at create time. Decremented per matching `denom` after each authorized operation. Reset to `spend_limit` when the current cycle ends (see `expiration` and `period` below).
-- `fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
+- `fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this `Participant` entry.
 - `remaining_fee_spend` (DenomAmount[]) (*conditional*): runtime balance for `fee_spend_limit`. Present iff `fee_spend_limit` is set. Initialized, decremented and reset following the same rules as `remaining_spend`.
-- `with_feegrant` (bool) (*mandatory*): if true, `corporation` pays the transaction fees for `vs_operator` when executing authorized messages in the context of this permission, through an on-chain `FeeGrant`.
+- `with_feegrant` (bool) (*mandatory*): if true, `corporation` pays the transaction fees for `vs_operator` when executing authorized messages in the context of this `Participant` entry, through an on-chain `FeeGrant`.
 - `expiration` (timestamp) (*mandatory*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the record is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the record auto-renews until removed via [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)). Initially written to `now` at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op) (disabled until validation) and to `Participant.effective_until` at [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-op-to-validated) / [[MOD-PP-MSG-8]](#mod-pp-msg-8-set-participant-effective-until) / [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant).
-- `period` (duration) (*optional*): reset period for `spend_limit` and `fee_spend_limit` in the context of this permission.
+- `period` (duration) (*optional*): reset period for `spend_limit` and `fee_spend_limit` in the context of this `Participant` entry.
 
 ### ExchangeRate
 
@@ -3184,12 +3184,12 @@ In all cases, the process is very similar. Example execution of an [[ref: onboar
 
 1. The [[ref: applicant]] starts an [[ref: onboarding process]] by running [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op). The process MAY be subject to paying `validation_fees`, as defined in the [[ref: validator]]'s Participant entry.
 2. The [[ref: applicant]] connects to the [[ref: validator]]'s [[ref: VS]] (identified by its [[ref: DID]]) and executes the validation steps required for the [[ref: onboarding process]] to conclude.
-3. If the [[ref: applicant]] qualifies, the [[ref: validator]] runs [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-op-to-validated) to update the Participant entry; the [[ref: applicant]] is then granted the new permissions and/or issued a credential.
+3. If the [[ref: applicant]] qualifies, the [[ref: validator]] runs [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-op-to-validated) to update the Participant entry; the [[ref: applicant]] is then granted the new `Participant` entries and/or issued a credential.
 
 Once in the `VALIDATED` state, a Participant entry remains valid for a specific period (e.g., 365 days), configured in the [[ref: credential schema]] for credential-schema-related onboarding, or set by the [[ref: ecosystem]] for user-agent onboarding.
 
 :::note
-Even when the Participant entry remains in the `VALIDATED` state for the configured period, the resulting permission or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the [[ref: applicant]] MUST provide updated information to the [[ref: validator]] before attribute expiration in order to be issued an updated permission and/or credential.
+Even when the Participant entry remains in the `VALIDATED` state for the configured period, the resulting `Participant` entry or issued credential MAY have a shorter expiration timestamp because the validated attribute(s) might expire earlier. In this case, the [[ref: applicant]] MUST provide updated information to the [[ref: validator]] before attribute expiration in order to be issued an updated `Participant` entry and/or credential.
 :::
 
 If the `VALIDATED` state is set to expire, an [[ref: applicant]] that wishes to extend the expiration timestamp MUST renew its [[ref: onboarding process]] (see [[MOD-PP-MSG-2]](#mod-pp-msg-2-renew-participant-op)).
@@ -3207,7 +3207,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-PP-MSG-1-1] Start Participant OP parameters
 
-An Applicant that would like to start a permission onboarding process MUST execute this method by specifying:
+An Applicant that would like to start an onboarding process MUST execute this method by specifying:
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
@@ -3215,17 +3215,17 @@ An Applicant that would like to start a permission onboarding process MUST execu
 - `role` (ParticipantRole) (*mandatory*): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the Participant role that the applicant would like to get;
 - `validator_participant_id` (uint64) (*mandatory*): the [[ref: validator]] participant (parent participant in the tree), chosen by the applicant.
 - `validation_fees` (number) (*optional*): Requested validation_fees for this participant (can be modified by validator).
-- `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
-- `verification_fees` (number) (*optional*): Requested verification_fees for this permission (can be modified by validator).
+- `issuance_fees` (number) (*optional*): Requested issuance_fees for this `Participant` entry (can be modified by validator).
+- `verification_fees` (number) (*optional*): Requested verification_fees for this `Participant` entry (can be modified by validator).
 - `did` (string) (*required*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
 
-The following VS Operator Authorization parameters are **optional** and collectively define the initial [ParticipantAuthorizationRecord](#participantauthorizationrecord) that will be created for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode (the corporation signs and pays for its own permission-related transactions directly). VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
+The following VS Operator Authorization parameters are **optional** and collectively define the initial [ParticipantAuthorizationRecord](#participantauthorizationrecord) that will be created for this `Participant` entry. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the `Participant` entry operates in manual mode (the corporation signs and pays for its own `Participant`-related transactions directly). VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the `Participant` entry MUST be revoked and re-created.
 
-- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `ParticipantAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified. The permitted list of message types is provided below.
-- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.
-- `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this permission.
-- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
-- `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
+- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this `Participant` entry. If provided, a `ParticipantAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified. The permitted list of message types is provided below.
+- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this `Participant` entry as a direct consequence of executing authorized messages.
+- `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this `Participant` entry.
+- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this `Participant` entry.
+- `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this `Participant` entry.
 
 Permitted message types to be set in `vs_operator_authz_msg_types` depends on `role`.
 
@@ -3254,9 +3254,9 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `role` (ParticipantRole) (*mandatory*) MUST be a valid ParticipantRole: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.
 - `validator_participant_id` (uint64) (*mandatory*): see [MOD-PP-MSG-1-2-2](#mod-pp-msg-1-2-2-start-participant-op-permission-checks).
-- `validation_fees` (number) (*optional*): Requested validation_fees for this permission (can be modified by validator).
-- `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
-- `verification_fees` (number) (*optional*): Requested verification_fees for this permission (can be modified by validator).
+- `validation_fees` (number) (*optional*): Requested validation_fees for this `Participant` entry (can be modified by validator).
+- `issuance_fees` (number) (*optional*): Requested issuance_fees for this `Participant` entry (can be modified by validator).
+- `verification_fees` (number) (*optional*): Requested verification_fees for this `Participant` entry (can be modified by validator).
 - `did`, if specified, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
 - VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-1-1](#mod-pp-msg-1-1-start-participant-op-parameters).
 
@@ -3348,7 +3348,7 @@ Trust deposit MUST always be paid in [[ref: native denom]]
 
 We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different OP with differents validators for the same `schema_id`, `role`.
 
-Find all permission `participants[]` for `schema_id`, `role`, `validator_participant_id`, `corporation` with op_state = VALIDATED or PENDING.
+Find all `Participant` entries `participants[]` for `schema_id`, `role`, `validator_participant_id`, `corporation` with op_state = VALIDATED or PENDING.
 
 if size of `participants[]` > 0, it means there is already an existing onboarding process in this context, so MUST abort.
 
@@ -3368,7 +3368,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - define `now`: current timestamp.
 
-- create an persist a new permission entry `applicant_participant`:
+- create an persist a new `Participant` entry `applicant_participant`:
 
   - `applicant_participant.id`: auto-incremented uint64.
   - `applicant_participant.schema_id` = `validator_participant.schema_id`
@@ -3414,16 +3414,16 @@ During an onboarding process, if the associated `validator_participant` includes
 
 Upon connecting to the [[ref: VS]], the [[ref: applicant]] should be required by the [[ref: validator]] to complete one or more of the following tasks:
 
-1. **Prove control** over the `vs_operator` [[ref: account]] specifid in the permission (e.g., via blind signature or cryptographic challenge).
+1. **Prove control** over the `vs_operator` [[ref: account]] specified in the `Participant` entry (e.g., via blind signature or cryptographic challenge).
 2. **Provide requested information**, such as filling out forms, submitting documents, or other forms of disclosure as required by the validation [[ref: VS]].
-3. If the requested permission includes a [[ref: VS]] DID, the [[ref: applicant]] should prove control over the corresponding [[ref: DID]] to the validator's [[ref: VS]].
+3. If the requested `Participant` entry includes a [[ref: VS]] DID, the [[ref: applicant]] should prove control over the corresponding [[ref: DID]] to the validator's [[ref: VS]].
 
-Once the [[ref: validator]] determines that the process is complete, they may terminate the onboarding process and create the permission accordingly. This permission configuration usually include:
+Once the [[ref: validator]] determines that the process is complete, they may terminate the onboarding process and create the `Participant` entry accordingly. This `Participant`-entry configuration usually includes:
 
 - `validation_fees`  
 - `issuance_fees`  
 - `verification_fees`  
-- `permission expiration`
+- `Participant` expiration
 
 The [[ref: validator]] may compile a summary file of the onboarding process, documenting exchanged data, proofs, and decisions, and share it with the [[ref: applicant]] via the [[ref: VS]] connection or another secure channel.
 
@@ -3435,17 +3435,17 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 *This section is non-normative.*
 
-- Requesting a renewal has no effect on permission expiration or issued credentials.
+- Requesting a renewal has no effect on `Participant` expiration or issued credentials.
 - Renewal is only possible with the same validator.
-- If validator permission is not valid anymore, applicant MUST perform a new onboarding process with another validator.
+- If validator `Participant` is not valid anymore, applicant MUST perform a new onboarding process with another validator.
 - Renewal does not allow changing the `participant.validation_fees`, `participant.issuance_fees`, `participant.verification_fees`. To change these values, applicant MUST start a new onboarding process.
-- if permission is revoked, slashed, or repaid, method MUST fail.
+- if `applicant_participant` is revoked, slashed, or repaid, method MUST fail.
 
 ##### [MOD-PP-MSG-2-1] Renew Participant OP parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): id of the permission for which applicant would like to renew the onboarding process;
+- `id` (uint64) (*mandatory*): id of the `Participant` entry for which applicant would like to renew the onboarding process;
 
 ##### [MOD-PP-MSG-2-2] Renew Participant OP precondition checks
 
@@ -3458,7 +3458,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `id` MUST be a valid uint64 and a permission entry with the same id MUST exist.
+- `id` MUST be a valid uint64 and a `Participant` entry with the same id MUST exist.
 
 ###### [MOD-PP-MSG-2-2-2] Renew Participant OP permission checks
 
@@ -3519,7 +3519,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - define `now`: current timestamp.
 
-- update permission entry:
+- update `Participant` entry:
 
   - `applicant_participant.op_state`: PENDING.
   - `applicant_participant.op_last_state_change`: current timestamp.
@@ -3539,13 +3539,13 @@ An [[ref: account]] that would like to set a validation entry to VALIDATED MUST 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the onboarding process;
-- `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this `Participant` is effective, null if no time limit should been set for this permission or if we want it to be aligned with the onboarding process expiration timestamp calculated by this method.
-- `validation_fees` (number) (*mandatory*): Agreed validation_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
-- `issuance_fees` (number) (*mandatory*): Agreed issuance_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
-- `verification_fees` (number) (*mandatory*): Agreed verification_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
+- `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this `Participant` is effective, null if no time limit should been set for this `Participant` entry or if we want it to be aligned with the onboarding process expiration timestamp calculated by this method.
+- `validation_fees` (number) (*mandatory*): Agreed validation_fees for this `Participant` entry. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
+- `issuance_fees` (number) (*mandatory*): Agreed issuance_fees for this `Participant` entry. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
+- `verification_fees` (number) (*mandatory*): Agreed verification_fees for this `Participant` entry. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
 - `op_summary_digest` (string) (*optional*): an optional digest, set by [[ref: validator]], of a summary of the information, proofs... provided by the [[ref: applicant]].
-- `issuance_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_ONBOARDING_PROCESS mode) or an ISSUER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
-- `verification_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_ONBOARDING_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
+- `issuance_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR or ISSUER `Participant` entry (if GRANTOR_ONBOARDING_PROCESS mode) or to an ISSUER `Participant` entry (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated issuance fees for the subtree of `Participant` entries. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
+- `verification_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR or VERIFIER `Participant` entry (if GRANTOR_ONBOARDING_PROCESS mode) and/or to a VERIFIER `Participant` entry (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated fees for the subtree of `Participant` entries. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 
 ##### [MOD-PP-MSG-3-2] Set Participant OP to Validated precondition checks
 
@@ -3565,7 +3565,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 either (executed by any operator of corporation):
 [[AUTHZ-CHECK-1]](#authz-check-1-operator-authorization-checks) MUST pass for this (`corporation`, `operator`) tuple and `SetParticipantOPtoValidated` message.
 [[AUTHZ-CHECK-2]](#authz-check-2-fee-grant-checks) MUST pass for this (`corporation`, `operator`) tuple and `SetParticipantOPtoValidated` message.
-OR (executed by vs-agent account defined in validator permission):
+OR (executed by vs-agent account defined in validator `Participant`):
 [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) MUST pass for this (`corporation`, `operator`, `validator_participant`) tuple.
 [[AUTHZ-CHECK-4]](#authz-check-4-vs-operator-fee-grant-checks) MUST pass for this (`corporation`, `operator`, `validator_participant`) tuple.
 else MUST abort.
@@ -3625,7 +3625,7 @@ If `validator_participant` is not a [[ref: active participant]] (expired, revoke
 
 ###### [MOD-PP-MSG-3-2-4] Set Participant OP to Validated overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. That should not occur in this method, but better do the check anyway.
+We want to make sure that 2 `Participant` entries cannot be active at the same time for the same `validator_participant_id`. That should not occur in this method, but better do the check anyway.
 
 Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `role`, `validator_participant_id`, `corporation`.
 
@@ -3633,7 +3633,7 @@ for each `Participant` entry `p` from `participants[]`:
 
 - if `p.effective_until` is greater than `effective_from`, method execution MUST abort.
 - if `p.effective_from` is lower than `effective_until`, method execution MUST abort.
-- if `p.effective_until` is NULL (never expire), creation of a new permission doesn't make any sense and method execution MUST abort.
+- if `p.effective_until` is NULL (never expire), creation of a new `Participant` entry doesn't make any sense and method execution MUST abort.
 
 > note: this check was not present in v3.
 
@@ -3709,7 +3709,7 @@ This call is a no-op if no record was created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-At any time, [[ref: applicant]] of a permission onboarding process may request cancellation of the process, provided state is PENDING. Upon method execution, the pending validation is cancelled and escrewed [[ref: trust fees]] are refunded. If `op_exp` is not null, `op_state` is set back to VALIDATED, else `op_state` is set to TERMINATED.
+At any time, [[ref: applicant]] of an onboarding process may request cancellation of the process, provided state is PENDING. Upon method execution, the pending validation is cancelled and escrewed [[ref: trust fees]] are refunded. If `op_exp` is not null, `op_state` is set back to VALIDATED, else `op_state` is set to TERMINATED.
 
 ##### [MOD-PP-MSG-6-1] Cancel Participant OP Last Request parameters
 
@@ -3764,7 +3764,7 @@ If `applicant_participant.op_state` was set to TERMINATED (i.e. `applicant_parti
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-This method is used by controller authorities of Ecosystems. When they create a Credential Schema, they need to create (a) permission(s) of type ECOSYSTEM so that other participants can run onboarding processes (if schema mode is ECOSYSTEM) or self create their permissions (schema mode set to OPEN).
+This method is used by controller authorities of Ecosystems. When they create a Credential Schema, they need to create (a) `Participant` entry(ies) of role ECOSYSTEM so that other participants can run onboarding processes (if schema mode is ECOSYSTEM) or self create their `Participant` entries (schema mode set to OPEN).
 
 ##### [MOD-PP-MSG-7-1] Create Root Participant parameters
 
@@ -3773,7 +3773,7 @@ An [[ref: account]] that would like to create a `Participant` entry MUST call th
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `schema_id` (uint64) (*mandatory*)
-- `vs_operator` (account) (*optional*): the account we want to authorize to act on behalf of `corporation` in the context of this permission. **Required** for payment delegation.
+- `vs_operator` (account) (*optional*): the account we want to authorize to act on behalf of `corporation` in the context of this `Participant` entry. **Required** for payment delegation.
 - `did` (string) (*mandatory*): [[ref: DID]] of the VS.
 - `effective_from` (timestamp) (*mandatory*): timestamp from when (exclusive) this Perm is effective. MUST be in the future.
 - `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this Perm is effective, null if it doesn't expire. If not null, MUST be greater than `effective_from`.
@@ -3781,15 +3781,15 @@ An [[ref: account]] that would like to create a `Participant` entry MUST call th
 - `issuance_fees` (number) (*mandatory*): price to pay by the issuer of a credential of this schema to the grantee of this perm when a credential is issued, in the denom specified in the credential schema. Default to 0.
 - `verification_fees` (number) (*mandatory*): price to pay by the verifier of a credential of this schema to the grantee of this perm when a credential is verified, in the denom specified in the credential schema. Default to 0.
 
-The following VS Operator Authorization parameters are **optional** and collectively define the initial [ParticipantAuthorizationRecord](#participantauthorizationrecord) for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
+The following VS Operator Authorization parameters are **optional** and collectively define the initial [ParticipantAuthorizationRecord](#participantauthorizationrecord) for this `Participant` entry. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the `Participant` entry operates in manual mode. VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the `Participant` entry MUST be revoked and re-created.
 
-- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `ParticipantAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified. The permitted list of message types is provided below.
-- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.
-- `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this permission.
-- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
-- `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
+- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this `Participant` entry. If provided, a `ParticipantAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified. The permitted list of message types is provided below.
+- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this `Participant` entry as a direct consequence of executing authorized messages.
+- `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this `Participant` entry.
+- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this `Participant` entry.
+- `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this `Participant` entry.
 
-Permitted message types to be set in `vs_operator_authz_msg_types` depends on `role`. Since [Create Root Participant](#mod-pp-msg-7-create-root-participant) always creates an ECOSYSTEM permission, only the following is allowed:
+Permitted message types to be set in `vs_operator_authz_msg_types` depends on `role`. Since [Create Root Participant](#mod-pp-msg-7-create-root-participant) always creates an ECOSYSTEM `Participant` entry, only the following is allowed:
 
 |Participant role|Permitted Messages|
 |-|-|
@@ -3830,17 +3830,17 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
 ###### [MOD-PP-MSG-7-2-4] Create Root Participant overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Set Participant Effective Until](#mod-pp-msg-8-set-participant-effective-until) to set or adjust the `effective_until` value.
+We want to make sure that 2 `Participant` entries cannot be active at the same time. If `corporation` wishes to create a new `Participant` entry but the existing one never expires (or expires too far from now), `corporation` MUST use first the [Set Participant Effective Until](#mod-pp-msg-8-set-participant-effective-until) to set or adjust the `effective_until` value.
 
 Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, ECOSYSTEM,  `corporation`.
 
-> Note: unlike overlap checks from other methods, here we do not need to check for `validator_participant_id`, as for ECOSYSTEM type permissions it is NULL.
+> Note: unlike overlap checks from other methods, here we do not need to check for `validator_participant_id`, as for ECOSYSTEM-role `Participant` entries it is NULL.
 
 for each `Participant` entry `p` from `participants[]`:
 
 - if `p.effective_until` is greater than `effective_from`, method execution MUST abort.
 - if `p.effective_from` is lower than `effective_until`, method execution MUST abort.
-- if `p.effective_until` is NULL (never expire), creation of a new permission doesn't make any sense and method execution MUST abort.
+- if `p.effective_until` is NULL (never expire), creation of a new `Participant` entry doesn't make any sense and method execution MUST abort.
 
 > note: this check was not present in v3.
 
@@ -3890,15 +3890,15 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 This method can be called:
 
-- by `participant.corporation`, if permission is of type ECOSYSTEM.
-- by `participant.corporation`, if it is a self-created permission (schema configuration is open)
-- by a `corporation` of a validator permission (if permission is managed by an OP).
+- by `participant.corporation`, if the `Participant` entry has role ECOSYSTEM.
+- by `participant.corporation`, if it is a self-created `Participant` entry (schema configuration is open).
+- by a `corporation` of a validator `Participant`, if the `Participant` entry is managed by an OP.
 
 ##### [MOD-PP-MSG-8-1] Set Participant Effective Until parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): id of the permission;
+- `id` (uint64) (*mandatory*): id of the `Participant` entry;
 - `effective_until` (timestamp) (*mandatory*): timestamp until when (exclusive) this `Participant` will be effective.
 
 ##### [MOD-PP-MSG-8-2] Set Participant Effective Until precondition checks
@@ -3922,15 +3922,15 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 ###### [MOD-PP-MSG-8-2-2] Set Participant Effective Until advanced checks
 
-1. ECOSYSTEM permissions
+1. ECOSYSTEM `Participant` entries
 
 - if `applicant_participant.validator_participant_id` is null and `applicant_participant.role` is ECOSYSTEM, `corporation` running the method MUST be `applicant_participant.corporation`.
 
-2. Self-created permissions
+2. Self-created `Participant` entries
 
-- load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active participant]] of type ECOSYSTEM. `corporation` running the method MUST be `applicant_participant.corporation`.
+- load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active participant]] of role ECOSYSTEM. `corporation` running the method MUST be `applicant_participant.corporation`.
 
-3. OP managed permissions
+3. OP-managed `Participant` entries
 
 - `effective_until` MUST be lower or equal to `applicant_participant.op_exp` else MUST abort.
 - load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active participant]]. `corporation` running the method MUST be `validator_participant.corporation`.
@@ -3941,7 +3941,7 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[re
 
 ###### [MOD-PP-MSG-8-2-4] Set Participant Effective Until overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Set Participant Effective Until](#mod-pp-msg-8-set-participant-effective-until) to set or adjust the `effective_until` value.
+We want to make sure that 2 `Participant` entries cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new `Participant` entry but the existing one never expires (or expires too far from now), `corporation` MUST use first the [Set Participant Effective Until](#mod-pp-msg-8-set-participant-effective-until) to set or adjust the `effective_until` value.
 
 Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `role`, `validator_participant_id`, `corporation`.
 
@@ -3949,7 +3949,7 @@ for each `Participant` entry `p` from `participants[]`:
 
 - if `p.effective_until` is greater than `effective_from`, method execution MUST abort.
 - if `p.effective_from` is lower than `effective_until`, method execution MUST abort.
-- if `p.effective_until` is NULL (never expire), creation of a new permission doesn't make any sense and method execution MUST abort.
+- if `p.effective_until` is NULL (never expire), creation of a new `Participant` entry doesn't make any sense and method execution MUST abort.
 
 > note: this check was not present in v3.
 
@@ -3980,7 +3980,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 This method can only be called:
 
-- by an ancestor (`corporation` of a validator in the permission branch until the root permission (GRANTOR, ECOSYSTEM, OPEN schema mode)).
+- by an ancestor (`corporation` of a validator in the `Participant` branch until the root `Participant` entry (GRANTOR, ECOSYSTEM, OPEN schema mode)).
 - by the grantee `corporation` (OPEN, GRANTOR, ECOSYSTEM schema mode).
 - by the `Ecosystem` `corporation` (owner of the credential schema).
 
@@ -3988,7 +3988,7 @@ This method can only be called:
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): id of the permission;
+- `id` (uint64) (*mandatory*): id of the `Participant` entry;
 
 ##### [MOD-PP-MSG-9-2] Revoke Participant precondition checks
 
@@ -4031,11 +4031,11 @@ if `applicant_participant.validator_participant_id` is defined:
 
 Example:
 
-In the following permission tree, "Verifier E" permission can be revoked:
+In the following `Participant` tree, the "Verifier E" `Participant` entry can be revoked:
 
-- by "Verifier E", if the corresponding permission is a [[ref: active participant]];
-- by "Verifier Grantor D", if the corresponding permission is a [[ref: active participant]];
-- by "Ecosystem A", if the corresponding root permission is a [[ref: active participant]];
+- by "Verifier E", if the corresponding `Participant` entry is a [[ref: active participant]];
+- by "Verifier Grantor D", if the corresponding `Participant` entry is a [[ref: active participant]];
+- by "Ecosystem A", if the corresponding root `Participant` entry is a [[ref: active participant]];
 - by the `Ecosystem` object controller, obtained by resolving perm => credential schema => ecosystem.
 
 ```plantuml
@@ -4101,7 +4101,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - set `applicant_participant.revoked` to `now`
 - set `applicant_participant.modified` to `now`
 
-Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any authorization record for this permission. The call is a no-op if no record exists.
+Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any authorization record for this `Participant` entry. The call is a no-op if no record exists.
 
 #### [MOD-PP-MSG-10] Create or Update Participant Session
 
@@ -4112,13 +4112,13 @@ Any credential exchange that requires issuer or verifier to pay fees, register a
 If the peer wants to issue a credential, the `agent`, the Verifiable User Agent or Verifiable Service that receive the request MUST send to peer:
 
 - a `uuid` for session identification;
-- *optional*: the `agent_participant_id` permission id of the agent that will receive the credential, if peer is a **Verifiable User Agent**. it MUST NOT be set if peer is a **Verifiable Service**.
-- *optional*: the `wallet_agent_participant_id` permission id of the agent wallet that will store the credential. If this is the same software than the agent, then it should be equal to `agent_participant_id`. It MUST NOT be set if peer is a **Verifiable Service**.
+- *optional*: the `agent_participant_id` `Participant` id of the agent that will receive the credential, if peer is a **Verifiable User Agent**. it MUST NOT be set if peer is a **Verifiable Service**.
+- *optional*: the `wallet_agent_participant_id` `Participant` id of the agent wallet that will store the credential. If this is the same software than the agent, then it should be equal to `agent_participant_id`. It MUST NOT be set if peer is a **Verifiable Service**.
 
 If the peer wants to verify a credential, agent must send to peer:
 
 - a `uuid` for session identification;
-- *optional*: the `agent_participant_id` permission id of the agent that will receive the credential, if peer is a **Verifiable User Agent**. it MUST NOT be set if peer is a **Verifiable Service**.
+- *optional*: the `agent_participant_id` `Participant` id of the agent that will receive the credential, if peer is a **Verifiable User Agent**. it MUST NOT be set if peer is a **Verifiable Service**.
 - *optional*: a map of compatible found credentials in available wallets for the requested schema_id: Map<uint64[] issuer_participant_ids, uint64: wallet_agent_participant_id>. wallet_agent_participant_id MUST NOT be set if peer is a **Verifiable Service**.
 
 In case peer is a **Verifiable Service** and illegaly set `agent_participant_id` and/or `wallet_agent_participant_id`, the other end MUST refuse the request.
@@ -4155,8 +4155,8 @@ An [[ref: account]] that would like to create or update a `ParticipantSession` e
 - `id` (uuid) (*mandatory*): id of the `ParticipantSession`.
 - `issuer_participant_id` (uint64) (*optional*): the id of the perm of the issuer, if we are dealing with the issuance of a credential.
 - `verifier_participant_id` (uint64) (*optional*): the id of the perm of the verifier, if we are dealing with the verification of a credential.
-- `agent_participant_id` (uint64) (*optional*): the agent credential issuer permission id (extracted from the agent credential that VUA has in its wallet) of the agent that received the request (credential offer for issuance, presentation request for verification). Only set by VUAs, MUST NOT be specified when peer is a VS.
-- `wallet_agent_participant_id` (uint64) (*optional*): the wallet credential issuer permission id of the VUA where the credential will be or is stored. Can be the same perm than `agent_participant_id` if agent and wallet_agent are the same agent. Only set by VUAs, MUST NOT be specified when peer is a VS.
+- `agent_participant_id` (uint64) (*optional*): the agent credential issuer `Participant` id (extracted from the agent credential that VUA has in its wallet) of the agent that received the request (credential offer for issuance, presentation request for verification). Only set by VUAs, MUST NOT be specified when peer is a VS.
+- `wallet_agent_participant_id` (uint64) (*optional*): the wallet credential issuer `Participant` id of the VUA where the credential will be or is stored. Can be the same perm than `agent_participant_id` if agent and wallet_agent are the same agent. Only set by VUAs, MUST NOT be specified when peer is a VS.
 - `digest` (string) (*optional*): digest derived from an issued or verified credential.
 
 ##### [MOD-PP-MSG-10-2] Create or Update Participant Session precondition checks
@@ -4190,7 +4190,7 @@ if `verifier_participant_id` is not null:
 - if `verifier_participant.corporation` is not equal to `corporation`, abort.
 - if `digest_sri` is present but not a valid digest SRI, abort.
 
-Define the **primary permission** `perm`: if `verifier_participant` is not null, `perm` = `verifier_participant` (the caller is the `vs_operator` of the verifier). Else, `perm` = `issuer_participant` (the caller is the `vs_operator` of the issuer).
+Define the **primary `Participant`** `perm`: if `verifier_participant` is not null, `perm` = `verifier_participant` (the caller is the `vs_operator` of the verifier). Else, `perm` = `issuer_participant` (the caller is the `vs_operator` of the issuer).
 
 [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) MUST pass for this (`corporation`, `operator`, `perm`) tuple.
 [[AUTHZ-CHECK-4]](#authz-check-4-vs-operator-fee-grant-checks) MUST pass for this (`corporation`, `operator`, `perm`) tuple.
@@ -4208,7 +4208,7 @@ wallet_agent:
 - if `wallet_agent_participant` is not a [[ref: active participant]], abort.
 
 :::warning
-we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a permission that is not controlled by its owner.
+we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a `Participant` entry that is not controlled by its owner.
 :::
 
 ###### [MOD-PP-MSG-10-3] Create or Update Participant Session fee checks
@@ -4220,7 +4220,7 @@ For trust fees, `corporation` account MUST have sufficient available balance as 
 
 **Step 1: Calculate total beneficiary fees in credential schema pricing asset**
 
-Use "Find Beneficiaries" query method to get the set of beneficiary permissions `found_participant_set` (all ancestors in the permission tree).
+Use "Find Beneficiaries" query method to get the set of beneficiary `Participant` entries `found_participant_set` (all ancestors in the `Participant` tree).
 
 - define `total_beneficiary_fees` = 0
 
@@ -4376,7 +4376,7 @@ Required balance check:
 
 If all precondition checks passed, method is executed.
 
-- Load all permissions as in basic checks.
+- Load all `Participant` entries as in basic checks.
 - Load `CredentialSchema` entry `cs` from `issuer_participant.schema_id` if `issuer_participant` is not null, else from `verifier_participant.schema_id`.
 - define `now`: current timestamp.
 - use "Find Beneficiaries" to build `found_participant_set`.
@@ -4404,7 +4404,7 @@ Determine the operation type and applicable discount:
   - `discount` = `verifier_participant.verification_fee_discount`
   - `payer_participant` = `verifier_participant`
 
-**For each beneficiary permission `perm` in `found_participant_set`:**
+**For each beneficiary `Participant` `perm` in `found_participant_set`:**
 
 If `participant.[fee_field]` > 0:
 
@@ -4572,14 +4572,14 @@ for each parameter `param` <`key`, `value`> in `parameters`:
 
 This method can only be called by either:
 
-- a `corporation` ancestor validator of this permission;
+- a `corporation` ancestor validator of this `Participant` entry;
 - the `corporation` controller of the `Ecosystem` object, owner of the corresponding credential schema.
 
 ##### [MOD-PP-MSG-12-1] Slash Participant Trust Deposit parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): id of the permission;
+- `id` (uint64) (*mandatory*): id of the `Participant` entry;
 - `amount` (number) (*mandatory*): the amount to slash
 
 ##### [MOD-PP-MSG-12-2] Slash Participant Trust Deposit precondition checks
@@ -4598,7 +4598,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `amount` MUST be lower or equal to `applicant_participant.deposit` else MUST abort.
 
 :::note
-Even if the permission has expired or is revoked, it is still possible to slash it.
+Even if the `Participant` entry has expired or is revoked, it is still possible to slash it.
 :::
 
 ###### [MOD-PP-MSG-12-2-2] Slash Participant Trust Deposit validator perms
@@ -4643,19 +4643,19 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 use [MOD-TD-MSG-7](#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit) to burn the slashed `amount` from the trust deposit of `applicant_participant.corporation`.
 
-Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any authorization record for this permission. The call is a no-op if no record exists.
+Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any authorization record for this `Participant` entry. The call is a no-op if no record exists.
 
 #### [MOD-PP-MSG-13] Repay Participant Slashed Trust Deposit
 
-This method can only be called by the `corporation` that want to repay the deposit of a slashed perm they own. This won't make the perm re-usable: it will be needed for the `corporation` associated to this permission to request a new permission, as slashed permissions cannot be revived (same happen for revoked, etc...).
+This method can only be called by the `corporation` that wants to repay the deposit of a slashed `Participant` entry they own. This won't make the `Participant` entry re-usable: it will be needed for the `corporation` associated to this `Participant` entry to request a new `Participant` entry, as slashed `Participant` entries cannot be revived (same happens for revoked, etc.).
 
-Nevertheless, to get a new permission for a given ecosystem, it is needed, using this method, to repay the deposit of a slashed permission first.
+Nevertheless, to get a new `Participant` entry for a given ecosystem, it is needed, using this method, to repay the deposit of a slashed `Participant` entry first.
 
 ##### [MOD-PP-MSG-13-1] Repay Participant Slashed Trust Deposit parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): id of the permission
+- `id` (uint64) (*mandatory*): id of the `Participant` entry
 
 ##### [MOD-PP-MSG-13-2] Repay Participant Slashed Trust Deposit precondition checks
 
@@ -4696,10 +4696,10 @@ use [Adjust Trust Deposit](#mod-td-msg-1-adjust-trust-deposit) to transfer `appl
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-This simple permission creation method can be used to self-create an ISSUER (resp. VERIFIER) permission if issuance mode (resp. verification mode) is set to `OPEN` for a given schema. As permissions are the anchor of ecosystem trust deposit operations, it is required for an issuer/verifier candidate to self-create a permission for being issuer or verifier of a given schema.
+This simple `Participant`-creation method can be used to self-create an ISSUER (resp. VERIFIER) `Participant` entry if issuance mode (resp. verification mode) is set to `OPEN` for a given schema. As `Participant` entries are the anchor of ecosystem trust deposit operations, it is required for an issuer/verifier candidate to self-create a `Participant` entry for being issuer or verifier of a given schema.
 
 :::note
-Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their permission may be revoked by ecosystem governance authority and their deposit slashed.
+Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their `Participant` entry may be revoked by ecosystem governance authority and their deposit slashed.
 :::
 
 ##### [MOD-PP-MSG-14-1] Self Create Participant parameters
@@ -4708,20 +4708,20 @@ Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `role` (ParticipantRole) (*mandatory*): ISSUER or VERIFIER.
 - `validator_participant_id` (uint64) (*mandatory*): MUST be an ECOSYSTEM [[ref: active participant]] or [[ref: future participant]].
-- `vs_operator` (account) (*optional*): the account we want to authorize to create permission sessions linked to this permission. **Required** for payment delegation.
+- `vs_operator` (account) (*optional*): the account we want to authorize to create `ParticipantSession` entries linked to this `Participant` entry. **Required** for payment delegation.
 - `did` (string) (*mandatory*): [[ref: DID]] of the VS grantee service.
 - `effective_from` (timestamp) (*optional*): timestamp from when (exclusive) this Perm is effective. MUST be in the future.
 - `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this Perm is effective, null if it doesn't expire. If not null, MUST be greater than `effective_from`.
 - `verification_fees` (number) (*optional*): price to pay by the verifier of a credential of this schema to the grantee of this ISSUER perm when a credential is verified, in the denom specified in the credential schema. Default to 0.
 - `validation_fees` (number) (*optional*): price to pay by the holder of a credential of this schema to the issuer when executing an onboarding process to obtain a credential, in the denom specified in the credential schema. Default to 0.
 
-The following VS Operator Authorization parameters are **optional** and collectively define the initial [ParticipantAuthorizationRecord](#participantauthorizationrecord) for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
+The following VS Operator Authorization parameters are **optional** and collectively define the initial [ParticipantAuthorizationRecord](#participantauthorizationrecord) for this `Participant` entry. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the `Participant` entry operates in manual mode. VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the `Participant` entry MUST be revoked and re-created.
 
-- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `ParticipantAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified.
-- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.
-- `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this permission.
-- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
-- `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
+- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this `Participant` entry. If provided, a `ParticipantAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified.
+- `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this `Participant` entry as a direct consequence of executing authorized messages.
+- `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this `Participant` entry.
+- `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this `Participant` entry.
+- `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this `Participant` entry.
 
 Permitted message types to be set in `vs_operator_authz_msg_types` depends on `role`.
 
@@ -4754,8 +4754,8 @@ Load `Participant` `validator_participant` from `validator_participant_id`.
 - `effective_until`:
   - if null, `validator_participant.effective_until` MUST be NULL
   - else if not null, must be greater than `effective_from` AND if `validator_participant.effective_until` is not null, MUST be lower or equal to `validator_participant.effective_until`
-- `verification_fees` (number) (*optional*): If specified, MUST be >= 0 and MUST be a ISSUER permission.
-- `validation_fees` (number) (*optional*): If specified, MUST be >= 0 and MUST be a ISSUER permission.
+- `verification_fees` (number) (*optional*): If specified, MUST be >= 0 and the `Participant` entry MUST be an ISSUER.
+- `validation_fees` (number) (*optional*): If specified, MUST be >= 0 and the `Participant` entry MUST be an ISSUER.
 - VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-14-1](#mod-pp-msg-14-1-self-create-participant-parameters).
 
 ###### [MOD-PP-MSG-14-2-2] Self Create Participant permission checks
@@ -4774,7 +4774,7 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
 ###### [MOD-PP-MSG-14-2-4] Self Create Participant overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Set Participant Effective Until](#mod-pp-msg-8-set-participant-effective-until) to set or adjust the `effective_until` value.
+We want to make sure that 2 `Participant` entries cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new `Participant` entry but the existing one never expires (or expires too far from now), `corporation` MUST use first the [Set Participant Effective Until](#mod-pp-msg-8-set-participant-effective-until) to set or adjust the `effective_until` value.
 
 Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `cs.id`, `role`, `validator_participant_id`, `corporation`.
 
@@ -4782,7 +4782,7 @@ for each `Participant` entry `p` from `participants[]`:
 
 - if `p.effective_until` is greater than `effective_from`, method execution MUST abort.
 - if `p.effective_from` is lower than `effective_until`, method execution MUST abort.
-- if `p.effective_until` is NULL (never expire), creation of a new permission doesn't make any sense and method execution MUST abort.
+- if `p.effective_until` is NULL (never expire), creation of a new `Participant` entry doesn't make any sense and method execution MUST abort.
 
 > note: this check was not present in v3.
 
@@ -4832,14 +4832,14 @@ If `vs_operator_authz_msg_types` is provided, create the [ParticipantAuthorizati
 
 This method CAN be executed by:
 
-- the `vs_operator` of the permission, acting on behalf of `participant.corporation`; or
-- any ancestor validator of the permission in the permission tree (from the direct parent up to the root permission). For an ancestor validator `v`, the method CAN be executed by the `vs_operator` defined in `v`, or by any `operator` authorized by `v.corporation` for this message type.
+- the `vs_operator` of the `Participant` entry, acting on behalf of `participant.corporation`; or
+- any ancestor validator of the `Participant` entry in the `Participant` tree (from the direct parent up to the root `Participant` entry). For an ancestor validator `v`, the method CAN be executed by the `vs_operator` defined in `v`, or by any `operator` authorized by `v.corporation` for this message type.
 
-This method is intended to be used by external services (such as the Verana indexer) to be notified that a trust resolution must be performed for the `did` registered in the permission. Typical use cases include:
+This method is intended to be used by external services (such as the Verana indexer) to be notified that a trust resolution must be performed for the `did` registered in the `Participant` entry. Typical use cases include:
 
 - a new [[ref: verifiable service]] has been onboarded and its credentials are now present in the DID Document, so trust can be (re-)evaluated;
-- an issuer has revoked a credential issued to a holder: the issuer (acting as the validator of the corresponding HOLDER permission) notifies the trust resolver to re-evaluate trust for the revoked HOLDER permission;
-- an issuer is no longer operating: a parent issuer grantor or root ecosystem permission triggers a re-evaluation.
+- an issuer has revoked a credential issued to a holder: the issuer (acting as the validator of the corresponding HOLDER `Participant` entry) notifies the trust resolver to re-evaluate trust for the revoked HOLDER `Participant` entry;
+- an issuer is no longer operating: a parent issuer grantor or root ecosystem `Participant` entry triggers a re-evaluation.
 
 The method does not modify the [[ref: VPR]] state; it only emits an event that off-chain components MAY consume.
 
@@ -4847,7 +4847,7 @@ The method does not modify the [[ref: VPR]] state; it only emits an event that o
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): id of the permission for which a trust resolution must be triggered.
+- `id` (uint64) (*mandatory*): id of the `Participant` entry for which a trust resolution must be triggered.
 
 ##### [MOD-PP-MSG-15-2] Trigger Resolver precondition checks
 
@@ -4868,14 +4868,14 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 At least one of the two authorization paths below MUST pass, else [[ref: transaction]] MUST abort.
 
-*Path 1 — vs_operator of the target permission*
+*Path 1 — vs_operator of the target `Participant` entry*
 
 - `corporation` MUST be equal to `participant.corporation`.
 - `operator` MUST be equal to `participant.vs_operator`.
 - [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) MUST pass for this (`corporation`, `operator`, `perm`) tuple.
 - [[AUTHZ-CHECK-4]](#authz-check-4-vs-operator-fee-grant-checks) MUST pass for this (`corporation`, `operator`, `perm`) tuple.
 
-*Path 2 — ancestor validator in the permission tree*
+*Path 2 — ancestor validator in the `Participant` tree*
 
 The target `perm` itself is excluded from this walk; only its ancestors (from the direct parent up to the root) are considered. Walk the tree:
 
@@ -4908,25 +4908,25 @@ Anyone CAN execute this method.
 
 Generic query used for (at least):
 
-- find all permissions (all or limit to active) of a given schema;
+- find all `Participant` entries (all or limit to active) of a given schema;
 - for a given validator, get PENDING onboarding processes;
-- find all permissions of a given grantee;
-- find all permissions of a given did;
-- find all ISSUER_GRANTOR active participants, so that I can apply to an ISSUER permission;
+- find all `Participant` entries of a given grantee;
+- find all `Participant` entries of a given did;
+- find all ISSUER_GRANTOR active participants, so that I can apply to an ISSUER `Participant` entry;
 ...
 
 ##### [MOD-PP-QRY-1-1] List Participants parameters
 
 - `schema_id` (number) (*optional*): the schema id.
 - `grantee` (account) (*optional*): the grantee account.
-- `did` (string) (*optional*): the did the permission refers to.
-- `participant_id` (number) (*optional*): limit to permissions where the `validator_participant_id` is `participant_id`.
+- `did` (string) (*optional*): the did the `Participant` entry refers to.
+- `participant_id` (number) (*optional*): limit to `Participant` entries where the `validator_participant_id` is `participant_id`.
 - `role` (ParticipantRole) (*optional*): if we want to limit to a specific `Participant` role.
 - `only_valid` (boolean) (*optional*): if set to true, only return active participants.
-- `only_slashed` (boolean) (*optional*): if set to true, only return slashed permissions.
-- `only_repaid` (boolean) (*optional*): if set to true, only return repaid slashed permissions.
-- `modified_after` (timestamp) (*optional*): limit to permissions modified after (or equal to) `modified_after`.
-- `op_state` (OnboardingState) (*optional*): limit to permissions with a `op_state` not null and equal to `op_state`.
+- `only_slashed` (boolean) (*optional*): if set to true, only return slashed `Participant` entries.
+- `only_repaid` (boolean) (*optional*): if set to true, only return repaid slashed `Participant` entries.
+- `modified_after` (timestamp) (*optional*): limit to `Participant` entries modified after (or equal to) `modified_after`.
+- `op_state` (OnboardingState) (*optional*): limit to `Participant` entries with a `op_state` not null and equal to `op_state`.
 - `response_max_size` (small number) (*optional*): limit to `response_max_size` results. Must be min 1, max 1,024. Default to 64.
 - `when` (timestamp) (*optional*): if set, query *at* `when`, else query *at* now(). Used to query the VPR state at a previous datetime.
 
@@ -4948,7 +4948,7 @@ Anyone CAN execute this method.
 
 ##### [MOD-PP-QRY-2-1] Get Participant parameters
 
-- `id` of the [[ref: credential schema permission]] (*mandatory*);
+- `id` of the [[ref: credential schema participant]] (*mandatory*);
 
 ##### [MOD-PP-QRY-2-2] Get Participant checks
 
@@ -4966,7 +4966,7 @@ Obsoleted by [MOD-PP-QRY-1].
 
 Anyone can execute this method.
 
-To calculate the fees required for paying the beneficiaries, it is needed to recurse all involved perms until the root of the permission tree (which is the ecosystem perm), starting from the 2 branches `issuer_participant` and `verifier_participant`. As both branches may have common ancestors, we can create a Set (unordered collection with no duplicates), and recurse over the 2 branches, adding found perms. If `verifier_participant` is null, `issuer_participant` is never added to the set. If `verifier_participant` is NOT null, `issuer_participant` is added to the set if it exists but `verifier_participant` is not added to the set.
+To calculate the fees required for paying the beneficiaries, it is needed to recurse all involved perms until the root of the `Participant` tree (which is the ecosystem perm), starting from the 2 branches `issuer_participant` and `verifier_participant`. As both branches may have common ancestors, we can create a Set (unordered collection with no duplicates), and recurse over the 2 branches, adding found perms. If `verifier_participant` is null, `issuer_participant` is never added to the set. If `verifier_participant` is NOT null, `issuer_participant` is added to the set if it exists but `verifier_participant` is not added to the set.
 
 Example 1: `verifier_participant`: is not set: it's a credential offer, schema configured to have Issuer Grantors.
 
@@ -5043,8 +5043,8 @@ v --> vg
 
 ##### [MOD-PP-QRY-4-1] Find Beneficiaries parameters
 
-- `issuer_participant_id` (uint64) (*optional*): id of issuer permission.
-- `verifier_participant_id` (uint64) (*optional*): id of verifier permission.
+- `issuer_participant_id` (uint64) (*optional*): id of issuer `Participant` entry.
+- `verifier_participant_id` (uint64) (*optional*): id of verifier `Participant` entry.
 
 ##### [MOD-PP-QRY-4-2] Find Beneficiaries checks
 
@@ -5054,11 +5054,11 @@ v --> vg
 
 ##### [MOD-PP-QRY-4-3] Find Beneficiaries execution
 
-Example: Let's build the set. Revoked and slashed permissions will not be added to the set. Expired permissions, if not revoked/slashed, will be considered.
+Example: Let's build the set. Revoked and slashed `Participant` entries will not be added to the set. Expired `Participant` entries, if not revoked/slashed, will be considered.
 
 - create Set `found_participant_set`.
 
-- define permission `current_participant` as null.
+- define `current_participant` as null.
 
 - load perms `issuer_participant` and optional `verifier_participant` as specified in basic checks above.
 
@@ -5169,8 +5169,8 @@ actor "Validator\n(issuer grantor)\nAccount" as ValidatorAccount
 participant "Verifiable Public Registry" as VPR #3fbdb6
 
 ApplicantAccount --> VPR: Start Participant OP
-VPR <-- VPR: create permission entry.
-ApplicantAccount <-- VPR: permission entry created,\nassigned participant.validator_participant_id from ISSUER_GRANTOR permissions.
+VPR <-- VPR: create `Participant` entry.
+ApplicantAccount <-- VPR: `Participant` entry created,\nassigned participant.validator_participant_id from ISSUER_GRANTOR `Participant` entries.
 ApplicantBrowser --> ValidatorVS: connect to validator VS DID found in validator_participant.did\nby creating a DIDComm connection
 ApplicantBrowser <-- ValidatorVS: DIDComm connection established.
 ApplicantBrowser --> ValidatorVS: I want to proceed with participant.id=...
@@ -5181,17 +5181,17 @@ ApplicantBrowser <-- ValidatorVS: proof accepted, you are the controller\nof val
 ApplicantBrowser <-- ValidatorVS: which DID do you want to register as an issuer?
 ApplicantBrowser --> ValidatorVS: send DID
 ValidatorVS --> ValidatorVS: resolve DID and get pub keys
-ApplicantBrowser <-- ValidatorVS: request proof of ownership\nof the DID to be added in an ISSUER permission (blind sign)
+ApplicantBrowser <-- ValidatorVS: request proof of ownership\nof the DID to be added in an ISSUER `Participant` entry (blind sign)
 ApplicantBrowser --> ValidatorVS: send blind sign proofs
 ApplicantBrowser <-- ValidatorVS: proof accepted, you are the controller of the DID, I trust you.
 note over ApplicantBrowser, ValidatorVS #EEEEEE: (*optional*) repeat the following until tasks completed
 ApplicantBrowser <-- ValidatorVS: Are you a legitimate issuer?\nProve it, by filling forms, sending documents...
 ApplicantBrowser --> ValidatorVS: perform requested tasks...
 note over ApplicantBrowser, ValidatorVS #EEEEEE: tasks completed
-ApplicantBrowser <-- ValidatorVS: Your are a legitimate issuer. I'll now create an ISSUER permission for your account and DID.
+ApplicantBrowser <-- ValidatorVS: Your are a legitimate issuer. I'll now create an ISSUER `Participant` entry for your account and DID.
 ValidatorAccount --> VPR #3fbdb6: Set Participant OP to Validated\nset validation.state to VALIDATED\n.
 VPR --> ValidatorAccount: Receive trust fees.
-ApplicantBrowser <-- ValidatorVS: notify permission added for your DID.\nDID can now issue credentials of this schema.
+ApplicantBrowser <-- ValidatorVS: notify `Participant` entry added for your DID.\nDID can now issue credentials of this schema.
 ```
 
 ### Trust deposit module

--- a/spec.md
+++ b/spec.md
@@ -558,7 +558,7 @@ The `Participant` registry CAN be used by crawlers to index the metadata associa
 
 Search engines can iterate over `Participant` entries and index [[ref: VSs]] by resolving the service identifier (currently a [[ref: DID]], extensible in the future), verify whether the service is a [[ref: verifiable service]], and in that case extract its verifiable metadata, such as [[ref: linked-vp]] presented credentials.
 
-The index is particularly important for [[ref: verifiable user agents]], such as social browsers, CDN enabled browsers... However, it can also be leveraged by **traditional, form-based search engines**, which may return simple links for accessing [[ref: VSs]].
+The index is particularly important for [[ref: verifiable user agents]], such as social browsers, CDN enabled browser, or any service or AI agent that wants to search for a specific service and connect to it. However, it can also be leveraged by **traditional, form-based search engines**, which may return simple links for accessing [[ref: VSs]].
 
 
 ```plantuml
@@ -590,9 +590,7 @@ user <|-- browser : show result
 
 In a [[ref: VPR]], each [[ref: corporation]] is associated with a [[ref: trust deposit]].
 
-This [[ref: trust deposit]] is automatically funded through transactions involving **trust operations**, such as:
-
-- Paying trust fees between participants when enforcing ecosystem governance rules for services, credential issuance, or presentation...
+This [[ref: trust deposit]] is automatically funded through transactions involving **trust operations**, such as onboarding processes, credential issuance, or presentation...
 
 The trust deposit is fundamental to the **"Proof-of-Trust" (PoT)** mechanism of the [[ref: Verifiable Trust Specification]], and it operates as follows:
 
@@ -784,7 +782,7 @@ vg --> verifier : creates schema participant
 
 [[ref: Corporations]] acting as **issuers** or **verifiers** for a given credential schema **may be required to pay trust fees** based on the schema's configuration and `Participant` tree.
 
-If trust fee payment is required, the entity **must execute a transaction** in the [[ref: VPR]] to pay the appropriate [[ref: trust fees]] **before issuing or verifying a credential**.
+If trust fee payment is required, the entity **must execute a transaction** in the [[ref: VPR]] to pay the appropriate [[ref: trust fees]] **before issuing or verifying a credential**, else HOLDER agent will not accept the operation.
 
 Key Points for "Pay-Per" Business Models
 
@@ -793,8 +791,8 @@ Key Points for "Pay-Per" Business Models
 - In such cases, an `ISSUER` (or `VERIFIER`) `Participant` **must pay**:
   - the corresponding **issuance** (or **verification**) trust fees for each involved `Participant` entry along the `Participant` tree;
   - an additional amount equal to the `trust_deposit_rate` of the calculated trust fees, allocated to the **payer's [[ref: trust deposit]]**;
-  - an amount equal to `wallet_user_agent_reward_rate` of the calculated trust fees, used to **reward the Wallet User Agent**;
-  - an amount equal to `user_agent_reward_rate` of the calculated trust fees, used to **reward the User Agent**.
+  - (optional) an amount equal to `wallet_user_agent_reward_rate` of the calculated trust fees, used to **reward the Wallet User Agent**;
+  - (optional) an amount equal to `user_agent_reward_rate` of the calculated trust fees, used to **reward the User Agent**.
 
 Fee Distribution Model
 
@@ -804,7 +802,7 @@ Trust fees are **consistently distributed** across participants:
 - The remaining portion is **transferred directly to the participant’s wallet**.
 
 :::note
-**Wallet User Agents** and **User Agents** that implement the [[ref: VT spec]] **must verify** that the ISSUER or VERIFIER has fulfilled the required trust fee payment.  
+Agents that implement the [[ref: VT spec]] **must verify** that the ISSUER or VERIFIER has fulfilled the required trust fee payment.  
 If not, they **must reject** the issuance or verification request.
 
 Note: The **User Agent** and **Wallet User Agent** may refer to the same implementation.
@@ -974,7 +972,7 @@ verifiera --> verifiertd:  \t+11.4 TUs
 
 A [[ref: governance framework]] must define the governance rules that apply to a [[ref: VPR]].
 
-A designated [[ref: governance authority]] is responsible for **enforcing these rules** and, when necessary, **applying financial sanctions** to participants who violate the rules.
+A designated [[ref: governance authority]] (aka a council) is responsible for **enforcing these rules** and, when necessary, **applying financial sanctions** to participants who violate the rules.
 
 :::note
 **Ecosystem Governance Frameworks (EGFs)** operate **independently** from the [[ref: VPR]] [[ref: governance framework]].
@@ -1698,7 +1696,7 @@ For Msg methods, all precondition checks MUST be verified first for accepting th
 A VPR implementation MUST implement all the following requirements.
 
 :::note
-The relative REST path is the path suffix. Implementer can set any prefix, like https://example/verana/es/v1/get.
+The relative REST path is the path suffix. Implementer can set any prefix, like https://example/verana/ec/v1/get.
 :::
 
 ### Authorization and Fee Grants
@@ -1743,17 +1741,17 @@ Some module messages specify only a `corporation`:
 - `corporation` (group):  
   The `group` that owns the manipulated resource.
 
-Such messages **cannot be delegated** and MUST be executed exclusively through a **group proposal**.
+Such messages **cannot be delegated** and MUST be executed exclusively through a **corporation proposal**.
 
 #### Governance-Signed Module Messages
 
-Some module messages can be executed **only through a governance proposal**.
+Some module messages can be executed **only through a VPR council governance proposal**.
 
 These messages do not support delegation and are not executable by accounts, whether directly or via group authorization.
 
 #### Fee Grants
 
-A `corporation` group MAY allow its `operator`s to pay **network transaction fees** using the `corporation`’s funds.
+A `corporation` MAY allow its `operator`s to pay **network transaction fees** using the `corporation`’s funds.
 
 Fee grants are **not created directly**.  
 They are created, updated, and revoked **exclusively by Authorization module messages**.  
@@ -1858,9 +1856,9 @@ As a result, `accountABC` is authorized to:
 |                                | Update Ecosystem                   |       N/A (Tx)                   | Msg    | [[MOD-ES-MSG-2]](#mod-es-msg-2-update-ecosystem)   |corporation + operator |
 |                                | Archive Ecosystem                  |        N/A (Tx)                 | Msg    | [[MOD-ES-MSG-3]](#mod-es-msg-3-archive-ecosystem)   |corporation + operator |
 |                                | Update Ecosystem Module Parameters             |         N/A (Tx)                 | Msg    | [[MOD-ES-MSG-4]](#mod-es-msg-4-update-module-parameters)   |governance proposal |
-|                                | Get Ecosystem                      | /es/v1/get                  | Query  | [[MOD-ES-QRY-1]](#mod-es-qry-1-get-ecosystem)   |N/A |
-|                                | List Ecosystems                   | /es/v1/list                 | Query  | [[MOD-ES-QRY-2]](#mod-es-qry-2-list-ecosystems)   |N/A |
-|                                | List Ecosystem Module Parameters               | /es/v1/params                 | Query  | [[MOD-ES-QRY-3]](#mod-es-qry-3-list-module-parameters)   |N/A |
+|                                | Get Ecosystem                      | /ec/v1/get                  | Query  | [[MOD-ES-QRY-1]](#mod-es-qry-1-get-ecosystem)   |N/A |
+|                                | List Ecosystems                   | /ec/v1/list                 | Query  | [[MOD-ES-QRY-2]](#mod-es-qry-2-list-ecosystems)   |N/A |
+|                                | List Ecosystem Module Parameters               | /ec/v1/params                 | Query  | [[MOD-ES-QRY-3]](#mod-es-qry-3-list-module-parameters)   |N/A |
 | Governance Framework      | Add Governance Framework Document            | N/A (Tx)                         | Msg    | [[MOD-GF-MSG-1]](#mod-gf-msg-1-add-governance-framework-document)   | corporation + operator |
 |                                | Increase Active Governance Framework Version | N/A (Tx)                         | Msg    | [[MOD-GF-MSG-2]](#mod-gf-msg-2-increase-active-governance-framework-version)   | corporation + operator |
 |                                | Get Governance Framework Version             | /gf/v1/get                       | Query  | [[MOD-GF-QRY-1]](#mod-gf-qry-1-get-governance-framework-version)   | N/A |

--- a/spec.md
+++ b/spec.md
@@ -1234,8 +1234,9 @@ csp "1" --- "0..n" da: vs_operator_spend_limit
 csp "1" --- "0..n" da: vs_operator_fee_spend_limit
 
 
-tr "1" --- "1..n" gfv: versions 
-gfv "1" --- "1..n" gfd: documents 
+tr "1" --- "0..n" gfv: versions (ecosystem_id)
+corp "1" --- "0..n" gfv: versions (corporation_id)
+gfv "1" --- "1..n" gfd: documents
 
 group "1" --- "1" corp
 
@@ -1287,21 +1288,26 @@ A `Corporation` is the VPR-level entity that extends a Cosmos SDK [[ref: group]]
 
 ### GovernanceFrameworkVersion
 
+A `GovernanceFrameworkVersion` represents a single version of either an [[ref: EGF]] or a [[ref: CGF]]. Its owning subject is identified by exactly one of `ecosystem_id` or `corporation_id` (XOR).
+
 `GovernanceFrameworkVersion`:
 
-- `id` (uint64) (*mandatory*): the id of the schema.
-- `ecosystem_id` (uint64) (*mandatory*): the id of the ecosystem that controls this `GovernanceFrameworkVersion` entry.
+- `id` (uint64) (*mandatory*): the id of the GFV.
+- `ecosystem_id` (uint64) (*conditional*): the id of the [[ref: ecosystem]] that controls this `GovernanceFrameworkVersion` entry. MUST be set if `corporation_id` is null.
+- `corporation_id` (uint64) (*conditional*): the id of the [[ref: corporation]] that controls this `GovernanceFrameworkVersion` entry. MUST be set if `ecosystem_id` is null.
 - `created` (timestamp) (*mandatory*): timestamp this GovernanceFrameworkVersion has been created.
 - `version` (int) (*mandatory*): version of this GF. MUST Starts with 1.
+
+> Constraint: exactly one of `ecosystem_id` and `corporation_id` MUST be set.
 
 ### GovernanceFrameworkDocument
 
 `GovernanceFrameworkDocument`
 
-- `id` (uint64) (*mandatory*): the id of the schema.
+- `id` (uint64) (*mandatory*): the id of the GFD.
 - `gfv_id` (uint64) (*mandatory*): the id of the `GovernanceFrameworkVersion` entry.
 - `created` (timestamp) (*mandatory*): timestamp this GovernanceFrameworkDocument has been created.
-- `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this ecosystem.
+- `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this governance framework document.
 - `url` (string) (*mandatory*): URL where the document is published.
 - `digest_sri` (string) (*mandatory*): digest_sri of the document.
 

--- a/spec.md
+++ b/spec.md
@@ -1798,9 +1798,9 @@ As a result, `accountABC` is authorized to:
 | Module                         | Method Name                             | Relative REST API path           | Type   |Requirements      | Signers |
 |--------------------------------|-----------------------------------------|----------------------------------|--------|------------------|---|
 | Ecosystem                 | Create an Ecosystem                 |    N/A (Tx)                    | Msg    | [[MOD-ES-MSG-1]](#mod-es-msg-1-create-new-ecosystem)   | corporation + operator |
-|                                | Update Ecosystem                   |       N/A (Tx)                   | Msg    | [[MOD-ES-MSG-4]](#mod-es-msg-4-update-ecosystem)   |corporation + operator |
-|                                | Archive Ecosystem                  |        N/A (Tx)                 | Msg    | [[MOD-ES-MSG-5]](#mod-es-msg-5-archive-ecosystem)   |corporation + operator |
-|                                | Update Ecosystem Module Parameters             |         N/A (Tx)                 | Msg    | [[MOD-ES-MSG-6]](#mod-es-msg-6-update-module-parameters)   |governance proposal |
+|                                | Update Ecosystem                   |       N/A (Tx)                   | Msg    | [[MOD-ES-MSG-2]](#mod-es-msg-2-update-ecosystem)   |corporation + operator |
+|                                | Archive Ecosystem                  |        N/A (Tx)                 | Msg    | [[MOD-ES-MSG-3]](#mod-es-msg-3-archive-ecosystem)   |corporation + operator |
+|                                | Update Ecosystem Module Parameters             |         N/A (Tx)                 | Msg    | [[MOD-ES-MSG-4]](#mod-es-msg-4-update-module-parameters)   |governance proposal |
 |                                | Get Ecosystem                      | /es/v1/get                  | Query  | [[MOD-ES-QRY-1]](#mod-es-qry-1-get-ecosystem)   |N/A |
 |                                | List Ecosystems                   | /es/v1/list                 | Query  | [[MOD-ES-QRY-2]](#mod-es-qry-2-list-ecosystems)   |N/A |
 |                                | List Ecosystem Module Parameters               | /es/v1/params                 | Query  | [[MOD-ES-QRY-3]](#mod-es-qry-3-list-module-parameters)   |N/A |
@@ -1952,11 +1952,11 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 > Subsequent governance framework documents and version activations for this ecosystem MUST be managed through [[MOD-GF-MSG-1]](#mod-gf-msg-1-add-governance-framework-document) and [[MOD-GF-MSG-2]](#mod-gf-msg-2-increase-active-governance-framework-version).
 
-#### [MOD-ES-MSG-4] Update Ecosystem
+#### [MOD-ES-MSG-2] Update Ecosystem
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-ES-MSG-4-1] Update Ecosystem parameters
+##### [MOD-ES-MSG-2-1] Update Ecosystem parameters
 
 - `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
@@ -1964,11 +1964,11 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 - `did` (string) (*mandatory*): the did of the ecosystem.
 - `aka` (string) (*optional*): optional additional URI of this ecosystem. If null, it means replace existing value with null.
 
-##### [MOD-ES-MSG-4-2] Update Ecosystem precondition checks
+##### [MOD-ES-MSG-2-2] Update Ecosystem precondition checks
 
 If any of these precondition checks fail, method MUST abort.
 
-###### [MOD-ES-MSG-4-2-1] Update Ecosystem basic checks
+###### [MOD-ES-MSG-2-2-1] Update Ecosystem basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
 
@@ -1979,11 +1979,11 @@ If any of these precondition checks fail, method MUST abort.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
 - `aka` (string) (*optional*): optional additional URI of this ecosystem. MUST be an [[ref: URI]] or null.
 
-###### [MOD-ES-MSG-4-2-2] Update Ecosystem fee checks
+###### [MOD-ES-MSG-2-2-2] Update Ecosystem fee checks
 
 Fee payer must have available balance in its [[ref: account]] to cover the required [[ref: transaction fees]].
 
-##### [MOD-ES-MSG-4-3] Update Ecosystem execution
+##### [MOD-ES-MSG-2-3] Update Ecosystem execution
 
 If all precondition checks passed, method is executed.
 
@@ -1995,22 +1995,22 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - `ecosystem.aka`: `aka`
 - `ecosystem.modified`: current timestamp
 
-#### [MOD-ES-MSG-5] Archive Ecosystem
+#### [MOD-ES-MSG-3] Archive Ecosystem
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-ES-MSG-5-1] Archive Ecosystem parameters
+##### [MOD-ES-MSG-3-1] Archive Ecosystem parameters
 
 - `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*) id of the ecosystem (*mandatory*);
 - `archive` (boolean) (*mandatory*), true means archive, false means unarchive.
 
-##### [MOD-ES-MSG-5-2] Archive Ecosystem precondition checks
+##### [MOD-ES-MSG-3-2] Archive Ecosystem precondition checks
 
 If any of these precondition checks fail, method MUST abort.
 
-###### [MOD-ES-MSG-5-2-1] Archive Ecosystem basic checks
+###### [MOD-ES-MSG-3-2-1] Archive Ecosystem basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
 
@@ -2022,11 +2022,11 @@ If any of these precondition checks fail, method MUST abort.
   - If `archive` is true and `ecosystem.archived` is not null, MUST abort as `Ecosystem` is already archived.
   - If `archive` is false and `ecosystem.archived` is null, MUST abort as `Ecosystem` is already not archived.
 
-###### [MOD-ES-MSG-5-2-2] Archive Ecosystem fee checks
+###### [MOD-ES-MSG-3-2-2] Archive Ecosystem fee checks
 
 Fee payer MUST have an available balance in its [[ref: account]] to cover the required [[ref: transaction fees]].
 
-##### [MOD-ES-MSG-5-3] Archive Ecosystem execution
+##### [MOD-ES-MSG-3-3] Archive Ecosystem execution
 
 If all precondition checks passed, method is executed.
 
@@ -2037,29 +2037,29 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - if `archived` is false: set `ecosystem.archived` to null.
 - `ecosystem.modified`: current timestamp
 
-#### [MOD-ES-MSG-6] Update Module Parameters
+#### [MOD-ES-MSG-4] Update Module Parameters
 
 Update Module Parameters.
 
 Can only be executed through a governance proposal.
 
-##### [MOD-ES-MSG-6-1] Update Module Parameters parameters
+##### [MOD-ES-MSG-4-1] Update Module Parameters parameters
 
 - `params` (KeySet<String, String>): the parameters to update and their values.
 
-##### [MOD-ES-MSG-6-2] Update Module Parameters precondition checks
+##### [MOD-ES-MSG-4-2] Update Module Parameters precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-ES-MSG-6-2-1] Update Module Parameters basic checks
+###### [MOD-ES-MSG-4-2-1] Update Module Parameters basic checks
 
 - `params`: size of `params` MUST be greater than 0. For each `param` <`key`, `value`> `key` MUST exist, else abort.
 
-###### [MOD-ES-MSG-6-2-2] Update Module Parameters fee checks
+###### [MOD-ES-MSG-4-2-2] Update Module Parameters fee checks
 
 provided transaction fees MUST be sufficient for execution
 
-##### [MOD-ES-MSG-6-3] Update Module Parameters execution
+##### [MOD-ES-MSG-4-3] Update Module Parameters execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 

--- a/spec.md
+++ b/spec.md
@@ -1261,7 +1261,7 @@ group  --o td: corporation
 
 - `id` (uint64) (*mandatory*): the id of the ecosystem.
 - `did` (string) (*mandatory*): the did of the ecosystem.
-- `corporation` (group) (*mandatory*): [[ref: group]] that controls this entry.
+- `corporation` (Corporation) (*mandatory*): [[ref: corporation]] that controls this entry.
 - `created` (timestamp) (*mandatory*): timestamp this Ecosystem has been created.
 - `modified` (timestamp) (*mandatory*): timestamp this Ecosystem has been modified.
 - `archived` (timestamp) (*mandatory*): timestamp this Ecosystem has been archived.
@@ -1358,7 +1358,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 - `schema_id` (uint64) (*mandatory*): the id of the related `CredentialSchema` entry.
 - `type` (ParticipantRole): ISSUER, VERIFIER, ISSUER_GRANTOR, VERIFIER_GRANTOR, ECOSYSTEM, HOLDER
 - `did` (string) (*optional*): [[ref: DID]] this permission refers to. MUST conform to [[spec-norm:RFC3986]].
-- `corporation` (group) (*mandatory*): [[ref: group]] that owns this permission.
+- `corporation` (Corporation) (*mandatory*): [[ref: corporation]] that owns this permission.
 - `vs_operator` (account) (*mandatory*): verifiable service agent account. This is the account that will have the right to create or update permission sessions.
 - `created` (timestamp) (*mandatory*): timestamp this `Participant` has been created.
 - `adjusted` (timestamp) (*mandatory*): timestamp this `Participant` has been adjusted.
@@ -1392,7 +1392,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 `ParticipantSession`:
 
 - `id` (uuid) (*mandatory*): session uuid.
-- `corporation` (group) (*mandatory*): corporation that controls the entry.
+- `corporation` (Corporation) (*mandatory*): corporation that controls the entry.
 - `vs_operator` (account) (*mandatory*): verifiable service agent account that controls the entry (agent crypto account).
 - `created` (timestamp) (*mandatory*): timestamp this ParticipantSession has been created.
 - `modified` (timestamp) (*mandatory*): timestamp this ParticipantSession has been modified.
@@ -1413,7 +1413,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 `TrustDeposit`:
 
 - `share` (number) (*mandatory*): share of the module total deposit.
-- `corporation` (group) (*mandatory*) (key): the [[ref: group]]
+- `corporation` (Corporation) (*mandatory*) (key): the [[ref: corporation]]
 - `deposit` (number) (*mandatory*): amount of deposit in `denom`.
 - `refunded` (number) (*mandatory*): amount of refunded trust deposit, in `denom`. Refunded trust deposit is reused as funding for the next trust deposit spending before drawing additional funds from the corporation account.
 - `slashed_deposit` (number) (*optional*): amount of slashed deposit in `denom`.
@@ -1434,7 +1434,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 
 ### OperatorAuthorization
 
-- `corporation` (group) (*mandatory*): the corporation group granting the authorization.
+- `corporation` (Corporation) (*mandatory*): the [[ref: corporation]] granting the authorization.
 - `operator` (account) (*mandatory*): the operator account receiving the authorization.
 - `msg_types` (msg_type[]) (*mandatory*): list of module message types this authorization applies to.
 - `spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds that the grantee is allowed to spend
@@ -1449,7 +1449,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 
 `FeeGrant`:
 
-- `grantor` (group) (*mandatory*): the corporation group granting the fee allowance.
+- `grantor` (Corporation) (*mandatory*): the [[ref: corporation]] granting the fee allowance.
 - `grantee` (account) (*mandatory*): the account that receives the fee grant from `grantor`.
 - `msg_types` (msg_type[]) (*mandatory*): list of VPR delegable message types for which the fee allowance applies.
 - `spend_limit` (DenomAmount[]) (*optional*): maximum amount of fees that can be spent using this grant.
@@ -1461,7 +1461,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 
 A `VSOperatorAuthorization` groups all `ParticipantAuthorizationRecord` entries delegated by one `corporation` to one `vs_operator`. It is keyed by the `(corporation, vs_operator)` pair. The entry exists if, and only if, it has at least one record.
 
-- `corporation` (group) (*mandatory*): the corporation group granting the authorization.
+- `corporation` (Corporation) (*mandatory*): the [[ref: corporation]] granting the authorization.
 - `vs_operator` (account) (*mandatory*): the operator account receiving the authorization.
 - `records` (ParticipantAuthorizationRecord[]) (*mandatory*): per-permission authorization records granted to `vs_operator` by `corporation`.
 
@@ -1669,7 +1669,7 @@ Delegable messages are defined as messages that can be executed by an `operator`
 
 Such messages conceptually involve **two roles**:
 
-- `corporation` (group):  
+- `corporation` (Corporation):  
   The `group` that owns the created or manipulated resource.  
   The corporation is represented in the Msg through an authorization granted to an `operator` account.
 
@@ -1698,7 +1698,7 @@ It is entirely up to the `corporation` group to decide **which accounts may exec
 
 Some module messages specify only a `corporation`:
 
-- `corporation` (group):  
+- `corporation` (Corporation):  
   The `group` that owns the manipulated resource.
 
 Such messages **cannot be delegated** and MUST be executed exclusively through a **group proposal**.
@@ -1878,7 +1878,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 An authorized `operator` that would like to create a [[ref: ecosystem]] MUST call this method by specifying:
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `did` (string) (*mandatory*): the did of the ecosystem that is creating the ecosystem.
 - `aka` (string) (*optional*): optional additional URI of this ecosystem.
@@ -1896,7 +1896,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
@@ -1953,7 +1953,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-ES-MSG-2-1] Add Governance Framework Document parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): the id of the ecosystem.
 - `doc_language` (string) (*mandatory*): language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of the [[ref: EGF]] document, provided by the [[ref: EGA]].
@@ -1971,7 +1971,7 @@ If any of these precondition checks fail, method MUST abort.
 
 if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` (uint64) (*mandatory*): a `Ecosystem` entry with this id MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry.
@@ -2013,7 +2013,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-ES-MSG-3-1] Increase Active Governance Framework Version parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): the id of the ecosystem.
 
@@ -2025,7 +2025,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` (uint64) (*mandatory*): a `Ecosystem` entry with this id MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry.
@@ -2050,7 +2050,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-ES-MSG-4-1] Update Ecosystem parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): the id of the ecosystem.
 - `did` (string) (*mandatory*): the did of the ecosystem.
@@ -2064,7 +2064,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` (uint64) (*mandatory*): a `Ecosystem` entry `tr` with id `id` MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry `tr`.
@@ -2093,7 +2093,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-ES-MSG-5-1] Archive Ecosystem parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*) id of the ecosystem (*mandatory*);
 - `archive` (boolean) (*mandatory*), true means archive, false means unarchive.
@@ -2106,7 +2106,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - load `Ecosystem` `tr` from `id`. `ecosystem.corporation` MUST be the corporation executing the method, else MUST abort.
@@ -2183,7 +2183,7 @@ return found `Ecosystem` entry (if any), as well as *all its nested* `Governance
 
 The following parameters are optional:
 
-- `corporation` (group) (*optional*): if specified, filter by corporation.
+- `corporation` (Corporation) (*optional*): if specified, filter by corporation.
 - `modified_after` (timestamp) (*optional*): if specified, returns only `Ecosystem` entries with `Ecosystem.modified` greater than `modified`.
 - `active_gf_only` (boolean) (*optional*): if true, include only current governance framework data. If false or null, returns everything.
 - `preferred_language` (string) (*optional*): if set, return only one document per version, with language=`preferred_language` when possible, else if no document exist with this language, return language. If not set, return all documents of all languages.
@@ -2234,7 +2234,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 An [[ref: account]] that would like to create a [[ref: credential schema]] MUST call this method by specifying:
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `ecosystem_id` id of the ecosystem (*mandatory*);
 - `json_schema` the [[ref: Json Schema]] of the credential (*mandatory*).
@@ -2258,7 +2258,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `ecosystem_id` MUST represent an existing `Ecosystem` entry `tr` and `ecosystem.corporation` MUST be the `corporation` executing the method.
@@ -2324,7 +2324,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 An [[ref: account]] that would like to update a [[ref: credential schema]] MUST call this method by specifying:
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` id of the credential schema (*mandatory*);
 - `issuer_grantor_validation_validity_period` (*mandatory*), default to 0 (days).
@@ -2343,7 +2343,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST represent an existing `CredentialSchema` entry `cs`.
@@ -2381,7 +2381,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 An [[ref: account]] that would like to archive or unarchive a [[ref: credential schema]] MUST call this method by specifying:
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*) id of the credential schema (*mandatory*);
 - `archive` (boolean) (*mandatory*), true means archive, false means unarchive.
@@ -2394,7 +2394,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST represent an existing `CredentialSchema` entry `cs`.
@@ -2462,7 +2462,7 @@ Accordingly, if a credential schema defines one or more active policies for the 
 
 ##### [MOD-CS-MSG-5-1] Create Schema Authorization Policy parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `schema_id` (uint64): id of the related `CredentialSchema` (*mandatory*).
 - `role` (SchemaAuthorizationPolicyRole): `ISSUER` or `VERIFIER` (*mandatory*).
@@ -2476,7 +2476,7 @@ If any of these precondition checks fail, method MUST abort.
 ###### [MOD-CS-MSG-5-2-1] Create Schema Authorization Policy basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `schema_id` MUST reference an existing `CredentialSchema` entry controlled by `corporation`.
@@ -2519,7 +2519,7 @@ This message activates the current draft `SchemaAuthorizationPolicy` for the giv
 
 ##### [MOD-CS-MSG-6-1] Increase Active Schema Authorization Policy Version parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `schema_id` (uint64): id of the related `CredentialSchema` (*mandatory*).
 - `role` (SchemaAuthorizationPolicyRole): `ISSUER` or `VERIFIER` (*mandatory*).
@@ -2531,7 +2531,7 @@ If any of these precondition checks fail, method MUST abort.
 ###### [MOD-CS-MSG-6-2-1] Basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `schema_id` MUST reference an existing `CredentialSchema` entry controlled by `corporation`.
@@ -2562,7 +2562,7 @@ This message revokes a previously enabled `SchemaAuthorizationPolicy` version. R
 
 ##### [MOD-CS-MSG-7-1] Revoke Schema Authorization Policy parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `schema_id` (uint64): id of the related `CredentialSchema` (*mandatory*).
 - `role` (SchemaAuthorizationPolicyRole): `ISSUER` or `VERIFIER` (*mandatory*).
@@ -2575,7 +2575,7 @@ If any of these precondition checks fail, method MUST abort.
 ###### [MOD-CS-MSG-7-2-1] Basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - a policy MUST exist for `(schema_id, role, version)`.
@@ -2840,7 +2840,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 An Applicant that would like to start a permission onboarding process MUST execute this method by specifying:
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `vs_operator` (account) (*optional*): the account of the Veriable Service we want to authorize to create permission sessions linked to this permission. If not specified, Verifiable Service will not be able to use the payment delegation feature. **Required** to use the payment delegation feature.
 - `type` (ParticipantRole) (*mandatory*): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the permission that the applicant would like to get;
@@ -2880,7 +2880,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `type` (ParticipantRole) (*mandatory*) MUST be a valid ParticipantRole: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.
@@ -3074,7 +3074,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-PP-MSG-2-1] Renew Participant OP parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission for which applicant would like to renew the onboarding process;
 
@@ -3086,7 +3086,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64 and a permission entry with the same id MUST exist.
@@ -3167,7 +3167,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 An [[ref: account]] that would like to set a validation entry to VALIDATED MUST execute this method by specifying:
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the onboarding process;
 - `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this `Participant` is effective, null if no time limit should been set for this permission or if we want it to be aligned with the onboarding process expiration timestamp calculated by this method.
@@ -3186,7 +3186,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - `id` MUST be a valid uint64.
 - Load `Participant` entry `applicant_participant` from `id`. If no entry found, abort.
@@ -3344,7 +3344,7 @@ At any time, [[ref: applicant]] of a permission onboarding process may request c
 
 ##### [MOD-PP-MSG-6-1] Cancel Participant OP Last Request parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the `Participant` entry;
 
@@ -3356,7 +3356,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
@@ -3401,7 +3401,7 @@ This method is used by controller authorities of Ecosystems. When they create a 
 
 An [[ref: account]] that would like to create a `Participant` entry MUST call this method by specifying:
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `schema_id` (uint64) (*mandatory*)
 - `vs_operator` (account) (*optional*): the account we want to authorize to act on behalf of `corporation` in the context of this permission. **Required** for payment delegation.
@@ -3434,7 +3434,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `schema_id` MUST be a valid uint64 and a [[ref: credential schema]] entry with this id MUST exist.
@@ -3527,7 +3527,7 @@ This method can be called:
 
 ##### [MOD-PP-MSG-8-1] Adjust Participant parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
 - `effective_until` (timestamp) (*mandatory*): timestamp until when (exclusive) this `Participant` will be effective.
@@ -3540,7 +3540,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
@@ -3617,7 +3617,7 @@ This method can only be called:
 
 ##### [MOD-PP-MSG-9-1] Revoke Participant parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
 
@@ -3629,7 +3629,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
@@ -3781,7 +3781,7 @@ See [[ref: VT spec]].
 
 An [[ref: account]] that would like to create or update a `ParticipantSession` entry MUST send a Msg by specifying:
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uuid) (*mandatory*): id of the `ParticipantSession`.
 - `issuer_participant_id` (uint64) (*optional*): the id of the perm of the issuer, if we are dealing with the issuance of a credential.
@@ -3794,7 +3794,7 @@ An [[ref: account]] that would like to create or update a `ParticipantSession` e
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - `id` MUST be a valid uuid. If an entry `existing_entry` with `id` already exist, then  `existing_entry.corporation` MUST be equal to `corporation` AND `existing_entry.vs_operator` MUST be equal to `operator`, else abort.
 
@@ -4208,7 +4208,7 @@ This method can only be called by either:
 
 ##### [MOD-PP-MSG-12-1] Slash Participant Trust Deposit parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
 - `amount` (number) (*mandatory*): the amount to slash
@@ -4221,7 +4221,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
@@ -4284,7 +4284,7 @@ Nevertheless, to get a new permission for a given ecosystem, it is needed, using
 
 ##### [MOD-PP-MSG-13-1] Repay Participant Slashed Trust Deposit parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission
 
@@ -4296,7 +4296,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
@@ -4335,7 +4335,7 @@ Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else
 
 ##### [MOD-PP-MSG-14-1] Self Create Participant parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `type` (ParticipantRole) (*mandatory*): ISSUER or VERIFIER.
 - `validator_participant_id` (uint64) (*mandatory*): MUST be an ECOSYSTEM [[ref: active participant]] or [[ref: future participant]].
@@ -4372,7 +4372,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 Load `Participant` `validator_participant` from `validator_participant_id`.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `type` (ParticipantRole) (*mandatory*): MUST be ISSUER or VERIFIER, else abort.
@@ -4476,7 +4476,7 @@ The method does not modify the [[ref: VPR]] state; it only emits an event that o
 
 ##### [MOD-PP-MSG-15-1] Trigger Resolver parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission for which a trust resolution must be triggered.
 
@@ -4488,7 +4488,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - `id` MUST be a valid uint64.
 - Load `Participant` entry `perm` from `id`. If no entry found, abort.
@@ -4914,7 +4914,7 @@ Only the modules that require trust deposit manipulation CAN call this method. I
 
 ##### [MOD-TD-MSG-1-1] Adjust Trust Deposit method parameters
 
-- `corporation` (group) (*mandatory*): corporation owner of the [[ref: trust deposit]] we want to adjust.
+- `corporation` (Corporation) (*mandatory*): corporation owner of the [[ref: trust deposit]] we want to adjust.
 - `augend` (number) (*mandatory*): value to add to the deposit, in [[ref: denom]].
 
 ##### [MOD-TD-MSG-1-2] Adjust Trust Deposit precondition checks
@@ -5007,12 +5007,12 @@ If `claimable_yield` is positive, it can be claimed.
 
 ##### [MOD-TD-MSG-2-1] Reclaim Trust Deposit Yield method parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 
 ##### [MOD-TD-MSG-2-2] Reclaim Trust Deposit Yield precondition checks
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 
@@ -5083,7 +5083,7 @@ This method is for network governance authority slash. For ecosystem slash, see 
 
 ##### [MOD-TD-MSG-5-1] Slash Trust Deposit method parameters
 
-- `corporation` (group) (*mandatory*): corporation we want to slash.
+- `corporation` (Corporation) (*mandatory*): corporation we want to slash.
 - `amount` (number) (*mandatory*): value to slash, in [[ref: denom]].
 
 ##### [MOD-TD-MSG-5-2] Slash Trust Deposit precondition checks
@@ -5122,7 +5122,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-TD-MSG-6-1] Repay Slashed Trust Deposit method parameters
 
-- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `amount` (number) (*mandatory*): value to repay, in [[ref: denom]].
 
@@ -5134,7 +5134,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `amount` must be > 0.
@@ -5169,7 +5169,7 @@ Make sure to **properly protect access to the execution of this method** else it
 
 ##### [MOD-TD-MSG-7-1] Burn Ecosystem Slashed Trust Deposit method parameters
 
-- `corporation` (group) (*mandatory*): corporation of the [[ref: trust deposit]] we want to burn.
+- `corporation` (Corporation) (*mandatory*): corporation of the [[ref: trust deposit]] we want to burn.
 - `amount` (number) (*mandatory*): value to burn, in [[ref: denom]].
 
 :::warning
@@ -5256,7 +5256,7 @@ This method can only be called directly by the following methods:
 
 ##### [MOD-DE-MSG-1-1] Grant Fee Allowance method parameters
 
-- `corporation` (group) (*mandatory*): the corporation that grants the fees.
+- `corporation` (Corporation) (*mandatory*): the corporation that grants the fees.
 - `grantee` (account) (*mandatory*): the account that receives the fee grant from `corporation`.
 - `msg_types` (Msg[]) (*mandatory*): the type of messages for which we want to grant the fee allowance.
 - `expiration` (timestamp) (*optional*): when the grant expires.
@@ -5301,14 +5301,14 @@ This method can only be called directly by the following methods:
 
 ##### [MOD-DE-MSG-2-1] Revoke Allowance method parameters
 
-- `corporation` (group) (*mandatory*): the corporation.
+- `corporation` (Corporation) (*mandatory*): the corporation.
 - `grantee` (account) (*mandatory*): the grantee we want to revoke.
 
 ##### [MOD-DE-MSG-2-2] Revoke Fee Allowance basic checks
 
 MUST abort if one of these conditions fails:
 
-- `corporation` (group) (*mandatory*): MUST be specified.
+- `corporation` (Corporation) (*mandatory*): MUST be specified.
 - `grantee` (account) (*mandatory*): MUST be specified.
 
 ##### [MOD-DE-MSG-2-3] Revoke Fee Allowance fee checks
@@ -5326,7 +5326,7 @@ If FeeGrant entry for this (`corporation`, `grantee`) exist, delete it, else do 
 
 ##### [MOD-DE-MSG-3-1] Grant Operator Authorization method parameters
 
-- `corporation` (group) (*mandatory*): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation) (*mandatory*): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account) (*optional*): (Signer) the account authorized by the `corporation` to run this Msg.
 - `grantee` (account) (*mandatory*): the account that receives the authorization from `corporation`.
 - `msg_types` (Msg[]) (*mandatory*): the type of messages for which we want to grant the fee allowance.
@@ -5341,7 +5341,7 @@ If FeeGrant entry for this (`corporation`, `grantee`) exist, delete it, else do 
 
 if any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `msg_types` (Msg[]) (*mandatory*): MUST be a list of **VPR delegable messages only**, excepted `CreateOrUpdateParticipantSession` which is not allowed.
@@ -5391,7 +5391,7 @@ else if `with_feegrant` is true:
 
 ##### [MOD-DE-MSG-4-1] Revoke Operator Authorization method parameters
 
-- `corporation` (group) (*mandatory*): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation) (*mandatory*): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account) (*mandatory*): (Signer) the account authorized by the `corporation` to run this Msg.
 - `grantee` (account) (*mandatory*): the account that will be revoked its authorization`.
 
@@ -5399,7 +5399,7 @@ else if `with_feegrant` is true:
 
 MUST abort if one of these conditions fails:
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - An Authorization entry MUST exist for this (`corporation`, `grantee`)
@@ -5426,7 +5426,7 @@ This method does NOT read `Participant` state. All authorization configuration i
 
 ##### [MOD-DE-MSG-5-1] Grant VS Operator Authorization method parameters
 
-- `corporation` (group) (*mandatory*): the corporation delegating the authorization.
+- `corporation` (Corporation) (*mandatory*): the corporation delegating the authorization.
 - `vs_operator` (account) (*mandatory*): the account receiving the authorization.
 - `record` ([ParticipantAuthorizationRecord](#participantauthorizationrecord)) (*mandatory*): the full record to store.
 
@@ -5547,7 +5547,7 @@ Anyone CAN execute this method.
 
 ##### [MOD-DE-QRY-1-1] List Operator Authorizations parameters
 
-- `corporation` (group) (*optional*): filter by the corporation group that granted the authorization.
+- `corporation` (Corporation) (*optional*): filter by the corporation group that granted the authorization.
 - `operator` (account) (*optional*): filter by the operator account that received the authorization.
 - `response_max_size` (small number) (*optional*): limit to `response_max_size` results. Must be min 1, max 1,024. Default to 64.
 
@@ -5569,7 +5569,7 @@ Anyone CAN execute this method.
 
 ##### [MOD-DE-QRY-2-1] List VS Operator Authorizations parameters
 
-- `corporation` (group) (*optional*): filter by the corporation group that granted the authorization.
+- `corporation` (Corporation) (*optional*): filter by the corporation group that granted the authorization.
 - `vs_operator` (account) (*optional*): filter by the VS operator account that received the authorization.
 - `response_max_size` (small number) (*optional*): limit to `response_max_size` results. Must be min 1, max 1,024. Default to 64.
 
@@ -5592,7 +5592,7 @@ Return a list of `VSOperatorAuthorization` entries matching the filter criteria,
 
 ##### [MOD-DI-MSG-1-1] Store Digest method parameters
 
-- `corporation` (group) (*mandatory*): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (Corporation) (*mandatory*): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account) (*mandatory*): (Signer) the account authorized by the `corporation` to run this Msg.
 - `digest` (string) (*mandatory*): digest to store.
 
@@ -5604,7 +5604,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 
-- `corporation` (group): (Signer) signature must be verified.
+- `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - if `digest` is not present, abort.

--- a/spec.md
+++ b/spec.md
@@ -124,7 +124,13 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 ~ A [[ref: account]] that starts a [[ref: onboarding process]].
 
 [[def: corporation, corporations]]:
-~ An [[ref: group]] which is the owner of a specific resource in an [[ref: VPR]].
+~ A legal/organizational entity that controls Participants in zero or more [[ref: ecosystems]] and may itself be the controller of zero or more [[ref: ecosystems]]. A `Corporation` extends a Cosmos SDK [[ref: group]] with VPR-level attributes (DID, governance framework, lifecycle).
+
+[[def: corporation governance framework, CGF]]:
+~ The governance framework (GF) of a [[ref: corporation]].
+
+[[def: corporation governance authority, CGA]]:
+~ The governance authority (GA) of a [[ref: corporation]].
 
 [[def: credential schema, credential schemas]]:
 ~ An [[ref: VPR]] resource which represents a verifiable credential definition and the associated permissions and business rules for issuing, verifying or holding a credential linked to this credential schema.
@@ -168,7 +174,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 ~ A role an [[ref: entity]] is granted by an [[ref: ecosystem]] for operating its [[ref: ecosystem]].
 
 [[def: group, groups]]:
-~ A [[ref: verifiable public registry]] group.
+~ The underlying Cosmos SDK group primitive that a [[ref: corporation]] extends. Members and policies are managed by the group module; VPR-level attributes (DID, governance framework, lifecycle) live on the corresponding [[ref: corporation]] entry.
 
 [[def: holder, holders]]:
 ~ A role an entity might perform by possessing one or more verifiable credentials and generating verifiable presentations from them. A holder is often, but not always, a [[ref: subject]] of the verifiable credentials they are holding. Holders store their credentials in credential repositories. Example holders include organizations, persons, things.
@@ -950,6 +956,17 @@ entity "Ecosystem" as tr {
   +language: string
 }
 
+entity "Corporation" as corp {
+  *id: uint64
+  +did: string
+  +created: timestamp
+  +modified: timestamp
+  +archived: timestamp
+  +aka: string
+  +active_version: int
+  +language: string
+}
+
 entity "GovernanceFrameworkVersion" as gfv {
   *id: uint64
   +created: timestamp
@@ -1220,6 +1237,8 @@ csp "1" --- "0..n" da: vs_operator_fee_spend_limit
 tr "1" --- "1..n" gfv: versions 
 gfv "1" --- "1..n" gfd: documents 
 
+group "1" --- "1" corp
+
 group --o tr: corporation
 group --o csp: corporation
 group --o csps: corporation
@@ -1248,6 +1267,23 @@ group  --o td: corporation
 - `aka` (string) (*optional*): optional additional URI of this ecosystem.
 - `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this ecosystem.
 - `active_version` (int): (*mandatory*) active governance framework version.
+
+### Corporation
+
+A `Corporation` is the VPR-level entity that extends a Cosmos SDK [[ref: group]] with a DID, a governance framework, and lifecycle attributes. A Corporation may control [[ref: participants]] in zero or more [[ref: ecosystems]] and may itself be the controller of zero or more [[ref: ecosystems]].
+
+`Corporation`:
+
+- `id` (uint64) (*mandatory*): the id of the Corporation. MUST be equal to the id of the underlying Cosmos SDK [[ref: group]] that this Corporation extends (1:1).
+- `did` (string) (*mandatory*): the DID of the Corporation.
+- `created` (timestamp) (*mandatory*): timestamp this Corporation has been created.
+- `modified` (timestamp) (*mandatory*): timestamp this Corporation has been modified.
+- `archived` (timestamp) (*optional*): timestamp this Corporation has been archived.
+- `aka` (string) (*optional*): optional additional URI of this Corporation.
+- `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this Corporation.
+- `active_version` (int) (*mandatory*): active [[ref: CGF]] version.
+
+> Note: members and policies of a Corporation are managed by the underlying Cosmos SDK group module. The Corporation entry adds VPR-level attributes only (DID, governance framework, lifecycle).
 
 ### GovernanceFrameworkVersion
 
@@ -5701,7 +5737,7 @@ Create `ExchangeRate` entry `xr`:
 
 #### [MOD-XR-MSG-2] Update Exchange Rate
 
-The **Update Exchange Rate** method allows an operator authorized by network governance (via an [[ref: ExchangeRateAuthorization]]) to push a fresh `rate` for a given `ExchangeRate` entry.
+The **Update Exchange Rate** method allows an operator authorized by network governance (via an `ExchangeRateAuthorization`) to push a fresh `rate` for a given `ExchangeRate` entry.
 
 - Only the `operator` designated in an `ExchangeRateAuthorization` matching the target `ExchangeRate` CAN execute this method.
 

--- a/spec.md
+++ b/spec.md
@@ -1798,14 +1798,16 @@ As a result, `accountABC` is authorized to:
 | Module                         | Method Name                             | Relative REST API path           | Type   |Requirements      | Signers |
 |--------------------------------|-----------------------------------------|----------------------------------|--------|------------------|---|
 | Ecosystem                 | Create an Ecosystem                 |    N/A (Tx)                    | Msg    | [[MOD-ES-MSG-1]](#mod-es-msg-1-create-new-ecosystem)   | corporation + operator |
-|                                | Add Governance Framework Document       |     N/A (Tx)                      | Msg    | [[MOD-ES-MSG-2]](#mod-es-msg-2-add-governance-framework-document)   |corporation + operator |
-|                                | Increase Active Governance Framework Version |      N/A (Tx)                   | Msg    | [[MOD-ES-MSG-3]](#mod-es-msg-3-increase-active-governance-framework-version)   |corporation + operator |
 |                                | Update Ecosystem                   |       N/A (Tx)                   | Msg    | [[MOD-ES-MSG-4]](#mod-es-msg-4-update-ecosystem)   |corporation + operator |
 |                                | Archive Ecosystem                  |        N/A (Tx)                 | Msg    | [[MOD-ES-MSG-5]](#mod-es-msg-5-archive-ecosystem)   |corporation + operator |
 |                                | Update Ecosystem Module Parameters             |         N/A (Tx)                 | Msg    | [[MOD-ES-MSG-6]](#mod-es-msg-6-update-module-parameters)   |governance proposal |
 |                                | Get Ecosystem                      | /es/v1/get                  | Query  | [[MOD-ES-QRY-1]](#mod-es-qry-1-get-ecosystem)   |N/A |
 |                                | List Ecosystems                   | /es/v1/list                 | Query  | [[MOD-ES-QRY-2]](#mod-es-qry-2-list-ecosystems)   |N/A |
 |                                | List Ecosystem Module Parameters               | /es/v1/params                 | Query  | [[MOD-ES-QRY-3]](#mod-es-qry-3-list-module-parameters)   |N/A |
+| Governance Framework      | Add Governance Framework Document            | N/A (Tx)                         | Msg    | [[MOD-GF-MSG-1]](#mod-gf-msg-1-add-governance-framework-document)   | corporation + operator |
+|                                | Increase Active Governance Framework Version | N/A (Tx)                         | Msg    | [[MOD-GF-MSG-2]](#mod-gf-msg-2-increase-active-governance-framework-version)   | corporation + operator |
+|                                | Get Governance Framework Version             | /gf/v1/get                       | Query  | [[MOD-GF-QRY-1]](#mod-gf-qry-1-get-governance-framework-version)   | N/A |
+|                                | List Governance Framework Versions           | /gf/v1/list                      | Query  | [[MOD-GF-QRY-2]](#mod-gf-qry-2-list-governance-framework-versions)   | N/A |
 | Credential Schema              | Create a Credential Schema              |       N/A (Tx)                   | Msg    | [[MOD-CS-MSG-1]](#mod-cs-msg-1-create-new-credential-schema)   |corporation + operator |
 |                                | Update a Credential Schema              |      N/A (Tx)                     | Msg    | [[MOD-CS-MSG-2]](#mod-cs-msg-2-update-credential-schema)   |corporation + operator |
 |                                | Archive Credential Schema               |       N/A (Tx)                      | Msg    | [[MOD-CS-MSG-3]](#mod-cs-msg-3-archive-credential-schema)   |corporation + operator |
@@ -1934,6 +1936,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - `gfv.id`: auto-incremented uint64
 - `gfv.ecosystem_id`: `ecosystem.id`
+- `gfv.corporation_id`: null
 - `gfv.created`: current timestamp
 - `gfv.version`: 1
 - `gfv.active_since`: current timestamp
@@ -1947,102 +1950,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - `gfd.url`: `doc_url`
 - `gfd.digest_sri`: `doc_digest_sri`
 
-#### [MOD-ES-MSG-2] Add Governance Framework Document
-
-Any authorized `operator` CAN execute this method on behalf of a `corporation`.
-
-##### [MOD-ES-MSG-2-1] Add Governance Framework Document parameters
-
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
-- `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): the id of the ecosystem.
-- `doc_language` (string) (*mandatory*): language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of the [[ref: EGF]] document, provided by the [[ref: EGA]].
-- `doc_url` (string) (*mandatory*): URL where the document is published.
-- `doc_digest_sri` (string) (*mandatory*): digest_sri of the document.
-- `version` (int) (*mandatory*): targeted version.
-
-If for a given language, a document already exists, the execution of this transaction will replace the corresponding entry. Else, a new entry is created. It is only possible to edit future versions. Active version cannot be modified.
-
-##### [MOD-ES-MSG-2-2] Add Governance Framework Document precondition checks
-
-If any of these precondition checks fail, method MUST abort.
-
-###### [MOD-ES-MSG-2-2-1] Add Governance Framework Document basic checks
-
-if a mandatory parameter is not present, method MUST abort.
-
-- `corporation` (Corporation): (Signer) signature must be verified.
-- `operator` (account): (Signer) signature must be verified.
-- [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `id` (uint64) (*mandatory*): a `Ecosystem` entry with this id MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry.
-- `version`: there MUST exist a `GovernanceFrameworkVersion` entry `gfv` where `gfv.ecosystem_id` is equal to `id` and `gfv.version` = `version`, or `version` MUST be exactly equal to the biggest found `gfv.version` + 1 of all `GovernanceFrameworkVersion` entries found for this `gfv.ecosystem_id` equal to `id`. `version` MUST be greater than the `ecosystem.active_version`.
-- `doc_language` (string) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
-- `doc_url` (string) (*mandatory*): MUST be a valid URL.
-- `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
-
-###### [MOD-ES-MSG-2-2-2] Add Governance Framework Document fee checks
-
-Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]].
-
-##### [MOD-ES-MSG-2-3] Add Governance Framework Document execution
-
-If all precondition checks passed, method is executed.
-
-Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
-
-load `GovernanceFrameworkVersion` entry `gfv` for the requested version, or create a new `GovernanceFrameworkVersion` `gfv` if required:
-
-- `gfv.id`: auto-incremented uint64
-- `gfv.ecosystem_id`: `id`
-- `gfv.created`: current timestamp
-- `gfv.version`: `version`
-- `gfv.active_since`: null
-
-- create and persist or (replace if already exist) a `GovernanceFrameworkDocument` entry `gfd`:
-
-- `gfd.id`: auto-incremented uint64
-- `gfd.gfv_id`: `gfv.id`
-- `gfd.created`: current timestamp
-- `gfd.language`: `doc_language`
-- `gfd.url`: `doc_url`
-- `gfd.digest_sri`: `doc_digest_sri`
-
-#### [MOD-ES-MSG-3] Increase Active Governance Framework Version
-
-Any authorized `operator` CAN execute this method on behalf of a `corporation`.
-
-##### [MOD-ES-MSG-3-1] Increase Active Governance Framework Version parameters
-
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
-- `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): the id of the ecosystem.
-
-##### [MOD-ES-MSG-3-2] Increase Active Governance Framework Version precondition checks
-
-If any of these precondition checks fail, method MUST abort.
-
-###### [MOD-ES-MSG-3-2-1] Increase Active Governance Framework Version basic checks
-
-- if a mandatory parameter is not present, method MUST abort.
-
-- `corporation` (Corporation): (Signer) signature must be verified.
-- `operator` (account): (Signer) signature must be verified.
-- [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `id` (uint64) (*mandatory*): a `Ecosystem` entry with this id MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry.
-- load `Ecosystem` entry `tr` from its `id`. Find a `GovernanceFrameworkVersion` entry `gfv` where version is equal to `ecosystem.active_version` + 1. If none is found, transaction MUST abort.
-- find `GovernanceFrameworkDocument` `gfd` for `gfd.gfv_id` = `gfv.id` and `gfd.language` = `ecosystem.language`. If no document is found (and thus no document exist for the default language of this version for this ecosystem), transaction MUST abort.
-
-###### [MOD-ES-MSG-3-2-2] Increase Active Governance Framework Version fee checks
-
-Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]].
-
-##### [MOD-ES-MSG-3-3] Increase Active Governance Framework Version execution
-
-If all precondition checks passed, method is executed.
-
-Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
-
-- load `Ecosystem` entry `tr` from its `id`. Find a `GovernanceFrameworkVersion` entry `gfv` where version is equal to `ecosystem.active_version` + 1. If none is found, transaction MUST abort. Else, update `ecosystem.active_version` to `ecosystem.active_version` + 1. Set `ecosystem.modified` to current timestamp, and set `gfv.active_since` to current timestamp and persist changes.
+> Subsequent governance framework documents and version activations for this ecosystem MUST be managed through [[MOD-GF-MSG-1]](#mod-gf-msg-1-add-governance-framework-document) and [[MOD-GF-MSG-2]](#mod-gf-msg-2-increase-active-governance-framework-version).
 
 #### [MOD-ES-MSG-4] Update Ecosystem
 
@@ -2223,6 +2131,168 @@ Return the list of the existing parameters and their values.
   }
 }
 ```
+
+### Governance Framework Module
+
+This module handles [[ref: governance framework]] documents and version activation for both [[ref: ecosystems]] and [[ref: corporations]]. Methods are polymorphic over the owning subject: every message specifies exactly one of `ecosystem_id` or `corporation_id` to designate whose governance framework is being modified.
+
+The initial `GovernanceFrameworkVersion` and its first `GovernanceFrameworkDocument` are created atomically by [Create New Ecosystem](#mod-es-msg-1-create-new-ecosystem) (and, by parallel construction, by [Create New Corporation](#mod-co-msg-1-create-new-corporation)). After that, subsequent versions and documents are added through this module.
+
+#### [MOD-GF-MSG-1] Add Governance Framework Document
+
+Any authorized `operator` CAN execute this method on behalf of a `corporation`.
+
+##### [MOD-GF-MSG-1-1] Add Governance Framework Document parameters
+
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
+- `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]] whose governance framework will be modified. MUST be set if `corporation_id` is null.
+- `corporation_id` (uint64) (*conditional*): id of the target [[ref: corporation]] whose governance framework will be modified. MUST be set if `ecosystem_id` is null.
+- `doc_language` (string) (*mandatory*): language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of the governance framework document.
+- `doc_url` (string) (*mandatory*): URL where the document is published.
+- `doc_digest_sri` (string) (*mandatory*): digest_sri of the document.
+- `version` (int) (*mandatory*): targeted version.
+
+If for a given language, a document already exists, the execution of this transaction will replace the corresponding entry. Else, a new entry is created. It is only possible to edit future versions. Active version cannot be modified.
+
+##### [MOD-GF-MSG-1-2] Add Governance Framework Document precondition checks
+
+If any of these precondition checks fail, method MUST abort.
+
+###### [MOD-GF-MSG-1-2-1] Add Governance Framework Document basic checks
+
+if a mandatory parameter is not present, method MUST abort.
+
+- `corporation` (Corporation): (Signer) signature must be verified.
+- `operator` (account): (Signer) signature must be verified.
+- [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
+- Exactly one of `ecosystem_id` and `corporation_id` MUST be set; if both are set or both are null, method MUST abort.
+- Define `subject` as:
+  - if `ecosystem_id` is set: the `Ecosystem` entry with this id. The entry MUST exist and `subject.corporation` MUST be equal to the `corporation` executing the method.
+  - if `corporation_id` is set: the `Corporation` entry with this id. The entry MUST exist and `corporation_id` MUST be equal to the id of the `corporation` executing the method (a Corporation may only edit its own governance framework).
+- `version`: there MUST exist a `GovernanceFrameworkVersion` entry `gfv` whose owner matches `subject` (i.e., `gfv.ecosystem_id = ecosystem_id` if subject is an Ecosystem, else `gfv.corporation_id = corporation_id`) and `gfv.version = version`, OR `version` MUST be exactly equal to the biggest `gfv.version` + 1 of all `GovernanceFrameworkVersion` entries owned by `subject`. `version` MUST be greater than `subject.active_version`.
+- `doc_language` (string) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
+- `doc_url` (string) (*mandatory*): MUST be a valid URL.
+- `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
+
+###### [MOD-GF-MSG-1-2-2] Add Governance Framework Document fee checks
+
+Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]].
+
+##### [MOD-GF-MSG-1-3] Add Governance Framework Document execution
+
+If all precondition checks passed, method is executed.
+
+Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
+
+- if a `GovernanceFrameworkVersion` entry `gfv` matching `subject` and `version` does not exist, create and persist a new one:
+  - `gfv.id`: auto-incremented uint64
+  - `gfv.ecosystem_id`: `ecosystem_id` (or null if subject is a Corporation)
+  - `gfv.corporation_id`: `corporation_id` (or null if subject is an Ecosystem)
+  - `gfv.created`: current timestamp
+  - `gfv.version`: `version`
+
+- if a `GovernanceFrameworkDocument` entry `gfd` exists with `gfd.gfv_id = gfv.id` and `gfd.language = doc_language`, update it:
+  - `gfd.url`: `doc_url`
+  - `gfd.digest_sri`: `doc_digest_sri`
+
+- else, create and persist a new `GovernanceFrameworkDocument` entry `gfd`:
+  - `gfd.id`: auto-incremented uint64
+  - `gfd.gfv_id`: `gfv.id`
+  - `gfd.created`: current timestamp
+  - `gfd.language`: `doc_language`
+  - `gfd.url`: `doc_url`
+  - `gfd.digest_sri`: `doc_digest_sri`
+
+#### [MOD-GF-MSG-2] Increase Active Governance Framework Version
+
+Any authorized `operator` CAN execute this method on behalf of a `corporation`.
+
+##### [MOD-GF-MSG-2-1] Increase Active Governance Framework Version parameters
+
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
+- `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]]. MUST be set if `corporation_id` is null.
+- `corporation_id` (uint64) (*conditional*): id of the target [[ref: corporation]]. MUST be set if `ecosystem_id` is null.
+
+##### [MOD-GF-MSG-2-2] Increase Active Governance Framework Version precondition checks
+
+If any of these precondition checks fail, method MUST abort.
+
+###### [MOD-GF-MSG-2-2-1] Increase Active Governance Framework Version basic checks
+
+- if a mandatory parameter is not present, method MUST abort.
+
+- `corporation` (Corporation): (Signer) signature must be verified.
+- `operator` (account): (Signer) signature must be verified.
+- [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
+- Exactly one of `ecosystem_id` and `corporation_id` MUST be set; if both are set or both are null, method MUST abort.
+- Define `subject` as:
+  - if `ecosystem_id` is set: the `Ecosystem` entry with this id. The entry MUST exist and `subject.corporation` MUST be equal to the `corporation` executing the method.
+  - if `corporation_id` is set: the `Corporation` entry with this id. The entry MUST exist and `corporation_id` MUST be equal to the id of the `corporation` executing the method.
+- Find a `GovernanceFrameworkVersion` entry `gfv` owned by `subject` (matching `gfv.ecosystem_id` or `gfv.corporation_id` as appropriate) whose `gfv.version` is equal to `subject.active_version` + 1. If none is found, transaction MUST abort.
+- Find a `GovernanceFrameworkDocument` `gfd` for `gfd.gfv_id` = `gfv.id` and `gfd.language` = `subject.language`. If no document is found (and thus no document exists for the default language of this version for this subject), transaction MUST abort.
+
+###### [MOD-GF-MSG-2-2-2] Increase Active Governance Framework Version fee checks
+
+Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]].
+
+##### [MOD-GF-MSG-2-3] Increase Active Governance Framework Version execution
+
+If all precondition checks passed, method is executed.
+
+Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
+
+- Load `subject` (`Ecosystem` or `Corporation` as identified above).
+- Find a `GovernanceFrameworkVersion` entry `gfv` owned by `subject` whose `gfv.version` is equal to `subject.active_version` + 1.
+- Update `subject.active_version` to `subject.active_version` + 1.
+- Set `subject.modified` to current timestamp.
+- Set `gfv.active_since` to current timestamp.
+- Persist changes.
+
+#### [MOD-GF-QRY-1] Get Governance Framework Version
+
+Anyone CAN execute this method.
+
+##### [MOD-GF-QRY-1-1] Get Governance Framework Version query parameters
+
+- `id` (uint64) (*mandatory*): the id of the `GovernanceFrameworkVersion`.
+- `preferred_language` (string) (*optional*): if set, return only one document per version, preferring `preferred_language`. If not set, return all documents of all languages.
+
+##### [MOD-GF-QRY-1-2] Get Governance Framework Version query checks
+
+If any of these checks fail, [[ref: query]] MUST fail.
+
+- `id` (uint64) (*mandatory*): MUST be a valid uint64.
+
+##### [MOD-GF-QRY-1-3] Get Governance Framework Version execution
+
+Return the `GovernanceFrameworkVersion` entry with `id`, including its owning subject reference (`ecosystem_id` or `corporation_id`) and its nested `GovernanceFrameworkDocument` entries (filtered by `preferred_language` if set).
+
+#### [MOD-GF-QRY-2] List Governance Framework Versions
+
+Anyone CAN execute this method.
+
+##### [MOD-GF-QRY-2-1] List Governance Framework Versions query parameters
+
+Exactly one of `ecosystem_id` and `corporation_id` MUST be set:
+
+- `ecosystem_id` (uint64) (*conditional*): filter by ecosystem. MUST be set if `corporation_id` is null.
+- `corporation_id` (uint64) (*conditional*): filter by corporation. MUST be set if `ecosystem_id` is null.
+- `active_only` (boolean) (*optional*): if true, return only the entry corresponding to the subject's `active_version`.
+- `preferred_language` (string) (*optional*): if set, return only one document per version, preferring `preferred_language`.
+- `response_max_size` (small number) (*optional*): default to 64. Max 1,024.
+
+##### [MOD-GF-QRY-2-2] List Governance Framework Versions query checks
+
+If any of these checks fail, [[ref: query]] MUST fail.
+
+- Exactly one of `ecosystem_id` and `corporation_id` MUST be set.
+- `response_max_size` must be between 1 and 1,024. Default to 64 if unspecified.
+
+##### [MOD-GF-QRY-2-3] List Governance Framework Versions execution
+
+Return the list of `GovernanceFrameworkVersion` entries matching the filter, with their nested `GovernanceFrameworkDocument` entries (filtered as above). Entries MUST be ordered by ascending `version`.
 
 ### Credential Schema Module
 

--- a/spec.md
+++ b/spec.md
@@ -731,7 +731,7 @@ ig --> igtd: \t+200 TUs
 
 *This section is non-normative.*
 
-**Pay-per-issuance** and **pay-per-verification** [[ref: trust fees]] are defined **at the permission level** for each role within the ecosystem.
+**Pay-per-issuance** and **pay-per-verification** [[ref: trust fees]] are defined **on each `Participant` entry** for each role within the ecosystem.
 
 ```plantuml
 
@@ -775,19 +775,19 @@ vg --> verifier : creates schema participant
 
 ```
 
-Entities acting as **issuers** or **verifiers** for a given credential schema **may be required to pay trust fees** based on the schema's configuration and permission tree.
+[[ref: Corporations]] acting as **issuers** or **verifiers** for a given credential schema **may be required to pay trust fees** based on the schema's configuration and `Participant` tree.
 
 If trust fee payment is required, the entity **must execute a transaction** in the [[ref: VPR]] to pay the appropriate [[ref: trust fees]] **before issuing or verifying a credential**.
 
 Key Points for "Pay-Per" Business Models
 
-- For a given credential schema, **ecosystem** and their participants may define **pay-per-issuance** (or **pay-per-verification**) [[ref: trust fees]] in their respective permissions.
+- For a given credential schema, the **ecosystem** and its participants may define **pay-per-issuance** (or **pay-per-verification**) [[ref: trust fees]] on their respective `Participant` entries.
 
-- In such cases, a participant ISSUER (or VERIFIER) **must pay**:
-  - The corresponding **issuance** (or **verification**) trust fees for each involved permission;
-  - An additional amount equal to the `trust_deposit_rate` of the calculated trust fees, allocated to the **applicant’s trust deposit**;
-  - An amount equal to `wallet_user_agent_reward_rate` of the calculated trust fees, used to **reward the Wallet User Agent**;
-  - An amount equal to `user_agent_reward_rate` of the calculated trust fees, used to **reward the User Agent**.
+- In such cases, an `ISSUER` (or `VERIFIER`) `Participant` **must pay**:
+  - the corresponding **issuance** (or **verification**) trust fees for each involved `Participant` entry along the `Participant` tree;
+  - an additional amount equal to the `trust_deposit_rate` of the calculated trust fees, allocated to the **payer's [[ref: trust deposit]]**;
+  - an amount equal to `wallet_user_agent_reward_rate` of the calculated trust fees, used to **reward the Wallet User Agent**;
+  - an amount equal to `user_agent_reward_rate` of the calculated trust fees, used to **reward the User Agent**.
 
 Fee Distribution Model
 
@@ -803,7 +803,7 @@ If not, they **must reject** the issuance or verification request.
 Note: The **User Agent** and **Wallet User Agent** may refer to the same implementation.
 :::
 
-Distribution example for the issuance by ISSUER #C of a credential, using the permission tree above, 20% for `trust_deposit_rate`, 10% for `wallet_user_agent_reward_rate` and `user_agent_reward_rate`.
+Distribution example for the issuance by `ISSUER` #C of a credential, using the `Participant` tree above, 20% for `trust_deposit_rate`, 10% for `wallet_user_agent_reward_rate` and `user_agent_reward_rate`.
 
 ```plantuml
 
@@ -871,7 +871,7 @@ issuera --> issuertd:  \t+3 TUs
 
 ```
 
-Distribution example for the verification by VERIFIER #E of a credential issued by ISSUER #C, using the permission tree above, 20% for `trust_deposit_rate`, 10% for `wallet_user_agent_reward_rate` and `user_agent_reward_rate`.
+Distribution example for the verification by `VERIFIER` #E of a credential issued by `ISSUER` #C, using the `Participant` tree above, 20% for `trust_deposit_rate`, 10% for `wallet_user_agent_reward_rate` and `user_agent_reward_rate`.
 
 ```plantuml
 

--- a/spec.md
+++ b/spec.md
@@ -329,28 +329,28 @@ scale max 800 width
 package "Example Credential Schema Participant Tree" as cs {
 
     object "Ecosystem A" as tr #3fbdb6 {
-        type: ECOSYSTEM (Root)
+        role: ECOSYSTEM (Root)
         did:example:ecosystemA
     }
     object "Issuer Grantor B" as ig {
-        type: ISSUER_GRANTOR
+        role: ISSUER_GRANTOR
         did:example:igB
     }
     object "Issuer C" as issuer #7677ed  {
-        type: ISSUER
+        role: ISSUER
         did:example:iC
     }
     object "Verifier Grantor D" as vg {
-        type: VERIFIER_GRANTOR
+        role: VERIFIER_GRANTOR
         did:example:vgD
     }
     object "Verifier E" as verifier #00b0f0 {
-        type: VERIFIER
+        role: VERIFIER
         did:example:vE
     }
 
     object "Holder Z " as holder #FFB073 {
-        type: HOLDER
+        role: HOLDER
     }
 }
 
@@ -469,7 +469,7 @@ package "Pay per validation Fee Structure" as cs {
     }
 
     object "Holder Z - Credential Schema Participant" as holder #FFB073 {
-        type: HOLDER
+        role: HOLDER
     }
 }
 
@@ -965,22 +965,16 @@ verifiera --> verifiertd:  \t+11.4 TUs
 
 *This section is non-normative.*
 
-The governance of a [[ref: VPR]] is **layered**. Three independent [[ref: governance framework]] tiers cohabit on the registry:
+A [[ref: governance framework]] must define the governance rules that apply to a [[ref: VPR]].
 
-- the **VPR-level governance framework**, which defines the global rules for operating the registry itself;
-- one or more **[[ref: corporation governance framework]]s** (CGFs) — one per [[ref: corporation]] registered in the VPR;
-- one or more **[[ref: ecosystem governance framework]]s** (EGFs) — one per [[ref: ecosystem]] hosted on the VPR.
-
-Each tier has its own designated [[ref: governance authority]], responsible for **enforcing its rules** and, when necessary, **applying financial sanctions** (such as [[ref: trust deposit]] slashing) to participants who violate them.
+A designated [[ref: governance authority]] is responsible for **enforcing these rules** and, when necessary, **applying financial sanctions** to participants who violate the rules.
 
 :::note
-**Corporation Governance Frameworks (CGFs)** and **Ecosystem Governance Frameworks (EGFs)** operate **independently** from the [[ref: VPR]] [[ref: governance framework]].
+**Ecosystem Governance Frameworks (EGFs)** operate **independently** from the [[ref: VPR]] [[ref: governance framework]].
 
-- The **VPR governance framework** defines the global rules for operating the [[ref: VPR]] itself (e.g., trust deposits, fee distribution, slashing conditions, [[ref: corporation]] registration).
-- Each **[[ref: corporation]]** publishes its own **[[ref: corporation governance framework]]** (CGF) to govern the corporation as a VPR-level entity: its lifecycle, the scope of authority delegated to its `operator` accounts (via `OperatorAuthorization`), its membership and voting rules (managed by the underlying Cosmos SDK [[ref: group]]), and its obligations toward the VPR.
-- Each **[[ref: ecosystem]]** publishes its own **[[ref: ecosystem governance framework]]** (EGF) to govern roles, `Participant` lifecycle, credential schemas, onboarding policies, and compliance within that ecosystem.
+While the **VPR governance framework** defines the global rules for operating the Verifiable Public Registry (e.g., trust deposits, fee distribution, slashing conditions), each **ecosystem** must define its own **EGF** to govern roles, permissions, credential policies, and compliance within its specific domain.
 
-This **three-tier separation** ensures that corporations and ecosystems remain autonomous and can tailor governance to their respective needs, without being constrained by the global rules of the VPR.
+This separation ensures that ecosystems remain autonomous and can tailor governance to their unique needs, without being constrained by the global rules of the VPR.
 :::
 
 ## Data model
@@ -1282,7 +1276,7 @@ csp "1" --- "0..n" da: vs_operator_fee_spend_limit
 
 
 tr "1" --- "0..n" gfv: versions (ecosystem_id)
-corp "1" --- "0..n" gfv: versions (corporation)
+corp "1" --- "0..n" gfv: versions (corporation_id)
 gfv "1" --- "1..n" gfd: documents
 
 group "1" --- "1" corp
@@ -1332,17 +1326,17 @@ A `Corporation` is the VPR-level entity that extends a Cosmos SDK [[ref: group]]
 
 ### GovernanceFrameworkVersion
 
-A `GovernanceFrameworkVersion` represents a single version of either an [[ref: EGF]] or a [[ref: CGF]]. Its owning subject is identified by exactly one of `ecosystem_id` or `corporation` (XOR).
+A `GovernanceFrameworkVersion` represents a single version of either an [[ref: EGF]] or a [[ref: CGF]]. Its owning subject is identified by exactly one of `ecosystem_id` or `corporation_id` (XOR).
 
 `GovernanceFrameworkVersion`:
 
 - `id` (uint64) (*mandatory*): the id of the GFV.
-- `ecosystem_id` (uint64) (*conditional*): the id of the [[ref: ecosystem]] that controls this `GovernanceFrameworkVersion` entry. MUST be set if `corporation` is null.
-- `corporation` (group) (*conditional*): the [[ref: corporation]] that controls this `GovernanceFrameworkVersion` entry, identified by its underlying [[ref: group]]. MUST be set if `ecosystem_id` is null.
+- `ecosystem_id` (uint64) (*conditional*): the id of the [[ref: ecosystem]] that controls this `GovernanceFrameworkVersion` entry. MUST be set if `corporation_id` is null.
+- `corporation_id` (uint64) (*conditional*): the id of the [[ref: corporation]] that controls this `GovernanceFrameworkVersion` entry. MUST be set if `ecosystem_id` is null.
 - `created` (timestamp) (*mandatory*): timestamp this GovernanceFrameworkVersion has been created.
 - `version` (int) (*mandatory*): version of this GF. MUST Starts with 1.
 
-> Constraint: exactly one of `ecosystem_id` and `corporation` MUST be set.
+> Constraint: exactly one of `ecosystem_id` and `corporation_id` MUST be set.
 
 ### GovernanceFrameworkDocument
 
@@ -1400,7 +1394,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 
 - `id` (uint64) (*mandatory*): the id of the participant.
 - `schema_id` (uint64) (*mandatory*): the id of the related `CredentialSchema` entry.
-- `type` (ParticipantRole): ISSUER, VERIFIER, ISSUER_GRANTOR, VERIFIER_GRANTOR, ECOSYSTEM, HOLDER
+- `role` (ParticipantRole): ISSUER, VERIFIER, ISSUER_GRANTOR, VERIFIER_GRANTOR, ECOSYSTEM, HOLDER
 - `did` (string) (*optional*): [[ref: DID]] this permission refers to. MUST conform to [[spec-norm:RFC3986]].
 - `corporation` (group) (*mandatory*): [[ref: corporation]] that owns this permission.
 - `vs_operator` (account) (*mandatory*): verifiable service agent account. This is the account that will have the right to create or update permission sessions.
@@ -1987,7 +1981,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - `gfv.id`: auto-incremented uint64
 - `gfv.ecosystem_id`: null
-- `gfv.corporation`: the signing [[ref: group]] (i.e., the key of `co`)
+- `gfv.corporation_id`: id of the signing [[ref: group]] (i.e., the key of `co`)
 - `gfv.created`: current timestamp
 - `gfv.version`: 1
 - `gfv.active_since`: current timestamp
@@ -2241,7 +2235,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - `gfv.id`: auto-incremented uint64
 - `gfv.ecosystem_id`: `ecosystem.id`
-- `gfv.corporation`: null
+- `gfv.corporation_id`: null
 - `gfv.created`: current timestamp
 - `gfv.version`: 1
 - `gfv.active_since`: current timestamp
@@ -2436,7 +2430,7 @@ Return the list of the existing parameters and their values.
 
 ### Governance Framework Module
 
-This module handles [[ref: governance framework]] documents and version activation for both [[ref: ecosystems]] and [[ref: corporations]]. Methods are polymorphic over the owning subject: every message specifies exactly one of `ecosystem_id` or `subject_corporation` to designate whose governance framework is being modified.
+This module handles [[ref: governance framework]] documents and version activation for both [[ref: ecosystems]] and [[ref: corporations]]. Methods are polymorphic over the owning subject: every message specifies exactly one of `ecosystem_id` or `corporation_id` to designate whose governance framework is being modified.
 
 The initial `GovernanceFrameworkVersion` and its first `GovernanceFrameworkDocument` are created atomically by [Create New Ecosystem](#mod-es-msg-1-create-new-ecosystem) (and, by parallel construction, by [Create New Corporation](#mod-co-msg-1-create-new-corporation)). After that, subsequent versions and documents are added through this module.
 
@@ -2448,8 +2442,8 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]] whose governance framework will be modified. MUST be set if `subject_corporation` is null.
-- `subject_corporation` (group) (*conditional*): the target [[ref: corporation]] whose governance framework will be modified, identified by its underlying [[ref: group]]. MUST be set if `ecosystem_id` is null.
+- `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]] whose governance framework will be modified. MUST be set if `corporation_id` is null.
+- `corporation_id` (uint64) (*conditional*): id of the target [[ref: corporation]] whose governance framework will be modified. MUST be set if `ecosystem_id` is null.
 - `doc_language` (string) (*mandatory*): language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of the governance framework document.
 - `doc_url` (string) (*mandatory*): URL where the document is published.
 - `doc_digest_sri` (string) (*mandatory*): digest_sri of the document.
@@ -2468,11 +2462,11 @@ if a mandatory parameter is not present, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- Exactly one of `ecosystem_id` and `subject_corporation` MUST be set; if both are set or both are null, method MUST abort.
+- Exactly one of `ecosystem_id` and `corporation_id` MUST be set; if both are set or both are null, method MUST abort.
 - Define `subject` as:
   - if `ecosystem_id` is set: the `Ecosystem` entry with this id. The entry MUST exist and `subject.corporation` MUST be equal to the `corporation` executing the method.
-  - if `subject_corporation` is set: the `Corporation` entry whose underlying [[ref: group]] is `subject_corporation`. The entry MUST exist, and `subject_corporation` MUST be equal to the signing `corporation` (a Corporation may only edit its own governance framework).
-- `version`: there MUST exist a `GovernanceFrameworkVersion` entry `gfv` whose owner matches `subject` (i.e., `gfv.ecosystem_id = ecosystem_id` if subject is an Ecosystem, else `gfv.corporation = subject_corporation`) and `gfv.version = version`, OR `version` MUST be exactly equal to the biggest `gfv.version` + 1 of all `GovernanceFrameworkVersion` entries owned by `subject`. `version` MUST be greater than `subject.active_version`.
+  - if `corporation_id` is set: the `Corporation` entry keyed by `corporation_id` (i.e., the Corporation whose underlying [[ref: group]] has id `corporation_id`). The entry MUST exist, and `corporation_id` MUST equal the [[ref: group]] id of the signing `corporation` (a Corporation may only edit its own governance framework).
+- `version`: there MUST exist a `GovernanceFrameworkVersion` entry `gfv` whose owner matches `subject` (i.e., `gfv.ecosystem_id = ecosystem_id` if subject is an Ecosystem, else `gfv.corporation_id = corporation_id`) and `gfv.version = version`, OR `version` MUST be exactly equal to the biggest `gfv.version` + 1 of all `GovernanceFrameworkVersion` entries owned by `subject`. `version` MUST be greater than `subject.active_version`.
 - `doc_language` (string) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 - `doc_url` (string) (*mandatory*): MUST be a valid URL.
 - `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
@@ -2490,7 +2484,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - if a `GovernanceFrameworkVersion` entry `gfv` matching `subject` and `version` does not exist, create and persist a new one:
   - `gfv.id`: auto-incremented uint64
   - `gfv.ecosystem_id`: `ecosystem_id` (or null if subject is a Corporation)
-  - `gfv.corporation`: `subject_corporation` (or null if subject is an Ecosystem)
+  - `gfv.corporation_id`: `corporation_id` (or null if subject is an Ecosystem)
   - `gfv.created`: current timestamp
   - `gfv.version`: `version`
 
@@ -2514,8 +2508,8 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]]. MUST be set if `subject_corporation` is null.
-- `subject_corporation` (group) (*conditional*): the target [[ref: corporation]], identified by its underlying [[ref: group]]. MUST be set if `ecosystem_id` is null.
+- `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]]. MUST be set if `corporation_id` is null.
+- `corporation_id` (uint64) (*conditional*): id of the target [[ref: corporation]]. MUST be set if `ecosystem_id` is null.
 
 ##### [MOD-GF-MSG-2-2] Increase Active Governance Framework Version precondition checks
 
@@ -2528,11 +2522,11 @@ If any of these precondition checks fail, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- Exactly one of `ecosystem_id` and `subject_corporation` MUST be set; if both are set or both are null, method MUST abort.
+- Exactly one of `ecosystem_id` and `corporation_id` MUST be set; if both are set or both are null, method MUST abort.
 - Define `subject` as:
   - if `ecosystem_id` is set: the `Ecosystem` entry with this id. The entry MUST exist and `subject.corporation` MUST be equal to the `corporation` executing the method.
-  - if `subject_corporation` is set: the `Corporation` entry whose underlying [[ref: group]] is `subject_corporation`. The entry MUST exist, and `subject_corporation` MUST be equal to the signing `corporation`.
-- Find a `GovernanceFrameworkVersion` entry `gfv` owned by `subject` (matching `gfv.ecosystem_id` or `gfv.corporation` as appropriate) whose `gfv.version` is equal to `subject.active_version` + 1. If none is found, transaction MUST abort.
+  - if `corporation_id` is set: the `Corporation` entry keyed by `corporation_id` (i.e., the Corporation whose underlying [[ref: group]] has id `corporation_id`). The entry MUST exist, and `corporation_id` MUST equal the [[ref: group]] id of the signing `corporation`.
+- Find a `GovernanceFrameworkVersion` entry `gfv` owned by `subject` (matching `gfv.ecosystem_id` or `gfv.corporation_id` as appropriate) whose `gfv.version` is equal to `subject.active_version` + 1. If none is found, transaction MUST abort.
 - Find a `GovernanceFrameworkDocument` `gfd` for `gfd.gfv_id` = `gfv.id` and `gfd.language` = `subject.language`. If no document is found (and thus no document exists for the default language of this version for this subject), transaction MUST abort.
 
 ###### [MOD-GF-MSG-2-2-2] Increase Active Governance Framework Version fee checks
@@ -2569,7 +2563,7 @@ If any of these checks fail, [[ref: query]] MUST fail.
 
 ##### [MOD-GF-QRY-1-3] Get Governance Framework Version execution
 
-Return the `GovernanceFrameworkVersion` entry with `id`, including its owning subject reference (`ecosystem_id` or `corporation`) and its nested `GovernanceFrameworkDocument` entries (filtered by `preferred_language` if set).
+Return the `GovernanceFrameworkVersion` entry with `id`, including its owning subject reference (`ecosystem_id` or `corporation_id`) and its nested `GovernanceFrameworkDocument` entries (filtered by `preferred_language` if set).
 
 #### [MOD-GF-QRY-2] List Governance Framework Versions
 
@@ -2577,10 +2571,10 @@ Anyone CAN execute this method.
 
 ##### [MOD-GF-QRY-2-1] List Governance Framework Versions query parameters
 
-Exactly one of `ecosystem_id` and `corporation` MUST be set:
+Exactly one of `ecosystem_id` and `corporation_id` MUST be set:
 
-- `ecosystem_id` (uint64) (*conditional*): filter by ecosystem. MUST be set if `corporation` is null.
-- `corporation` (group) (*conditional*): filter by corporation (identified by its underlying [[ref: group]]). MUST be set if `ecosystem_id` is null.
+- `ecosystem_id` (uint64) (*conditional*): filter by ecosystem. MUST be set if `corporation_id` is null.
+- `corporation_id` (uint64) (*conditional*): filter by corporation. MUST be set if `ecosystem_id` is null.
 - `active_only` (boolean) (*optional*): if true, return only the entry corresponding to the subject's `active_version`.
 - `preferred_language` (string) (*optional*): if set, return only one document per version, preferring `preferred_language`.
 - `response_max_size` (small number) (*optional*): default to 64. Max 1,024.
@@ -2589,7 +2583,7 @@ Exactly one of `ecosystem_id` and `corporation` MUST be set:
 
 If any of these checks fail, [[ref: query]] MUST fail.
 
-- Exactly one of `ecosystem_id` and `corporation` MUST be set.
+- Exactly one of `ecosystem_id` and `corporation_id` MUST be set.
 - `response_max_size` must be between 1 and 1,024. Default to 64 if unspecified.
 
 ##### [MOD-GF-QRY-2-3] List Governance Framework Versions execution
@@ -3132,27 +3126,27 @@ scale max 800 width
 package "Example Credential Schema Participant Tree" as cs {
 
     object "Ecosystem A" as tr #3fbdb6 {
-        type: ECOSYSTEM (Root)
+        role: ECOSYSTEM (Root)
         did:example:trA
     }
     object "Issuer Grantor B" as ig {
-        type: ISSUER_GRANTOR
+        role: ISSUER_GRANTOR
         did:example:igB
     }
     object "Issuer C" as issuer #7677ed  {
-        type: ISSUER
+        role: ISSUER
         did:example:iC
     }
     object "Verifier Grantor D" as vg {
-        type: VERIFIER_GRANTOR
+        role: VERIFIER_GRANTOR
         did:example:vgD
     }
     object "Verifier E" as verifier #00b0f0 {
-        type: VERIFIER
+        role: VERIFIER
         did:example:vE
     }
     object "Holder Z " as holder #FFB073 {
-        type: HOLDER
+        role: HOLDER
     }
 }
 
@@ -3218,7 +3212,7 @@ An Applicant that would like to start a permission onboarding process MUST execu
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `vs_operator` (account) (*optional*): the account of the Veriable Service we want to authorize to create permission sessions linked to this permission. If not specified, Verifiable Service will not be able to use the payment delegation feature. **Required** to use the payment delegation feature.
-- `type` (ParticipantRole) (*mandatory*): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the permission that the applicant would like to get;
+- `role` (ParticipantRole) (*mandatory*): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the permission that the applicant would like to get;
 - `validator_participant_id` (uint64) (*mandatory*): the [[ref: validator]] permission (parent permission in the tree), chosen by the applicant.
 - `validation_fees` (number) (*optional*): Requested validation_fees for this permission (can be modified by validator).
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
@@ -3233,7 +3227,7 @@ The following VS Operator Authorization parameters are **optional** and collecti
 - `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
 - `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
 
-Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`.
+Permitted message types to be set in `vs_operator_authz_msg_types` depends on `role`.
 
 |Participant role|Permitted Messages|
 |-|-|
@@ -3258,7 +3252,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `type` (ParticipantRole) (*mandatory*) MUST be a valid ParticipantRole: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.
+- `role` (ParticipantRole) (*mandatory*) MUST be a valid ParticipantRole: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.
 - `validator_participant_id` (uint64) (*mandatory*): see [MOD-PP-MSG-1-2-2](#mod-pp-msg-1-2-2-start-participant-op-permission-checks).
 - `validation_fees` (number) (*optional*): Requested validation_fees for this permission (can be modified by validator).
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
@@ -3275,7 +3269,7 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 - Load `Participant` entry `validator_participant` from `validator_participant_id`. It MUST be a [[ref: active participant]] else transaction MUST abort.
 - Load `CredentialSchema` entry `cs` from `validator_participant.schema_id`. It MUST exist.
 
-- if `type` (ParticipantRole) is equal to ISSUER:
+- if `role` (ParticipantRole) is equal to ISSUER:
 
   - if `cs.issuer_onboarding_mode` is equal to GRANTOR_ONBOARDING_PROCESS: `validator_participant.role` MUST be ISSUER_GRANTOR, else MUST abort.
   
@@ -3283,13 +3277,13 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 
   - else MUST abort.
 
-- else if `type` (ParticipantRole) is equal to ISSUER_GRANTOR:
+- else if `role` (ParticipantRole) is equal to ISSUER_GRANTOR:
 
   - if `cs.issuer_onboarding_mode` is equal to GRANTOR_ONBOARDING_PROCESS:  `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
   
   - else abort.
 
-- else if `type` (ParticipantRole) is equal to VERIFIER:
+- else if `role` (ParticipantRole) is equal to VERIFIER:
 
   - if `cs.verifier_onboarding_mode` is equal to GRANTOR: `validator_participant.role` MUST be VERIFIER_GRANTOR, else MUST abort.
   
@@ -3297,13 +3291,13 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 
   - else abort.
 
-- else if `type` (ParticipantRole) is equal to VERIFIER_GRANTOR:
+- else if `role` (ParticipantRole) is equal to VERIFIER_GRANTOR:
 
   - if `cs.verifier_onboarding_mode` is equal to GRANTOR_ONBOARDING_PROCESS: `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
   
   - else abort.
 
-- else if `type` (ParticipantRole) is equal to HOLDER:
+- else if `role` (ParticipantRole) is equal to HOLDER:
 
   - if `cs.holder_onboarding_mode` is equal to ISSUER_ONBOARDING_PROCESS: `validator_participant.role` MUST be ISSUER, else MUST abort.
   
@@ -3352,9 +3346,9 @@ Trust deposit MUST always be paid in [[ref: native denom]]
 
 ###### [MOD-PP-MSG-1-2-4] Start Participant OP overlap checks
 
-We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different OP with differents validators for the same `schema_id`, `type`.
+We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different OP with differents validators for the same `schema_id`, `role`.
 
-Find all permission `participants[]` for `schema_id`, `type`, `validator_participant_id`, `corporation` with op_state = VALIDATED or PENDING.
+Find all permission `participants[]` for `schema_id`, `role`, `validator_participant_id`, `corporation` with op_state = VALIDATED or PENDING.
 
 if size of `participants[]` > 0, it means there is already an existing onboarding process in this context, so MUST abort.
 
@@ -3380,7 +3374,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - `applicant_participant.schema_id` = `validator_participant.schema_id`
   - `applicant_participant.corporation`: `corporation`.
   - `applicant_participant.vs_operator`: `vs_operator`.
-  - `applicant_participant.role`: `type`.
+  - `applicant_participant.role`: `role`.
   - `applicant_participant.created`: `now`
   - `applicant_participant.modified`: `now`
   - `applicant_participant.deposit`: `validation_trust_deposit_in_native_denom`.
@@ -3580,7 +3574,7 @@ else MUST abort.
 - `validation_fees` (number) (*mandatory*): MUST be zero or a positive integer. If `applicant_participant.effective_from` is not null (we are in renewal) `validation_fees` MUST be equal to `applicant_participant.validation_fees`, else abort.
 - `issuance_fees` (number) (*mandatory*): MUST be zero or a positive integer.  If `applicant_participant.effective_from` is not null (we are in renewal) `issuance_fees` MUST be equal to `applicant_participant.issuance_fees` or, else abort.
 - `verification_fees` (number) (*mandatory*): MUST be zero or a positive integer.  If `applicant_participant.effective_from` is not null (we are in renewal) `verification_fees` MUST be equal to `applicant_participant.verification_fees`, else abort.
-- `op_summary_digest` (string) (*optional*): MUST be null if `validation.type` is set to HOLDER (for HOLDER, proofs can be stored in credentials). Else, MUST be a valid digest. Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
+- `op_summary_digest` (string) (*optional*): MUST be null if `validation.role` is set to HOLDER (for HOLDER, proofs can be stored in credentials). Else, MUST be a valid digest. Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
 
 - Load `CredentialSchema` `cs` from `applicant_participant.schema_id`.
 - Load `Participant` `validator_participant` from `applicant_participant.validator_participant_id`.
@@ -3633,7 +3627,7 @@ If `validator_participant` is not a [[ref: active participant]] (expired, revoke
 
 We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. That should not occur in this method, but better do the check anyway.
 
-Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_participant_id`, `corporation`.
+Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `role`, `validator_participant_id`, `corporation`.
 
 for each `Participant` entry `p` from `participants[]`:
 
@@ -3795,7 +3789,7 @@ The following VS Operator Authorization parameters are **optional** and collecti
 - `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
 - `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
 
-Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`. Since [Create Root Participant](#mod-pp-msg-7-create-root-participant) always creates an ECOSYSTEM permission, only the following is allowed:
+Permitted message types to be set in `vs_operator_authz_msg_types` depends on `role`. Since [Create Root Participant](#mod-pp-msg-7-create-root-participant) always creates an ECOSYSTEM permission, only the following is allowed:
 
 |Participant role|Permitted Messages|
 |-|-|
@@ -3949,7 +3943,7 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[re
 
 We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-participant) to set or adjust the `effective_until` value.
 
-Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_participant_id`, `corporation`.
+Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `role`, `validator_participant_id`, `corporation`.
 
 for each `Participant` entry `p` from `participants[]`:
 
@@ -4052,28 +4046,28 @@ scale max 800 width
 package "Example Credential Schema Participant Tree" as cs {
 
     object "Ecosystem A" as tr #3fbdb6 {
-        type: ECOSYSTEM (Root)
+        role: ECOSYSTEM (Root)
         did:example:ecosystemA
     }
     object "Issuer Grantor B" as ig {
-        type: ISSUER_GRANTOR
+        role: ISSUER_GRANTOR
         did:example:igB
     }
     object "Issuer C" as issuer #7677ed  {
-        type: ISSUER
+        role: ISSUER
         did:example:iC
     }
     object "Verifier Grantor D" as vg {
-        type: VERIFIER_GRANTOR
+        role: VERIFIER_GRANTOR
         did:example:vgD
     }
     object "Verifier E" as verifier #00b0f0 {
-        type: VERIFIER
+        role: VERIFIER
         did:example:vE
     }
 
     object "Holder Z " as holder #FFB073 {
-        type: HOLDER
+        role: HOLDER
     }
 }
 
@@ -4712,7 +4706,7 @@ Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `type` (ParticipantRole) (*mandatory*): ISSUER or VERIFIER.
+- `role` (ParticipantRole) (*mandatory*): ISSUER or VERIFIER.
 - `validator_participant_id` (uint64) (*mandatory*): MUST be an ECOSYSTEM [[ref: active participant]] or [[ref: future participant]].
 - `vs_operator` (account) (*optional*): the account we want to authorize to create permission sessions linked to this permission. **Required** for payment delegation.
 - `did` (string) (*mandatory*): [[ref: DID]] of the VS grantee service.
@@ -4729,7 +4723,7 @@ The following VS Operator Authorization parameters are **optional** and collecti
 - `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
 - `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
 
-Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`.
+Permitted message types to be set in `vs_operator_authz_msg_types` depends on `role`.
 
 |Participant role|Permitted Messages|
 |-|-|
@@ -4750,7 +4744,7 @@ Load `Participant` `validator_participant` from `validator_participant_id`.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `type` (ParticipantRole) (*mandatory*): MUST be ISSUER or VERIFIER, else abort.
+- `role` (ParticipantRole) (*mandatory*): MUST be ISSUER or VERIFIER, else abort.
 - `validator_participant_id` (uint64) (*mandatory*): `validator_participant` MUST be an ECOSYSTEM [[ref: active participant]] or [[ref: future participant]].
 - `vs_operator` (account) (*optional*): no check required.
 - `did`, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
@@ -4769,10 +4763,10 @@ Load `Participant` `validator_participant` from `validator_participant_id`.
 To execute this method, [[ref: account]] MUST match at least one these rules, else [[ref: transaction]] MUST abort.
 
 - The related `CredentialSchema` entry is loaded with `validator_participant.schema_id`, and will be named `cs` in this section.
-- if `type` is equal to ISSUER: if `cs.issuer_onboarding_mode` is not equal to OPEN, MUST abort.
-- if `type` is equal to VERIFIER: if `cs.verifier_onboarding_mode` is not equal to OPEN, MUST abort.
-- if `type` is equal to VERIFIER and `validation_fees` is specified and different than 0, MUST abort.
-- if `type` is equal to VERIFIER and `verification_fees` is specified and different than 0, MUST abort.
+- if `role` is equal to ISSUER: if `cs.issuer_onboarding_mode` is not equal to OPEN, MUST abort.
+- if `role` is equal to VERIFIER: if `cs.verifier_onboarding_mode` is not equal to OPEN, MUST abort.
+- if `role` is equal to VERIFIER and `validation_fees` is specified and different than 0, MUST abort.
+- if `role` is equal to VERIFIER and `verification_fees` is specified and different than 0, MUST abort.
 
 ###### [MOD-PP-MSG-14-2-3] Self Create Participant fee checks
 
@@ -4782,7 +4776,7 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
 We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-participant) to set or adjust the `effective_until` value.
 
-Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `cs.id`, `type`, `validator_participant_id`, `corporation`.
+Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `cs.id`, `role`, `validator_participant_id`, `corporation`.
 
 for each `Participant` entry `p` from `participants[]`:
 
@@ -4807,16 +4801,16 @@ A new entry `Participant` `perm` MUST be created:
 - `participant.validator_participant_id`: `validator_participant_id`
 - `participant.schema_id`: `validator_participant.schema_id`
 - `participant.modified` to `now`.
-- `participant.role`: `type`.
+- `participant.role`: `role`.
 - `participant.did`: `did`.
 - `participant.corporation`: `corporation`.
 - `participant.vs_operator`: `vs_operator`.
 - `participant.created`: `now`
 - `participant.effective_from`: `effective_from`
 - `participant.effective_until`: `effective_until`
-- `participant.validation_fees`: `validation_fees` if specified and `type` is ISSUER, else 0.
+- `participant.validation_fees`: `validation_fees` if specified and `role` is ISSUER, else 0.
 - `participant.issuance_fees`: 0
-- `participant.verification_fees`: `verification_fees` if specified and `type` is ISSUER, else 0.
+- `participant.verification_fees`: `verification_fees` if specified and `role` is ISSUER, else 0.
 - `participant.deposit`: 0
 
 If `vs_operator_authz_msg_types` is provided, create the [ParticipantAuthorizationRecord](#participantauthorizationrecord) in **active** state by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
@@ -4927,7 +4921,7 @@ Generic query used for (at least):
 - `grantee` (account) (*optional*): the grantee account.
 - `did` (string) (*optional*): the did the permission refers to.
 - `participant_id` (number) (*optional*): limit to permissions where the `validator_participant_id` is `participant_id`.
-- `type` (ParticipantRole) (*optional*): if we want to limit to a specific permission type.
+- `role` (ParticipantRole) (*optional*): if we want to limit to a specific `Participant` role.
 - `only_valid` (boolean) (*optional*): if set to true, only return active participants.
 - `only_slashed` (boolean) (*optional*): if set to true, only return slashed permissions.
 - `only_repaid` (boolean) (*optional*): if set to true, only return repaid slashed permissions.

--- a/spec.md
+++ b/spec.md
@@ -1,6 +1,6 @@
 # Verifiable Public Registry v4 Specification
 
-**Latest draft:** [spec v4-draft18](https://verana-labs.github.io/verifiable-trust-vpr-spec/)
+**Latest draft:** [spec v4-draft19](https://verana-labs.github.io/verifiable-trust-vpr-spec/)
 
 **Latest stable:** [spec v3](https://verana-labs.github.io/verifiable-trust-vpr-spec/index-v3.html)
 
@@ -105,7 +105,7 @@ package "Verifiable Public Registry" as vpr {
 
 ```
 
-Permission directory is intended to be **crawled by indexers**, which resolve the listed DIDs, identify associated [[ref: verifiable services]], and index them.
+Participant directory is intended to be **crawled by indexers**, which resolve the listed DIDs, identify associated [[ref: verifiable services]], and index them.
 
 Indexers may expose this data through APIs for querying the indexed services or use it to build a search engine for querying the database of indexed [[ref: verifiable services]].
 
@@ -312,14 +312,14 @@ object "Ecosystem" as tra #3fbdb6 {
 - An **HolderOnboardingMode** for **holder policy**, which determines how `HOLDER` permissions are granted. Modes include:
   - `ISSUER_VALIDATION_PROCESS`: `HOLDER` permissions are granted directly by issuers to holder through the execution of a Validation Process.
   - `PERMISSIONLESS`: holder that want to obtain credentials from an issuer do not require a permission in the VPR.
-- A **Permission tree** that defines the roles and relationships involved in managing the schema’s lifecycle. Each created permission in the tree can define business rules, see below [Business Models](#business-models).
+- A **Participant tree** that defines the roles and relationships involved in managing the schema’s lifecycle. Each created permission in the tree can define business rules, see below [Business Models](#business-models).
 
 ```plantuml
 
 @startuml
 scale max 800 width
  
-package "Example Credential Schema Permission Tree" as cs {
+package "Example Credential Schema Participant Tree" as cs {
 
     object "Ecosystem A" as tr #3fbdb6 {
         permissionType: ECOSYSTEM (Root)
@@ -441,27 +441,27 @@ scale max 800 width
  
 package "Pay per validation Fee Structure" as cs {
 
-    object "Ecosystem A - Credential Schema Root Permission" as tr #3fbdb6 {
+    object "Ecosystem A - Credential Schema Root Participant" as tr #3fbdb6 {
         did:example:ecosystemA
         Grantor applicant validation cost: 1000 TUs
     }
-    object "Issuer Grantor B - Credential Schema Permission" as ig {
+    object "Issuer Grantor B - Credential Schema Participant" as ig {
         did:example:igB
         Issuer applicant validation cost: 1000 TUs
     }
-    object "Issuer C - Credential Schema Permission" as issuer #7677ed  {
+    object "Issuer C - Credential Schema Participant" as issuer #7677ed  {
         did:example:iC
         Holder applicant validation cost: 10 TUs
     }
-    object "Verifier Grantor D -  Credential Schema Permission" as vg {
+    object "Verifier Grantor D -  Credential Schema Participant" as vg {
         did:example:vgD
         Verifier applicant validation cost: 200 TUs
     }
-    object "Verifier E - Credential Schema Permission" as verifier #00b0f0 {
+    object "Verifier E - Credential Schema Participant" as verifier #00b0f0 {
         did:example:vE
     }
 
-    object "Holder Z - Credential Schema Permission" as holder #FFB073 {
+    object "Holder Z - Credential Schema Participant" as holder #FFB073 {
         permissionType: HOLDER
     }
 }
@@ -689,25 +689,25 @@ scale max 800 width
  
 package "Ecosystem #A - Credential Schema #1" as cs {
 
-    object "Ecosystem #A - Credential Schema #1 Root Permission" as tr #3fbdb6 {
+    object "Ecosystem #A - Credential Schema #1 Root Participant" as tr #3fbdb6 {
         did:example:ecosystemA
         issuance cost: 10 TUs
         verification cost: 20 TUs
     }
-    object "Issuer Grantor #B - Credential Schema #1 Permission" as ig {
+    object "Issuer Grantor #B - Credential Schema #1 Participant" as ig {
         did:example:igB
         issuance cost: 5 TUs
         verification cost: 5 TUs
     }
-    object "Issuer #C - Credential Schema #1 Permission" as issuer #7677ed  {
+    object "Issuer #C - Credential Schema #1 Participant" as issuer #7677ed  {
         did:example:iC
         verification cost: 30 TUs
     }
-    object "Verifier Grantor #D - Credential #1 Schema Permission" as vg {
+    object "Verifier Grantor #D - Credential #1 Schema Participant" as vg {
         did:example:vgD
         verification cost: 2 TUs
     }
-    object "Verifier #E - Credential Schema #1 Permission" as verifier #00b0f0 {
+    object "Verifier #E - Credential Schema #1 Participant" as verifier #00b0f0 {
         did:example:vE
     }
 }
@@ -1078,7 +1078,7 @@ entity "ExchangeRateAuthorization" as xrauthz {
 }
 
 
-entity "Permission" as csp {
+entity "Participant" as csp {
   *id: uint64
   did: string
   +created: timestamp
@@ -1323,7 +1323,7 @@ group  --o td: corporation
 - `repaid` (timestamp) (*mandatory*): timestamp this `Participant` has been repaid.
 - `effective_from` (timestamp) (*optional*): timestamp from which (inclusive) this `Participant` is effective.
 - `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this `Participant` is effective, null if no time limit has been set for this permission.
-- `modified` (timestamp) (*mandatory*): timestamp this Permission has been modified.
+- `modified` (timestamp) (*mandatory*): timestamp this Participant has been modified.
 - `validation_fees` (number) (*mandatory*): price to pay by an applicant to a validator (`corporation` grantee of this perm) for running a validation process for a given validation period. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
 - `issuance_fees` (number) (*mandatory*): fees requested by grantee `corporation` of this perm when a credential is issued. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
 - `verification_fees` (number) (*mandatory*): fees requested by grantee `corporation` of this perm when a credential is verified. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
@@ -1342,7 +1342,7 @@ group  --o td: corporation
 - `issuance_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_VALIDATION_PROCESS mode) or an ISSUER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 - `verification_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_VALIDATION_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 
-> Note: VS operator authorization settings (spend limits, feegrant, expiration, authorized message types) are no longer stored on `Participant`. They live in `ParticipantAuthorizationRecord` entries inside [VSOperatorAuthorization](#vsoperatorauthorization), keyed by `Permission.id`. See [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) and [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks).
+> Note: VS operator authorization settings (spend limits, feegrant, expiration, authorized message types) are no longer stored on `Participant`. They live in `ParticipantAuthorizationRecord` entries inside [VSOperatorAuthorization](#vsoperatorauthorization), keyed by `Participant.id`. See [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) and [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks).
 
 ### ParticipantSession
 
@@ -1424,7 +1424,7 @@ A `VSOperatorAuthorization` groups all `ParticipantAuthorizationRecord` entries 
 
 ### ParticipantAuthorizationRecord
 
-A `ParticipantAuthorizationRecord` carries the per-permission authorization configuration that was previously stored on `Permission.vs_operator_authz_*` fields. Each record is globally unique by `participant_id`: for any `Permission.id`, at most one record exists system-wide, so `(corporation, vs_operator)` can be derived from `participant_id` via a direct lookup.
+A `ParticipantAuthorizationRecord` carries the per-permission authorization configuration that was previously stored on `Participant.vs_operator_authz_*` fields. Each record is globally unique by `participant_id`: for any `Participant.id`, at most one record exists system-wide, so `(corporation, vs_operator)` can be derived from `participant_id` via a direct lookup.
 
 - `participant_id` (uint64) (*mandatory*): id of the `Participant` this authorization record applies to. Globally unique across all `ParticipantAuthorizationRecord` entries.
 - `msg_types` (msg_type[]) (*mandatory*): list of delegable message types for which the `vs_operator` is authorized on behalf of `corporation` when acting in the context of `participant_id`. Declared by the applicant at record creation time (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant)). Frozen after creation.
@@ -1433,7 +1433,7 @@ A `ParticipantAuthorizationRecord` carries the per-permission authorization conf
 - `fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
 - `remaining_fee_spend` (DenomAmount[]) (*conditional*): runtime balance for `fee_spend_limit`. Present iff `fee_spend_limit` is set. Initialized, decremented and reset following the same rules as `remaining_spend`.
 - `with_feegrant` (bool) (*mandatory*): if true, `corporation` pays the transaction fees for `vs_operator` when executing authorized messages in the context of this permission, through an on-chain `FeeGrant`.
-- `expiration` (timestamp) (*mandatory*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the record is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the record auto-renews until removed via [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)). Initially written to `now` at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp) (disabled until validation) and to `Permission.effective_until` at [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-vp-to-validated) / [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-participant) / [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant).
+- `expiration` (timestamp) (*mandatory*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the record is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the record auto-renews until removed via [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)). Initially written to `now` at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp) (disabled until validation) and to `Participant.effective_until` at [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-vp-to-validated) / [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-participant) / [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant).
 - `period` (duration) (*optional*): reset period for `spend_limit` and `fee_spend_limit` in the context of this permission.
 
 ### ExchangeRate
@@ -1502,14 +1502,14 @@ Note about Query REST API:
 
 - all query methods MUST return valid JSON.
 - objects MUST be nested when needed, such as when returning an ecosystem.
-- JSON formatting MUST obey to data model regarding attribute names. A method that returns a `Ecosystem` entry MUST return an entry called "trust_registry". A method that returns a list of Ecosystems MUST return an entry called "trustRegistries" that contain a list of `Ecosystem` entries.
+- JSON formatting MUST obey to data model regarding attribute names. A method that returns a `Ecosystem` entry MUST return an entry called "ecosystem". A method that returns a list of Ecosystems MUST return an entry called "ecosystems" that contain a list of `Ecosystem` entries.
 
 Examples:
 
-Get a `Ecosystem`
+Get an `Ecosystem`
 
 ```json
-"trust_registry": {
+"ecosystem": {
   {
     "active_version": 0,
     "aka": "string",
@@ -1543,7 +1543,7 @@ Get a `Ecosystem`
 ```
 
 ```json
-"trustRegistries": [ {
+"ecosystems": [ {
   {
     "active_version": 0,
     "aka": "string",
@@ -1776,7 +1776,7 @@ As a result, `accountABC` is authorized to:
 |                                | List CS Module Parameters               | /cs/v1/params                 | Query  | [[MOD-CS-QRY-4]](#mod-cs-qry-4-list-module-parameters)   |N/A  |
 |                  | Get Schema Authorization Policy                         | /cs/v1/sap/get         | Query | [[MOD-CS-QRY-5]](#mod-cs-qry-5-get-schema-authorization-policy) | N/A |
 |                  | List Schema Authorization Policies                      | /cs/v1/sap/list        | Query | [[MOD-CS-QRY-6]](#mod-cs-qry-6-list-schema-authorization-policies) | N/A |
-| Permission                     | Start Participant VP                     |     N/A (Tx)                       | Msg    | [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp)    |corporation + operator |
+| Participant                    | Start Participant VP                     |     N/A (Tx)                       | Msg    | [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp)    |corporation + operator |
 |                                | Renew a Participant VP                   |       N/A (Tx)                     | Msg    | [[MOD-PP-MSG-2]](#mod-pp-msg-2-renew-participant-vp)    |corporation + operator |
 |                                | Set Participant VP to Validated          |        N/A (Tx)                     | Msg    | [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-vp-to-validated)    |corporation + operator |
 |                                | Cancel Participant VP Last Request       |         N/A (Tx)                    | Msg    | [[MOD-PP-MSG-6]](#mod-pp-msg-6-cancel-participant-vp-last-request)    |corporation + operator |
@@ -2707,14 +2707,14 @@ Entries MUST be ordered by ascending `version`.
 
 *This section is non-normative.*
 
-Permission are linked to a Credential Schema and representable as a tree.
+Participants are linked to a Credential Schema and representable as a tree.
 
 ```plantuml
 
 @startuml
 scale max 800 width
  
-package "Example Credential Schema Permission Tree" as cs {
+package "Example Credential Schema Participant Tree" as cs {
 
     object "Ecosystem A" as tr #3fbdb6 {
         permissionType: ECOSYSTEM (Root)
@@ -2817,7 +2817,7 @@ The following VS Operator Authorization parameters are **optional** and collecti
 
 Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`.
 
-|Permission type|Permitted Messages|
+|Participant role|Permitted Messages|
 |-|-|
 | HOLDER | TriggerResolver |
 | ISSUER | CreateOrUpdateParticipantSession, SetPermissionVPtoValidated |
@@ -3379,7 +3379,7 @@ The following VS Operator Authorization parameters are **optional** and collecti
 
 Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`. Since [Create Root Participant](#mod-pp-msg-7-create-root-participant) always creates an ECOSYSTEM permission, only the following is allowed:
 
-|Permission type|Permitted Messages|
+|Participant role|Permitted Messages|
 |-|-|
 | ECOSYSTEM | SetPermissionVPtoValidated |
 
@@ -3631,7 +3631,7 @@ In the following permission tree, "Verifier E" permission can be revoked:
 @startuml
 scale max 800 width
  
-package "Example Credential Schema Permission Tree" as cs {
+package "Example Credential Schema Participant Tree" as cs {
 
     object "Ecosystem A" as tr #3fbdb6 {
         permissionType: ECOSYSTEM (Root)
@@ -3711,7 +3711,7 @@ If the peer wants to verify a credential, agent must send to peer:
 
 In case peer is a **Verifiable Service** and illegaly set `agent_participant_id` and/or `wallet_agent_participant_id`, the other end MUST refuse the request.
 
-`payer` MUST create a Permission Session using the above information, then, `agent` MUST check session has been created and is valid before accepting the action (receive and store issued credential, or accept a presentation request).
+`payer` MUST create a Participant Session using the above information, then, `agent` MUST check session has been created and is valid before accepting the action (receive and store issued credential, or accept a presentation request).
 
 ```plantuml
 scale max 800 width
@@ -4313,7 +4313,7 @@ The following VS Operator Authorization parameters are **optional** and collecti
 
 Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`.
 
-|Permission type|Permitted Messages|
+|Participant role|Permitted Messages|
 |-|-|
 | HOLDER | TriggerResolver |
 | ISSUER | CreateOrUpdateParticipantSession, SetPermissionVPtoValidated |
@@ -4637,8 +4637,8 @@ v --> vg
 ##### [MOD-PP-QRY-4-2] Find Beneficiaries checks
 
 - if `issuer_participant_id` and `verifier_participant_id` are unset then MUST abort.
-- if `issuer_participant_id` is specified, load `issuer_participant` from `issuer_participant_id`, Permission MUST exist and MUST be a [[ref: active permission]].
-- if `verifier_participant_id` is specified, load `verifier_participant` from `verifier_participant_id`, Permission MUST exist and MUST be a [[ref: active permission]].
+- if `issuer_participant_id` is specified, load `issuer_participant` from `issuer_participant_id`, Participant MUST exist and MUST be a [[ref: active permission]].
+- if `verifier_participant_id` is specified, load `verifier_participant` from `verifier_participant_id`, Participant MUST exist and MUST be a [[ref: active permission]].
 
 ##### [MOD-PP-QRY-4-3] Find Beneficiaries execution
 
@@ -4727,7 +4727,7 @@ autonumber "<font color='#7677ed'><b>(end start method)"
 Applicant <-- VPR: Transaction completed and Validation entry created
 autonumber stop
 autonumber "<font color='#7677ed'><b>(connects to Certification Entity Validation VS)"
-Applicant --> CE: share id of Permission
+Applicant --> CE: share id of Participant
 autonumber stop
 Applicant <-- CE: Request proof of account and DID ownership (blind sign)
 Applicant --> CE: send blind sign proofs 
@@ -5372,7 +5372,7 @@ MUST abort if one of these conditions fails:
 
 #### [MOD-DE-MSG-5] Grant VS Operator Authorization
 
-This method can only be called directly by the following Permission module methods, with no signer check:
+This method can only be called directly by the following Participant module methods, with no signer check:
 
 - [Start Participant VP](#mod-pp-msg-1-start-participant-vp)
 - [Self Create Participant](#mod-pp-msg-14-self-create-participant)
@@ -5433,7 +5433,7 @@ This is a shared subroutine invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-o
 
 #### [MOD-DE-MSG-6] Revoke VS Operator Authorization
 
-This method can only be called directly by the following Permission module methods, with no signer check:
+This method can only be called directly by the following Participant module methods, with no signer check:
 
 - [Cancel Participant VP Last Request](#mod-pp-msg-6-cancel-participant-vp-last-request) (only when the cancellation terminates the permission)
 - [Revoke Participant](#mod-pp-msg-9-revoke-participant)
@@ -5467,7 +5467,7 @@ This method does NOT read `Participant` state.
 
 #### [MOD-DE-MSG-9] Update VS Operator Authorization Expiration
 
-This method can only be called directly by the following Permission module methods, with no signer check:
+This method can only be called directly by the following Participant module methods, with no signer check:
 
 - [Set Participant VP to Validated](#mod-pp-msg-3-set-participant-vp-to-validated)
 - [Adjust Participant](#mod-pp-msg-8-adjust-participant)

--- a/spec.md
+++ b/spec.md
@@ -63,6 +63,12 @@ An ecosystem typically expose APIs that are consumed by services that would like
 
 A Verifiable Public Registry (VPR) is a “registry of registries”, a public service that provides foundational infrastructure for decentralized trust ecosystems. It offers:
 
+- [[ref: corporation]] lifecycle and directory:
+  - corporation onboarding, with associated [[ref: DID]] and [[ref: corporation governance framework]] publication
+  - multi-member governance via a Cosmos SDK [[ref: group]] (members, voting policy, threshold)
+  - a public corporation directory queryable by indexers, [[ref: verifiable services]], and [[ref: verifiable user agents]]
+  - corporations are the foundational actors of the VPR: they control [[ref: participants]] and may themselves control [[ref: ecosystems]].
+
 - ecosystem management:  
   - governance framework publication and versionning
   - [[ref: credential schemas]] publication
@@ -351,6 +357,7 @@ package "Example Credential Schema Participant Tree" as cs {
 
     object "Holder Z " as holder #FFB073 {
         role: HOLDER
+        did:example:vZ
     }
 }
 

--- a/spec.md
+++ b/spec.md
@@ -1035,7 +1035,7 @@ entity "VSOperatorAuthorization" as vsoauthz {
 }
 
 entity "PermissionAuthorizationRecord" as par {
-   *perm_id: uint64
+   *participant_id: uint64
    +msg_types: msg_type[]
    +with_feegrant: boolean
    +expiration: timestamp
@@ -1186,21 +1186,21 @@ account --o oauthz: operator
 group --o vsoauthz: corporation
 account --o vsoauthz: vs_operator
 vsoauthz "1" --- "1..n" par: records
-par o-- csp: perm_id
+par o-- csp: participant_id
 
 csp o-- cspt: type
 csp o-- cs: schema_id
-csp o-- "0..1" csp: validator_perm_id
-cs o-- tr: tr_id
+csp o-- "0..1" csp: validator_participant_id
+cs o-- tr: ecosystem_id
 
 cs o-- "0..n" sap: policies
 
 csps --- "1..n" cspsr : session_records
 
-cspsr  o-- "0..1" csp: issuer_perm_id
-cspsr  o-- "0..1" csp: verifier_perm_id
-cspsr  o-- "0..1" csp: wallet_agent_perm_id
-cspsr  o-- "0..1" csp: agent_perm_id
+cspsr  o-- "0..1" csp: issuer_participant_id
+cspsr  o-- "0..1" csp: verifier_participant_id
+cspsr  o-- "0..1" csp: wallet_agent_participant_id
+cspsr  o-- "0..1" csp: agent_participant_id
 
 oauthz "1" --- "0..n" da: fee_spend_limit
 oauthz "1" --- "0..n" da: spend_limit
@@ -1253,7 +1253,7 @@ group  --o td: corporation
 `GovernanceFrameworkVersion`:
 
 - `id` (uint64) (*mandatory*): the id of the schema.
-- `tr_id` (uint64) (*mandatory*): the id of the trust registry that controls this `GovernanceFrameworkVersion` entry.
+- `ecosystem_id` (uint64) (*mandatory*): the id of the trust registry that controls this `GovernanceFrameworkVersion` entry.
 - `created` (timestamp) (*mandatory*): timestamp this GovernanceFrameworkVersion has been created.
 - `version` (int) (*mandatory*): version of this GF. MUST Starts with 1.
 
@@ -1275,7 +1275,7 @@ group  --o td: corporation
 **General Info**:
 
 - `id` (uint64) (*mandatory*): the id of the schema.
-- `tr_id` (uint64) (*mandatory*): the id of the trust registry that controls this `CredentialSchema` entry.
+- `ecosystem_id` (uint64) (*mandatory*): the id of the trust registry that controls this `CredentialSchema` entry.
 - `created` (timestamp) (*mandatory*): timestamp this CredentialSchema has been created.
 - `modified` (timestamp) (*mandatory*): timestamp this CredentialSchema has been modified.
 - `archived` (timestamp) (*mandatory*): timestamp this CredentialSchema has been archived.
@@ -1311,7 +1311,7 @@ group  --o td: corporation
 
 `Permission`:
 
-- `id` (uint64) (*mandatory*): the id of the perm.
+- `id` (uint64) (*mandatory*): the id of the participant.
 - `schema_id` (uint64) (*mandatory*): the id of the related `CredentialSchema` entry.
 - `type` (PermissionType): ISSUER, VERIFIER, ISSUER_GRANTOR, VERIFIER_GRANTOR, ECOSYSTEM, HOLDER
 - `did` (string) (*optional*): [[ref: DID]] this permission refers to. MUST conform to [[spec-norm:RFC3986]].
@@ -1327,11 +1327,11 @@ group  --o td: corporation
 - `validation_fees` (number) (*mandatory*): price to pay by an applicant to a validator (`corporation` grantee of this perm) for running a validation process for a given validation period. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
 - `issuance_fees` (number) (*mandatory*): fees requested by grantee `corporation` of this perm when a credential is issued. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
 - `verification_fees` (number) (*mandatory*): fees requested by grantee `corporation` of this perm when a credential is verified. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
-- `deposit` (number) (*mandatory*): accumulated *grantee* deposit in the context of the *use* of this permission (including the validation process), in [[ ref: native denom ]]. Usually, it is incremented when for example, for a ISSUER type `Permission` `perm`, issuer issues credentials that require paying issuance fees: an additional % of the fees is charged to issuer and sent to its deposit, corresponding deposit amount increases this `perm.deposit` value as well. If `perm` is, let's say revoked, then corresponding `perm.deposit` value is freed from `perm.grantee` Trust Deposit.
+- `deposit` (number) (*mandatory*): accumulated *grantee* deposit in the context of the *use* of this permission (including the validation process), in [[ ref: native denom ]]. Usually, it is incremented when for example, for a ISSUER type `Permission` `perm`, issuer issues credentials that require paying issuance fees: an additional % of the fees is charged to issuer and sent to its deposit, corresponding deposit amount increases this `participant.deposit` value as well. If `perm` is, let's say revoked, then corresponding `participant.deposit` value is freed from `participant.grantee` Trust Deposit.
 - `slashed_deposit` (number) (*mandatory*): part of the deposit in [[ ref: native denom ]] that has been slashed.
 - `repaid_deposit` (number) (*mandatory*): part of the slashed deposit in [[ ref: native denom ]] that has been repaid.
 - `revoked` (timestamp) (*optional*): manual revocation timestamp of this Perm.
-- `validator_perm_id` (uint64) (*optional*): permission of the validator assigned to the validation process of this permission, ie *parent node* in the `Permission` tree.
+- `validator_participant_id` (uint64) (*optional*): permission of the validator assigned to the validation process of this permission, ie *parent node* in the `Permission` tree.
 - `vp_state` (enum) (*mandatory*): one of PENDING, VALIDATED, TERMINATED.
 - `vp_exp` (timestamp) (*optional*): validation expiration timestamp. This expiration timestamp is for the validation process itself, not for the issued credential or `Permission` expiration timestamp.
 - `vp_last_state_change` (timestamp) (*mandatory*)
@@ -1360,10 +1360,10 @@ group  --o td: corporation
 `PermissionSessionRecord`:
 
 - `created` (timestamp) (*mandatory*): timestamp this record has been created.
-- `issuer_perm_id` (uint64) (*optional*): related issuer `Permission` id (if applicable).
-- `verifier_perm_id` (uint64) (*optional*): related verifier `Permission` id (if applicable).
-- `wallet_agent_perm_id` (uint64) (*optional*): related wallet agent `Permission` id (if applicable).
-- `agent_perm_id` (uint64) (*optional*): permission id of the agent `Permission` id (if applicable).
+- `issuer_participant_id` (uint64) (*optional*): related issuer `Permission` id (if applicable).
+- `verifier_participant_id` (uint64) (*optional*): related verifier `Permission` id (if applicable).
+- `wallet_agent_participant_id` (uint64) (*optional*): related wallet agent `Permission` id (if applicable).
+- `agent_participant_id` (uint64) (*optional*): permission id of the agent `Permission` id (if applicable).
 
 ### TrustDeposit
 
@@ -1424,10 +1424,10 @@ A `VSOperatorAuthorization` groups all `PermissionAuthorizationRecord` entries d
 
 ### PermissionAuthorizationRecord
 
-A `PermissionAuthorizationRecord` carries the per-permission authorization configuration that was previously stored on `Permission.vs_operator_authz_*` fields. Each record is globally unique by `perm_id`: for any `Permission.id`, at most one record exists system-wide, so `(corporation, vs_operator)` can be derived from `perm_id` via a direct lookup.
+A `PermissionAuthorizationRecord` carries the per-permission authorization configuration that was previously stored on `Permission.vs_operator_authz_*` fields. Each record is globally unique by `participant_id`: for any `Permission.id`, at most one record exists system-wide, so `(corporation, vs_operator)` can be derived from `participant_id` via a direct lookup.
 
-- `perm_id` (uint64) (*mandatory*): id of the `Permission` this authorization record applies to. Globally unique across all `PermissionAuthorizationRecord` entries.
-- `msg_types` (msg_type[]) (*mandatory*): list of delegable message types for which the `vs_operator` is authorized on behalf of `corporation` when acting in the context of `perm_id`. Declared by the applicant at record creation time (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission)). Frozen after creation.
+- `participant_id` (uint64) (*mandatory*): id of the `Permission` this authorization record applies to. Globally unique across all `PermissionAuthorizationRecord` entries.
+- `msg_types` (msg_type[]) (*mandatory*): list of delegable message types for which the `vs_operator` is authorized on behalf of `corporation` when acting in the context of `participant_id`. Declared by the applicant at record creation time (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission)). Frozen after creation.
 - `spend_limit` (DenomAmount[]) (*optional*): maximum amount the `vs_operator` is allowed to spend, in the context of this permission, as a direct consequence of executing authorized messages.
 - `remaining_spend` (DenomAmount[]) (*conditional*): runtime balance for `spend_limit`. Present iff `spend_limit` is set. Initialized to `spend_limit` at create time. Decremented per matching `denom` after each authorized operation. Reset to `spend_limit` when the current cycle ends (see `expiration` and `period` below).
 - `fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
@@ -1525,7 +1525,7 @@ Get a `TrustRegistry`
         "active_since": "2025-01-14T19:40:37.967Z",
         "created": "2025-01-14T19:40:37.967Z",
         "id": "string",
-        "tr_id": "string",
+        "ecosystem_id": "string",
         "version": 0,
         "documents": [
           {
@@ -1559,7 +1559,7 @@ Get a `TrustRegistry`
         "active_since": "2025-01-14T19:40:37.967Z",
         "created": "2025-01-14T19:40:37.967Z",
         "id": "string",
-        "tr_id": "string",
+        "ecosystem_id": "string",
         "version": 0,
         "documents": [
           {
@@ -1588,7 +1588,7 @@ Get a `TrustRegistry`
         "active_since": "2025-01-14T19:40:37.967Z",
         "created": "2025-01-14T19:40:37.967Z",
         "id": "string",
-        "tr_id": "string",
+        "ecosystem_id": "string",
         "version": 0,
         "documents": [
           {
@@ -1707,9 +1707,9 @@ A second authorization grant mode exists for vs-agents. It is used when a corpor
 
 > Note: the set of messages a `vs_operator` is authorized to execute in the context of a permission is declared by the applicant at permission creation time (see [[MOD-PP-MSG-1-1]](#mod-pp-msg-1-1-start-permission-vp-parameters) and [[MOD-PP-MSG-14-1]](#mod-pp-msg-14-1-self-create-permission-parameters)) and stored in `record.msg_types`. It is frozen for the lifetime of the record and can only be changed by revoking the permission and starting a new one.
 
-Given a `corporation`, an `operator` (the `vs_operator`), a **primary permission id** `perm_id` (determined by the calling method), and the current message type `msg_type`:
+Given a `corporation`, an `operator` (the `vs_operator`), a **primary permission id** `participant_id` (determined by the calling method), and the current message type `msg_type`:
 
-1. A `PermissionAuthorizationRecord` `record` MUST exist for `perm_id`. Abort if not found.
+1. A `PermissionAuthorizationRecord` `record` MUST exist for `participant_id`. Abort if not found.
 2. `record` MUST belong to `VSOperatorAuthorization[corporation, operator]`, that is: the containing `VSOperatorAuthorization` MUST have `corporation` as its `corporation` and `operator` as its `vs_operator`. Abort otherwise.
 3. `msg_type` MUST be in `record.msg_types`. Abort otherwise.
 4. Cycle / expiration check:
@@ -1878,19 +1878,19 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - create and persist a new `TrustRegistry` entry `tr`:
 
-- `tr.id` : auto-incremented uint64
-- `tr.did`: `did`
-- `tr.corporation`: `corporation`
-- `tr.created`: current timestamp
-- `tr.modified`: `tr.created`
-- `tr.aka`: `aka`
-- `tr.language`: `language`
-- `tr.active_version`: 1
+- `ecosystem.id` : auto-incremented uint64
+- `ecosystem.did`: `did`
+- `ecosystem.corporation`: `corporation`
+- `ecosystem.created`: current timestamp
+- `ecosystem.modified`: `ecosystem.created`
+- `ecosystem.aka`: `aka`
+- `ecosystem.language`: `language`
+- `ecosystem.active_version`: 1
 
 - create and persist a new `GovernanceFrameworkVersion` entry `gfv`:
 
 - `gfv.id`: auto-incremented uint64
-- `gfv.tr_id`: `tr.id`
+- `gfv.ecosystem_id`: `ecosystem.id`
 - `gfv.created`: current timestamp
 - `gfv.version`: 1
 - `gfv.active_since`: current timestamp
@@ -1932,7 +1932,7 @@ if a mandatory parameter is not present, method MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` (uint64) (*mandatory*): a `TrustRegistry` entry with this id MUST exist and `corporation` executing the method MUST be the `corporation` of the `TrustRegistry` entry.
-- `version`: there MUST exist a `GovernanceFrameworkVersion` entry `gfv` where `gfv.tr_id` is equal to `id` and `gfv.version` = `version`, or `version` MUST be exactly equal to the biggest found `gfv.version` + 1 of all `GovernanceFrameworkVersion` entries found for this `gfv.tr_id` equal to `id`. `version` MUST be greater than the `tr.active_version`.
+- `version`: there MUST exist a `GovernanceFrameworkVersion` entry `gfv` where `gfv.ecosystem_id` is equal to `id` and `gfv.version` = `version`, or `version` MUST be exactly equal to the biggest found `gfv.version` + 1 of all `GovernanceFrameworkVersion` entries found for this `gfv.ecosystem_id` equal to `id`. `version` MUST be greater than the `ecosystem.active_version`.
 - `doc_language` (string) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 - `doc_url` (string) (*mandatory*): MUST be a valid URL.
 - `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
@@ -1950,7 +1950,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 load `GovernanceFrameworkVersion` entry `gfv` for the requested version, or create a new `GovernanceFrameworkVersion` `gfv` if required:
 
 - `gfv.id`: auto-incremented uint64
-- `gfv.tr_id`: `id`
+- `gfv.ecosystem_id`: `id`
 - `gfv.created`: current timestamp
 - `gfv.version`: `version`
 - `gfv.active_since`: null
@@ -1986,8 +1986,8 @@ If any of these precondition checks fail, method MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` (uint64) (*mandatory*): a `TrustRegistry` entry with this id MUST exist and `corporation` executing the method MUST be the `corporation` of the `TrustRegistry` entry.
-- load `TrustRegistry` entry `tr` from its `id`. Find a `GovernanceFrameworkVersion` entry `gfv` where version is equal to `tr.active_version` + 1. If none is found, transaction MUST abort.
-- find `GovernanceFrameworkDocument` `gfd` for `gfd.gfv_id` = `gfv.id` and `gfd.language` = `tr.language`. If no document is found (and thus no document exist for the default language of this version for this trust registry), transaction MUST abort.
+- load `TrustRegistry` entry `tr` from its `id`. Find a `GovernanceFrameworkVersion` entry `gfv` where version is equal to `ecosystem.active_version` + 1. If none is found, transaction MUST abort.
+- find `GovernanceFrameworkDocument` `gfd` for `gfd.gfv_id` = `gfv.id` and `gfd.language` = `ecosystem.language`. If no document is found (and thus no document exist for the default language of this version for this trust registry), transaction MUST abort.
 
 ###### [MOD-ES-MSG-3-2-2] Increase Active Governance Framework Version fee checks
 
@@ -1999,7 +1999,7 @@ If all precondition checks passed, method is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- load `TrustRegistry` entry `tr` from its `id`. Find a `GovernanceFrameworkVersion` entry `gfv` where version is equal to `tr.active_version` + 1. If none is found, transaction MUST abort. Else, update `tr.active_version` to `tr.active_version` + 1. Set `tr.modified` to current timestamp, and set `gfv.active_since` to current timestamp and persist changes.
+- load `TrustRegistry` entry `tr` from its `id`. Find a `GovernanceFrameworkVersion` entry `gfv` where version is equal to `ecosystem.active_version` + 1. If none is found, transaction MUST abort. Else, update `ecosystem.active_version` to `ecosystem.active_version` + 1. Set `ecosystem.modified` to current timestamp, and set `gfv.active_since` to current timestamp and persist changes.
 
 #### [MOD-ES-MSG-4] Update Trust Registry
 
@@ -2040,9 +2040,9 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - load `TrustRegistry` entry `tr` from `id` and set:
 
-- `tr.did`: `did`
-- `tr.aka`: `aka`
-- `tr.modified`: current timestamp
+- `ecosystem.did`: `did`
+- `ecosystem.aka`: `aka`
+- `ecosystem.modified`: current timestamp
 
 #### [MOD-ES-MSG-5] Archive Trust Registry
 
@@ -2066,10 +2066,10 @@ If any of these precondition checks fail, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- load `TrustRegistry` `tr` from `id`. `tr.corporation` MUST be the corporation executing the method, else MUST abort.
+- load `TrustRegistry` `tr` from `id`. `ecosystem.corporation` MUST be the corporation executing the method, else MUST abort.
 - `archive` (boolean) (*mandatory*) MUST be a boolean.
-  - If `archive` is true and `tr.archived` is not null, MUST abort as `TrustRegistry` is already archived.
-  - If `archive` is false and `tr.archived` is null, MUST abort as `TrustRegistry` is already not archived.
+  - If `archive` is true and `ecosystem.archived` is not null, MUST abort as `TrustRegistry` is already archived.
+  - If `archive` is false and `ecosystem.archived` is null, MUST abort as `TrustRegistry` is already not archived.
 
 ###### [MOD-ES-MSG-5-2-2] Archive Trust Registry fee checks
 
@@ -2081,10 +2081,10 @@ If all precondition checks passed, method is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- update `TrustRegistry` entry `tr` with `tr.id` equal to `id`:
-- if `archived` is true: set `tr.archived` to current timestamp.
-- if `archived` is false: set `tr.archived` to null.
-- `tr.modified`: current timestamp
+- update `TrustRegistry` entry `tr` with `ecosystem.id` equal to `id`:
+- if `archived` is true: set `ecosystem.archived` to current timestamp.
+- if `archived` is false: set `ecosystem.archived` to null.
+- `ecosystem.modified`: current timestamp
 
 #### [MOD-ES-MSG-6] Update Module Parameters
 
@@ -2193,7 +2193,7 @@ An [[ref: account]] that would like to create a [[ref: credential schema]] MUST 
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `tr_id` id of the trust registry (*mandatory*);
+- `ecosystem_id` id of the trust registry (*mandatory*);
 - `json_schema` the [[ref: Json Schema]] of the credential (*mandatory*).
 - `issuer_grantor_validation_validity_period` (*mandatory*), default to 0 (days).
 - `verifier_grantor_validation_validity_period` (*mandatory*), default to 0 (days).
@@ -2218,7 +2218,7 @@ If any of these precondition checks fail, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `tr_id` MUST represent an existing `TrustRegistry` entry `tr` and `tr.corporation` MUST be the `corporation` executing the method.
+- `ecosystem_id` MUST represent an existing `TrustRegistry` entry `tr` and `ecosystem.corporation` MUST be the `corporation` executing the method.
 - `json_schema` MUST be a valid [[ref: Json Schema]], and size must not be greater than `GlobalVariables.credential_schema_schema_max_size`. `$id` of the [[ref: Json Schema]] is ignored and will be replaced during execution by the auto-generated id of this `CredentialSchema`.
 - `issuer_grantor_validation_validity_period` must be between 0 (never expire) and `GlobalVariables.credential_schema_issuer_grantor_validation_validity_period_max_days` days.
 - `verifier_grantor_validation_validity_period` must be between 0 (never expire) and `GlobalVariables.credential_schema_verifier_grantor_validation_validity_period_max_days` days.
@@ -2253,7 +2253,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - create and persist a new `CredentialSchema` entry `cs`:
 
   - `cs.id`: auto-incremented uint64.
-  - `cs.tr_id`: id of the `TrustRegistry` entry that will be the owner of `cs`.
+  - `cs.ecosystem_id`: id of the `TrustRegistry` entry that will be the owner of `cs`.
   - `cs.json_schema`: `json_schema`, with VPR_CREDENTIAL_SCHEMA_ID string replaced by generated `cs.id`, and then canonicalize it using the [JSON Canonicalization Scheme (JCS)](https://www.rfc-editor.org/rfc/rfc8785) as defined in RFC 8785. Schema MUST be saved canonized.
   - `cs.issuer_grantor_validation_validity_period`: `issuer_grantor_validation_validity_period`
   - `cs.verifier_grantor_validation_validity_period`: `verifier_grantor_validation_validity_period`
@@ -2304,7 +2304,7 @@ If any of these precondition checks fail, method MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST represent an existing `CredentialSchema` entry `cs`.
-- load `TrustRegistry` `tr` from `cs.tr_id`. `tr.corporation` MUST be the `corporation` executing the method, else MUST abort.
+- load `TrustRegistry` `tr` from `cs.ecosystem_id`. `ecosystem.corporation` MUST be the `corporation` executing the method, else MUST abort.
 - `issuer_grantor_validation_validity_period` MUST be between 0 (never expire) and `GlobalVariables.credential_schema_issuer_grantor_validation_validity_period_max_days` days.
 - `verifier_grantor_validation_validity_period` MUST be between 0 (never expire) and `GlobalVariables.credential_schema_verifier_grantor_validation_validity_period_max_days` days.
 - `issuer_validation_validity_period` MUST be between 0 (never expire) and `GlobalVariables.credential_schema_issuer_validation_validity_period_max_days` days.
@@ -2355,7 +2355,7 @@ If any of these precondition checks fail, method MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST represent an existing `CredentialSchema` entry `cs`.
-- load `TrustRegistry` `tr` from `cs.tr_id`. `tr.corporation` MUST be the `corporation` executing the method, else MUST abort.
+- load `TrustRegistry` `tr` from `cs.ecosystem_id`. `ecosystem.corporation` MUST be the `corporation` executing the method, else MUST abort.
 - `archive` (boolean) (*mandatory*) MUST be a boolean. 
   - If `archive` is true and `cs.archived` is not null, MUST abort as Credential Schema is already archived.
   - If `archive` is false and `cs.archived` is null, MUST abort as Credential Schema is already not archived.
@@ -2555,7 +2555,7 @@ Method execution MUST perform the following task in a [[ref: transaction]]:
 
 ##### [MOD-CS-QRY-1-1] List Credential Schemas parameters
 
-- `tr_id` (uint64) (*optional*): to filter by trust registry id.
+- `ecosystem_id` (uint64) (*optional*): to filter by trust registry id.
 - `modified_after` (timestamp) (*optional*): show schemas modified after this timestamp.
 - `response_max_size` (small number) (*optional*): default to 64. Max 1,024.
 - `only_active` (boolean): if set to true, returns only not archived entries.
@@ -2801,7 +2801,7 @@ An Applicant that would like to start a permission validation process MUST execu
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `vs_operator` (account) (*optional*): the account of the Veriable Service we want to authorize to create permission sessions linked to this permission. If not specified, Verifiable Service will not be able to use the payment delegation feature. **Required** to use the payment delegation feature.
 - `type` (PermissionType) (*mandatory*): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the permission that the applicant would like to get;
-- `validator_perm_id` (uint64) (*mandatory*): the [[ref: validator]] permission (parent permission in the tree), chosen by the applicant.
+- `validator_participant_id` (uint64) (*mandatory*): the [[ref: validator]] permission (parent permission in the tree), chosen by the applicant.
 - `validation_fees` (number) (*optional*): Requested validation_fees for this permission (can be modified by validator).
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
 - `verification_fees` (number) (*optional*): Requested verification_fees for this permission (can be modified by validator).
@@ -2841,7 +2841,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `type` (PermissionType) (*mandatory*) MUST be a valid PermissionType: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.
-- `validator_perm_id` (uint64) (*mandatory*): see [MOD-PP-MSG-1-2-2](#mod-pp-msg-1-2-2-start-permission-vp-permission-checks).
+- `validator_participant_id` (uint64) (*mandatory*): see [MOD-PP-MSG-1-2-2](#mod-pp-msg-1-2-2-start-permission-vp-permission-checks).
 - `validation_fees` (number) (*optional*): Requested validation_fees for this permission (can be modified by validator).
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
 - `verification_fees` (number) (*optional*): Requested verification_fees for this permission (can be modified by validator).
@@ -2854,49 +2854,49 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 
 ###### [MOD-PP-MSG-1-2-2] Start Permission VP permission checks
 
-- Load `Permission` entry `validator_perm` from `validator_perm_id`. It MUST be a [[ref: active permission]] else transaction MUST abort.
-- Load `CredentialSchema` entry `cs` from `validator_perm.schema_id`. It MUST exist.
+- Load `Permission` entry `validator_participant` from `validator_participant_id`. It MUST be a [[ref: active permission]] else transaction MUST abort.
+- Load `CredentialSchema` entry `cs` from `validator_participant.schema_id`. It MUST exist.
 
 - if `type` (PermissionType) is equal to ISSUER:
 
-  - if `cs.issuer_onboarding_mode` is equal to GRANTOR_VALIDATION_PROCESS: `validator_perm.type` MUST be ISSUER_GRANTOR, else MUST abort.
+  - if `cs.issuer_onboarding_mode` is equal to GRANTOR_VALIDATION_PROCESS: `validator_participant.role` MUST be ISSUER_GRANTOR, else MUST abort.
   
-  - else if `cs.issuer_onboarding_mode` is equal to ECOSYSTEM_VALIDATION_PROCESS: `validator_perm.type` MUST be ECOSYSTEM, else MUST abort.
+  - else if `cs.issuer_onboarding_mode` is equal to ECOSYSTEM_VALIDATION_PROCESS: `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
 
   - else MUST abort.
 
 - else if `type` (PermissionType) is equal to ISSUER_GRANTOR:
 
-  - if `cs.issuer_onboarding_mode` is equal to GRANTOR_VALIDATION_PROCESS:  `validator_perm.type` MUST be ECOSYSTEM, else MUST abort.
+  - if `cs.issuer_onboarding_mode` is equal to GRANTOR_VALIDATION_PROCESS:  `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
   
   - else abort.
 
 - else if `type` (PermissionType) is equal to VERIFIER:
 
-  - if `cs.verifier_onboarding_mode` is equal to GRANTOR: `validator_perm.type` MUST be VERIFIER_GRANTOR, else MUST abort.
+  - if `cs.verifier_onboarding_mode` is equal to GRANTOR: `validator_participant.role` MUST be VERIFIER_GRANTOR, else MUST abort.
   
-  - else if `cs.verifier_onboarding_mode` is equal to ECOSYSTEM_VALIDATION_PROCESS: `validator_perm.type` MUST be ECOSYSTEM, else MUST abort.
+  - else if `cs.verifier_onboarding_mode` is equal to ECOSYSTEM_VALIDATION_PROCESS: `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
 
   - else abort.
 
 - else if `type` (PermissionType) is equal to VERIFIER_GRANTOR:
 
-  - if `cs.verifier_onboarding_mode` is equal to GRANTOR_VALIDATION_PROCESS: `validator_perm.type` MUST be ECOSYSTEM, else MUST abort.
+  - if `cs.verifier_onboarding_mode` is equal to GRANTOR_VALIDATION_PROCESS: `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
   
   - else abort.
 
 - else if `type` (PermissionType) is equal to HOLDER:
 
-  - if `cs.holder_onboarding_mode` is equal to ISSUER_VALIDATION_PROCESS: `validator_perm.type` MUST be ISSUER, else MUST abort.
+  - if `cs.holder_onboarding_mode` is equal to ISSUER_VALIDATION_PROCESS: `validator_participant.role` MUST be ISSUER, else MUST abort.
   
   - else abort.
 
-At the end, if a [[ ref: active permission]] `validator_perm` is not found, [[ref: transaction]] MUST abort.
+At the end, if a [[ ref: active permission]] `validator_participant` is not found, [[ref: transaction]] MUST abort.
 
 ###### [MOD-PP-MSG-1-2-3] Start Permission VP fee checks
 
-- Load `Permission` entry `validator_perm` from `validator_perm_id`.
-- Load `CredentialSchema` entry `cs` from `validator_perm.schema_id`.
+- Load `Permission` entry `validator_participant` from `validator_participant_id`.
+- Load `CredentialSchema` entry `cs` from `validator_participant.schema_id`.
 
 - Fee payer MUST have an available balance in its [[ref: account]], to cover the [[ref: estimated transaction fees]];
 
@@ -2907,26 +2907,26 @@ At the end, if a [[ ref: active permission]] `validator_perm` is not found, [[re
 if `(cs.pricing_asset_type, cs.pricing_asset)` is set to `(COIN, [[ref: native denom]])`:
 
 - `corporation` MUST have an available balance in its [[ref: account]], to cover the following trust fees.
-  - the required `validation_fees_in_denom` = `validator_perm.validation_fees` in [[ref: native denom]].
+  - the required `validation_fees_in_denom` = `validator_participant.validation_fees` in [[ref: native denom]].
   - the required `validation_trust_deposit_in_native_denom`: `validation_fees_in_denom` * `GlobalVariables.trust_deposit_rate` in [[ref: native denom]].
 
 else if `(cs.pricing_asset_type, cs.pricing_asset)` is set to `(TU, "tu")`:
 
 - `corporation` MUST have an available balance in its [[ref: account]], to cover the following trust fees.
-  - the required `validation_fees_in_denom` = getPrice(`cs.pricing_asset_type`, `cs.pricing_asset`, `COIN`, `[[ref: native denom]]`, `validator_perm.validation_fees`) in [[ref: native denom]];
+  - the required `validation_fees_in_denom` = getPrice(`cs.pricing_asset_type`, `cs.pricing_asset`, `COIN`, `[[ref: native denom]]`, `validator_participant.validation_fees`) in [[ref: native denom]];
   - the required `validation_trust_deposit_in_native_denom`: `validation_fees_in_denom` * `GlobalVariables.trust_deposit_rate` in [[ref: native denom]].
 
 else if `(cs.pricing_asset_type, cs.pricing_asset)` is set to an arbitrary coin `(COIN, [[ref: denom]])`:
 
 - `corporation` MUST have an available balance in its [[ref: account]], to cover the following trust fees.
-  - the required `validation_fees_in_denom` = `validator_perm.validation_fees` in specified (cs.pricing_asset_type, cs.pricing_asset)
+  - the required `validation_fees_in_denom` = `validator_participant.validation_fees` in specified (cs.pricing_asset_type, cs.pricing_asset)
   - the required `validation_trust_deposit_in_native_denom`: getPrice(`cs.pricing_asset_type`, `cs.pricing_asset`, `COIN`, `[[ref: native denom]]`, `validation_fees_in_denom`) * `GlobalVariables.trust_deposit_rate` in [[ref: native denom]].
 
 else if `(cs.pricing_asset_type, cs.pricing_asset)` is set to an arbitrary coin `(FIAT, [[ref: denom]])`:
 
 - `corporation` MUST have an available balance in its [[ref: account]], to cover the following trust fees.
   - the required `validation_fees_in_denom` = 0 in [[ref: native denom]].
-  - the required `validation_trust_deposit_in_native_denom`: getPrice(`cs.pricing_asset_type`, `cs.pricing_asset`, `COIN`, `[[ref: native denom]]`, `validator_perm.validation_fees`) * `GlobalVariables.trust_deposit_rate` in [[ref: native denom]].
+  - the required `validation_trust_deposit_in_native_denom`: getPrice(`cs.pricing_asset_type`, `cs.pricing_asset`, `COIN`, `[[ref: native denom]]`, `validator_participant.validation_fees`) * `GlobalVariables.trust_deposit_rate` in [[ref: native denom]].
 
 :::note
 Trust deposit MUST always be paid in [[ref: native denom]]
@@ -2936,9 +2936,9 @@ Trust deposit MUST always be paid in [[ref: native denom]]
 
 We want to make sure that 2 validation processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different VP with differents validators for the same `schema_id`, `type`.
 
-Find all permission `perms[]` for `schema_id`, `type`, `validator_perm_id`, `corporation` with vp_state = VALIDATED or PENDING.
+Find all permission `participants[]` for `schema_id`, `type`, `validator_participant_id`, `corporation` with vp_state = VALIDATED or PENDING.
 
-if size of `perms[]` > 0, it means there is already an existing validation process in this context, so MUST abort.
+if size of `participants[]` > 0, it means there is already an existing validation process in this context, so MUST abort.
 
 > note: this check was not present in v3.
 
@@ -2948,7 +2948,7 @@ If all precondition checks passed, [[ref: transaction]] is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- Load `Permission` entry `validator_perm` of the selected validator.
+- Load `Permission` entry `validator_participant` of the selected validator.
 
 - calculate `validation_fees_in_denom` and `validation_trust_deposit_in_native_denom` as explained above in fee checks.
 - use [MOD-TD-MSG-1] to increase by `validation_trust_deposit_in_native_denom` the [[ref: trust deposit]] of `corporation` running the method and transfer the corresponding amount to `TrustDeposit` module.
@@ -2956,33 +2956,33 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - define `now`: current timestamp.
 
-- create an persist a new permission entry `applicant_perm`:
+- create an persist a new permission entry `applicant_participant`:
 
-  - `applicant_perm.id`: auto-incremented uint64.
-  - `applicant_perm.schema_id` = `validator_perm.schema_id`
-  - `applicant_perm.corporation`: `corporation`.
-  - `applicant_perm.vs_operator`: `vs_operator`.
-  - `applicant_perm.type`: `type`.
-  - `applicant_perm.created`: `now`
-  - `applicant_perm.modified`: `now`
-  - `applicant_perm.deposit`: `validation_trust_deposit_in_native_denom`.
-  - `applicant_perm.validation_fees`: `validation_fees`.
-  - `applicant_perm.issuance_fees`: `issuance_fees`.
-  - `applicant_perm.verification_fees`: `verification_fees`.
-  - `applicant_perm.validator_perm_id`: `validator_perm_id`.
-  - `applicant_perm.vp_last_state_change`: `now`
-  - `applicant_perm.vp_state`: PENDING.
-  - `applicant_perm.vp_current_fees` (number): `validation_fees_in_denom`.
-  - `applicant_perm.vp_current_deposit` (number): `validation_trust_deposit_in_native_denom`.
-  - `applicant_perm.vp_summary_digest`: null.
-  - `applicant_perm.vp_validator_deposit`: 0.
+  - `applicant_participant.id`: auto-incremented uint64.
+  - `applicant_participant.schema_id` = `validator_participant.schema_id`
+  - `applicant_participant.corporation`: `corporation`.
+  - `applicant_participant.vs_operator`: `vs_operator`.
+  - `applicant_participant.role`: `type`.
+  - `applicant_participant.created`: `now`
+  - `applicant_participant.modified`: `now`
+  - `applicant_participant.deposit`: `validation_trust_deposit_in_native_denom`.
+  - `applicant_participant.validation_fees`: `validation_fees`.
+  - `applicant_participant.issuance_fees`: `issuance_fees`.
+  - `applicant_participant.verification_fees`: `verification_fees`.
+  - `applicant_participant.validator_participant_id`: `validator_participant_id`.
+  - `applicant_participant.vp_last_state_change`: `now`
+  - `applicant_participant.vp_state`: PENDING.
+  - `applicant_participant.vp_current_fees` (number): `validation_fees_in_denom`.
+  - `applicant_participant.vp_current_deposit` (number): `validation_trust_deposit_in_native_denom`.
+  - `applicant_participant.vp_summary_digest`: null.
+  - `applicant_participant.vp_validator_deposit`: 0.
 
 If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizationRecord](#permissionauthorizationrecord) in **disabled** state (`expiration = now`) by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
 
 - `corporation`: `corporation`
 - `vs_operator`: `vs_operator`
 - `record`:
-  - `record.perm_id`: `applicant_perm.id`
+  - `record.participant_id`: `applicant_participant.id`
   - `record.msg_types`: `vs_operator_authz_msg_types`
   - `record.spend_limit`: `vs_operator_authz_spend_limit`
   - `record.fee_spend_limit`: `vs_operator_authz_fee_spend_limit`
@@ -2990,7 +2990,7 @@ If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizatio
   - `record.expiration`: `now`
   - `record.period`: `vs_operator_authz_period`
 
-> Note: the record is created with `expiration = now` so authorization is **not yet active**. [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) will reject any attempt to use it until [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-permission-vp-to-validated) updates `expiration` to `applicant_perm.effective_until`. No on-chain `FeeGrant` object is created at this stage even if `with_feegrant` is true (the recompute subroutine in [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) requires `expiration > now`).
+> Note: the record is created with `expiration = now` so authorization is **not yet active**. [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) will reject any attempt to use it until [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-permission-vp-to-validated) updates `expiration` to `applicant_participant.effective_until`. No on-chain `FeeGrant` object is created at this stage even if `with_feegrant` is true (the recompute subroutine in [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) requires `expiration > now`).
 
 #### Connecting to the VS of the Validator
 
@@ -2998,7 +2998,7 @@ If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizatio
 
 This action must be initiated by the [[ref: applicant]].
 
-During a validation process, if the associated `validator_perm` includes a specific `did`, the [[ref: applicant]] should establish a secure connection with the validator's [[ref: VS]] (Verifiable Service) using a secure communication protocol such as [[ref: DIDComm]].
+During a validation process, if the associated `validator_participant` includes a specific `did`, the [[ref: applicant]] should establish a secure connection with the validator's [[ref: VS]] (Verifiable Service) using a secure communication protocol such as [[ref: DIDComm]].
 
 Upon connecting to the [[ref: VS]], the [[ref: applicant]] should be required by the [[ref: validator]] to complete one or more of the following tasks:
 
@@ -3015,7 +3015,7 @@ Once the [[ref: validator]] determines that the process is complete, they may te
 
 The [[ref: validator]] may compile a summary file of the validation process, documenting exchanged data, proofs, and decisions, and share it with the [[ref: applicant]] via the [[ref: VS]] connection or another secure channel.
 
-For audit or governance purposes, the [[ref: validator]] should register a digest (e.g., hash or SRI) of this summary in `applicant_perm.vp_summary_digest`.
+For audit or governance purposes, the [[ref: validator]] should register a digest (e.g., hash or SRI) of this summary in `applicant_participant.vp_summary_digest`.
 
 #### [MOD-PP-MSG-2] Renew Permission VP
 
@@ -3026,7 +3026,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 - Requesting a renewal has no effect on permission expiration or issued credentials.
 - Renewal is only possible with the same validator.
 - If validator permission is not valid anymore, applicant MUST perform a new validation process with another validator.
-- Renewal does not allow changing the `perm.validation_fees`, `perm.issuance_fees`, `perm.verification_fees`. To change these values, applicant MUST start a new validation process.
+- Renewal does not allow changing the `participant.validation_fees`, `participant.issuance_fees`, `participant.verification_fees`. To change these values, applicant MUST start a new validation process.
 - if permission is revoked, slashed, or repaid, method MUST fail.
 
 ##### [MOD-PP-MSG-2-1] Renew Permission VP parameters
@@ -3050,13 +3050,13 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 ###### [MOD-PP-MSG-2-2-2] Renew Permission VP permission checks
 
-- Load `Permission` entry `applicant_perm`. `corporation` running the operation MUST be `applicant_perm.corporation`, else MUST abort. `applicant_perm` MUST be a [[ref: active permission]].
-- Load `Permission` entry `validator_perm` from `applicant_perm.validator_perm_id`. It MUST exist, and be a [[ref: active permission]], else MUST abort.
+- Load `Permission` entry `applicant_participant`. `corporation` running the operation MUST be `applicant_participant.corporation`, else MUST abort. `applicant_participant` MUST be a [[ref: active permission]].
+- Load `Permission` entry `validator_participant` from `applicant_participant.validator_participant_id`. It MUST exist, and be a [[ref: active permission]], else MUST abort.
 
 ###### [MOD-PP-MSG-2-2-3] Renew Permission VP fee checks
 
-- Load `Permission` entry `validator_perm` from `applicant_perm.validator_perm_id`.
-- Load `CredentialSchema` entry `cs` from `validator_perm.schema_id`.
+- Load `Permission` entry `validator_participant` from `applicant_participant.validator_participant_id`.
+- Load `CredentialSchema` entry `cs` from `validator_participant.schema_id`.
 
 - Fee payer MUST have an available balance in its [[ref: account]], to cover the [[ref: estimated transaction fees]];
 
@@ -3067,26 +3067,26 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 if `(cs.pricing_asset_type, cs.pricing_asset)` is set to `(COIN, [[ref: native denom]])`:
 
 - `corporation` MUST have an available balance in its [[ref: account]], to cover the following trust fees.
-  - the required `validation_fees_in_denom` = `validator_perm.validation_fees` in [[ref: native denom]].
+  - the required `validation_fees_in_denom` = `validator_participant.validation_fees` in [[ref: native denom]].
   - the required `validation_trust_deposit_in_native_denom`: `validation_fees_in_denom` * `GlobalVariables.trust_deposit_rate` in [[ref: native denom]].
 
 else if `(cs.pricing_asset_type, cs.pricing_asset)` is set to `(TU, "tu")`:
 
 - `corporation` MUST have an available balance in its [[ref: account]], to cover the following trust fees.
-  - the required `validation_fees_in_denom` = getPrice(`cs.pricing_asset_type`, `cs.pricing_asset`, `COIN`, `[[ref: native denom]]`, `validator_perm.validation_fees`) in [[ref: native denom]];
+  - the required `validation_fees_in_denom` = getPrice(`cs.pricing_asset_type`, `cs.pricing_asset`, `COIN`, `[[ref: native denom]]`, `validator_participant.validation_fees`) in [[ref: native denom]];
   - the required `validation_trust_deposit_in_native_denom`: `validation_fees_in_denom` * `GlobalVariables.trust_deposit_rate` in [[ref: native denom]].
 
 else if `(cs.pricing_asset_type, cs.pricing_asset)` is set to an arbitrary coin `(COIN, [[ref: denom]])`:
 
 - `corporation` MUST have an available balance in its [[ref: account]], to cover the following trust fees.
-  - the required `validation_fees_in_denom` = `validator_perm.validation_fees` in specified (cs.pricing_asset_type, cs.pricing_asset)
+  - the required `validation_fees_in_denom` = `validator_participant.validation_fees` in specified (cs.pricing_asset_type, cs.pricing_asset)
   - the required `validation_trust_deposit_in_native_denom`: getPrice(`cs.pricing_asset_type`, `cs.pricing_asset`, `COIN`, `[[ref: native denom]]`, `validation_fees_in_denom`) * `GlobalVariables.trust_deposit_rate` in [[ref: native denom]].
 
 else if `(cs.pricing_asset_type, cs.pricing_asset)` is set to an arbitrary coin `(FIAT, [[ref: denom]])`:
 
 - `corporation` MUST have an available balance in its [[ref: account]], to cover the following trust fees.
   - the required `validation_fees_in_denom` = 0 in [[ref: native denom]].
-  - the required `validation_trust_deposit_in_native_denom`: getPrice(`cs.pricing_asset_type`, `cs.pricing_asset`, `COIN`, `[[ref: native denom]]`, `validator_perm.validation_fees`) * `GlobalVariables.trust_deposit_rate` in [[ref: native denom]].
+  - the required `validation_trust_deposit_in_native_denom`: getPrice(`cs.pricing_asset_type`, `cs.pricing_asset`, `COIN`, `[[ref: native denom]]`, `validator_participant.validation_fees`) * `GlobalVariables.trust_deposit_rate` in [[ref: native denom]].
 
 :::note
 Trust deposit MUST always be paid in [[ref: native denom]]
@@ -3098,8 +3098,8 @@ If all precondition checks passed, [[ref: transaction]] is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- Load `Permission` entry `applicant_perm`. 
-- Load `Permission` entry `validator_perm` from `applicant_perm.validator_perm_id`.
+- Load `Permission` entry `applicant_participant`. 
+- Load `Permission` entry `validator_participant` from `applicant_participant.validator_participant_id`.
 
 - calculate `validation_fees_in_denom` and `validation_trust_deposit_in_native_denom` as explained above in fee checks.
 - use [MOD-TD-MSG-1] to increase by `validation_trust_deposit_in_native_denom` the [[ref: trust deposit]] of `corporation` running the method and transfer the corresponding amount to `TrustDeposit` module.
@@ -3109,12 +3109,12 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - update permission entry:
 
-  - `applicant_perm.vp_state`: PENDING.
-  - `applicant_perm.vp_last_state_change`: current timestamp.
-  - `applicant_perm.deposit`: `applicant_perm.deposit` + `validation_trust_deposit_in_native_denom`.
-  - `applicant_perm.vp_current_fees` (number): `validation_fees_in_denom`.
-  - `applicant_perm.vp_current_deposit` (number): `validation_trust_deposit_in_native_denom`.
-  - `applicant_perm.modified`: `now`
+  - `applicant_participant.vp_state`: PENDING.
+  - `applicant_participant.vp_last_state_change`: current timestamp.
+  - `applicant_participant.deposit`: `applicant_participant.deposit` + `validation_trust_deposit_in_native_denom`.
+  - `applicant_participant.vp_current_fees` (number): `validation_fees_in_denom`.
+  - `applicant_participant.vp_current_deposit` (number): `validation_trust_deposit_in_native_denom`.
+  - `applicant_participant.modified`: `now`
 
 #### [MOD-PP-MSG-3] Set Permission VP to Validated
 
@@ -3146,78 +3146,78 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `applicant_perm` from `id`. If no entry found, abort.
-- Load `Permission` entry `validator_perm` from `applicant_perm_validator_perm_id`.
+- Load `Permission` entry `applicant_participant` from `id`. If no entry found, abort.
+- Load `Permission` entry `validator_participant` from `applicant_participant_validator_participant_id`.
 - Authorization:
 
 either (executed by any operator of corporation):
 [[AUTHZ-CHECK-1]](#authz-check-1-operator-authorization-checks) MUST pass for this (`corporation`, `operator`) tuple and `SetPermissionVPtoValidated` message.
 [[AUTHZ-CHECK-2]](#authz-check-2-fee-grant-checks) MUST pass for this (`corporation`, `operator`) tuple and `SetPermissionVPtoValidated` message.
 OR (executed by vs-agent account defined in validator permission):
-[[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) MUST pass for this (`corporation`, `operator`, `validator_perm`) tuple.
-[[AUTHZ-CHECK-4]](#authz-check-4-vs-operator-fee-grant-checks) MUST pass for this (`corporation`, `operator`, `validator_perm`) tuple.
+[[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) MUST pass for this (`corporation`, `operator`, `validator_participant`) tuple.
+[[AUTHZ-CHECK-4]](#authz-check-4-vs-operator-fee-grant-checks) MUST pass for this (`corporation`, `operator`, `validator_participant`) tuple.
 else MUST abort.
 
-- `applicant_perm.vp_state` MUST be equal to PENDING, else abort.
-- `validation_fees` (number) (*mandatory*): MUST be zero or a positive integer. If `applicant_perm.effective_from` is not null (we are in renewal) `validation_fees` MUST be equal to `applicant_perm.validation_fees`, else abort.
-- `issuance_fees` (number) (*mandatory*): MUST be zero or a positive integer.  If `applicant_perm.effective_from` is not null (we are in renewal) `issuance_fees` MUST be equal to `applicant_perm.issuance_fees` or, else abort.
-- `verification_fees` (number) (*mandatory*): MUST be zero or a positive integer.  If `applicant_perm.effective_from` is not null (we are in renewal) `verification_fees` MUST be equal to `applicant_perm.verification_fees`, else abort.
+- `applicant_participant.vp_state` MUST be equal to PENDING, else abort.
+- `validation_fees` (number) (*mandatory*): MUST be zero or a positive integer. If `applicant_participant.effective_from` is not null (we are in renewal) `validation_fees` MUST be equal to `applicant_participant.validation_fees`, else abort.
+- `issuance_fees` (number) (*mandatory*): MUST be zero or a positive integer.  If `applicant_participant.effective_from` is not null (we are in renewal) `issuance_fees` MUST be equal to `applicant_participant.issuance_fees` or, else abort.
+- `verification_fees` (number) (*mandatory*): MUST be zero or a positive integer.  If `applicant_participant.effective_from` is not null (we are in renewal) `verification_fees` MUST be equal to `applicant_participant.verification_fees`, else abort.
 - `vp_summary_digest` (string) (*optional*): MUST be null if `validation.type` is set to HOLDER (for HOLDER, proofs can be stored in credentials). Else, MUST be a valid digest. Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
 
-- Load `CredentialSchema` `cs` from `applicant_perm.schema_id`.
-- Load `Permission` `validator_perm` from `applicant_perm.validator_perm_id`.
+- Load `CredentialSchema` `cs` from `applicant_participant.schema_id`.
+- Load `Permission` `validator_participant` from `applicant_participant.validator_participant_id`.
 
 - `issuance_fee_discount` : (number) (*mandatory*):
-  - if `applicant_perm.effective_from` is not null (renewal), then `issuance_fee_discount` must be equal to `applicant_perm.issuance_fee_discount` else MUST abort.
+  - if `applicant_participant.effective_from` is not null (renewal), then `issuance_fee_discount` must be equal to `applicant_participant.issuance_fee_discount` else MUST abort.
   - if `cs.issuer_onboarding_mode` is set to GRANTOR_VALIDATION_PROCESS:
-    - if `applicant_perm.type` == ISSUER_GRANTOR: `issuance_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
-    - if `applicant_perm.type` == ISSUER: if `validator_perm.issuance_fee_discount` is defined,  `issuance_fee_discount` can be set between 0 (no discount) and `validator_perm.issuance_fee_discount` (100% discount) inclusive.
+    - if `applicant_participant.role` == ISSUER_GRANTOR: `issuance_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
+    - if `applicant_participant.role` == ISSUER: if `validator_participant.issuance_fee_discount` is defined,  `issuance_fee_discount` can be set between 0 (no discount) and `validator_participant.issuance_fee_discount` (100% discount) inclusive.
   - if `cs.issuer_onboarding_mode` is set to ECOSYSTEM_VALIDATION_PROCESS:
-    - if `applicant_perm.type` == ISSUER: `issuance_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
+    - if `applicant_participant.role` == ISSUER: `issuance_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
   - else MUST abort.
 
 - `verification_fee_discount` : (number) (*mandatory*):
-  - if `applicant_perm.effective_from` is not null (renewal), then `verification_fee_discount` must be equal to `applicant_perm.verification_fee_discount` else MUST abort.
+  - if `applicant_participant.effective_from` is not null (renewal), then `verification_fee_discount` must be equal to `applicant_participant.verification_fee_discount` else MUST abort.
   - if `cs.verifier_onboarding_mode` is set to GRANTOR_VALIDATION_PROCESS:
-    - if `applicant_perm.type` == VERIFIER_GRANTOR: `verification_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
-    - if `applicant_perm.type` == VERIFIER: if `validator_perm.verification_fee_discount` is defined,  `verification_fee_discount` can be set between 0 (no discount) and `validator_perm.verification_fee_discount` (100% discount) inclusive.
+    - if `applicant_participant.role` == VERIFIER_GRANTOR: `verification_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
+    - if `applicant_participant.role` == VERIFIER: if `validator_participant.verification_fee_discount` is defined,  `verification_fee_discount` can be set between 0 (no discount) and `validator_participant.verification_fee_discount` (100% discount) inclusive.
   - if `cs.verifier_onboarding_mode` is set to ECOSYSTEM_VALIDATION_PROCESS:
-    - if `applicant_perm.type` == VERIFIER: `verification_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
+    - if `applicant_participant.role` == VERIFIER: `verification_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
   - else MUST abort.
 
 Calculation of `vp_exp`, the validation process expiration timestamp, required to verify provided `effective_until`:
 
-- let's define `validity_period` = `cs.issuer_grantor_validation_validity_period` (if `applicant_perm.type` is ISSUER_GRANTOR), `cs.verifier_grantor_validation_validity_period` (if `applicant_perm.type` is VERIFIER_GRANTOR), `cs.issuer_validation_validity_period` (if `applicant_perm.type` is ISSUER), `cs.verifier_validation_validity_period` (if `applicant_perm.type` is VERIFIER), or `cs.holder_validation_validity_period` (if `applicant_perm.type` is HOLDER).
+- let's define `validity_period` = `cs.issuer_grantor_validation_validity_period` (if `applicant_participant.role` is ISSUER_GRANTOR), `cs.verifier_grantor_validation_validity_period` (if `applicant_participant.role` is VERIFIER_GRANTOR), `cs.issuer_validation_validity_period` (if `applicant_participant.role` is ISSUER), `cs.verifier_validation_validity_period` (if `applicant_participant.role` is VERIFIER), or `cs.holder_validation_validity_period` (if `applicant_participant.role` is HOLDER).
 
 - if `validity_period` is NULL:  `vp_exp` = NULL.
-- else if `applicant_perm.vp_exp` is null, `vp_exp` =  timestamp of now() plus `validity_period`.
-- else `vp_exp` =  `applicant_perm.vp_exp` plus `validity_period`
+- else if `applicant_participant.vp_exp` is null, `vp_exp` =  timestamp of now() plus `validity_period`.
+- else `vp_exp` =  `applicant_participant.vp_exp` plus `validity_period`
 
 Now, let's verify `effective_until`:
 
 - if `effective_until` is NULL, no issue.
-- else if `applicant_perm.effective_until` is NULL, `effective_until` MUST be greater than current current timestamp AND, if `vp_exp` is not null, lower or equal to `vp_exp`.
-- else `effective_until` MUST be greater than `applicant_perm.effective_until` AND, if `vp_exp` is not null, lower or equal to `vp_exp`.
+- else if `applicant_participant.effective_until` is NULL, `effective_until` MUST be greater than current current timestamp AND, if `vp_exp` is not null, lower or equal to `vp_exp`.
+- else `effective_until` MUST be greater than `applicant_participant.effective_until` AND, if `vp_exp` is not null, lower or equal to `vp_exp`.
 
 ###### [MOD-PP-MSG-3-2-2] Set Permission VP to Validated validator perms
 
-- load `validator_perm` from `applicant_perm.validator_perm_id`. `validator_perm` MUST be a [[ref: active permission]].
-- `corporation` running the method MUST be `validator_perm.corporation`.
+- load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active permission]].
+- `corporation` running the method MUST be `validator_participant.corporation`.
 
-If `validator_perm` is not a [[ ref: active permission]] (expired, revoked, slashed...) then applicant MUST start a new validation process.
+If `validator_participant` is not a [[ ref: active permission]] (expired, revoked, slashed...) then applicant MUST start a new validation process.
 
 ###### [MOD-PP-MSG-3-2-3] Set Permission VP to Validated fee checks
 
 - Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
-- if `applicant_perm.vp_current_fees` is not in [[ref: native denom]], `corporation` account MUST have `applicant_perm.vp_current_deposit` available in [[ref: native denom]] on its account for paying the trust deposit.
+- if `applicant_participant.vp_current_fees` is not in [[ref: native denom]], `corporation` account MUST have `applicant_participant.vp_current_deposit` available in [[ref: native denom]] on its account for paying the trust deposit.
 
 ###### [MOD-PP-MSG-3-2-4] Set Permission VP to Validated overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time for the same `validator_perm_id`. That should not occur in this method, but better do the check anyway.
+We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. That should not occur in this method, but better do the check anyway.
 
-Find all [[ref: active permissions]] `perms[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_perm_id`, `corporation`.
+Find all [[ref: active permissions]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_participant_id`, `corporation`.
 
-for each `Permission` entry `p` from `perms[]`:
+for each `Permission` entry `p` from `participants[]`:
 
 - if `p.effective_until` is greater than `effective_from`, method execution MUST abort.
 - if `p.effective_from` is lower than `effective_until`, method execution MUST abort.
@@ -3231,63 +3231,63 @@ If all precondition checks passed, [[ref: transaction]] is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- Load `Permission` entry `applicant_perm` from `id`.
-- Load `Permission` entry `validator_perm` from `applicant_perm.validator_perm_id`.
+- Load `Permission` entry `applicant_participant` from `id`.
+- Load `Permission` entry `validator_participant` from `applicant_participant.validator_participant_id`.
 - define `now` timestamp of now().
 
 Calculate `vp_exp`:
 
-- Load `CredentialSchema` `cs` from `applicant_perm.schema_id`.
-- let's define `validity_period` = `cs.issuer_grantor_validation_validity_period` (if `applicant_perm.type` is ISSUER_GRANTOR), `cs.verifier_grantor_validation_validity_period` (if `applicant_perm.type` is VERIFIER_GRANTOR), `cs.issuer_validation_validity_period` (if `applicant_perm.type` is ISSUER), `cs.verifier_validation_validity_period` (if `applicant_perm.type` is VERIFIER), or `cs.holder_validation_validity_period` (if `applicant_perm.type` is HOLDER).
+- Load `CredentialSchema` `cs` from `applicant_participant.schema_id`.
+- let's define `validity_period` = `cs.issuer_grantor_validation_validity_period` (if `applicant_participant.role` is ISSUER_GRANTOR), `cs.verifier_grantor_validation_validity_period` (if `applicant_participant.role` is VERIFIER_GRANTOR), `cs.issuer_validation_validity_period` (if `applicant_participant.role` is ISSUER), `cs.verifier_validation_validity_period` (if `applicant_participant.role` is VERIFIER), or `cs.holder_validation_validity_period` (if `applicant_participant.role` is HOLDER).
 
 - if `validity_period` is NULL:  `vp_exp` = NULL.
-- else if `applicant_perm.vp_exp` is null, `vp_exp` =  timestamp of now() plus `validity_period`.
-- else `vp_exp` =  `applicant_perm.vp_exp` plus `validity_period`.
+- else if `applicant_participant.vp_exp` is null, `vp_exp` =  timestamp of now() plus `validity_period`.
+- else `vp_exp` =  `applicant_participant.vp_exp` plus `validity_period`.
 
 Change value of provided `effective_until` if needed, and abort if needed:
 
 - if provided  `effective_until` is NULL:
   - change value of provided `effective_until` to `vp_exp`.
 
-- else if `applicant_perm.effective_until` is NULL:
+- else if `applicant_participant.effective_until` is NULL:
   - verify that provided `effective_until` is greater than `now` else MUST abort
   - if `vp_exp` is not null, verify that provided `effective_until` is lower or equal to `vp_exp` else MUST abort
 
 - else:
-  - `effective_until` MUST be greater than `applicant_perm.effective_until` else MUST abort
+  - `effective_until` MUST be greater than `applicant_participant.effective_until` else MUST abort
   - if `vp_exp` is not null, verify that provided `effective_until` is lower or equal to `vp_exp` else MUST abort.
 
 Fees and Trust Deposits:
 
-- transfer the full amount `applicant_perm.vp_current_fees` in the proper [[ref: denom]] from escrow [[ref: account]] to validator `corporation` [[ref: account]] `validator_perm.corporation`;
-- Increase validator perm trust deposit: use [MOD-TD-MSG-1] to increase by `applicant_perm.vp_current_deposit` the [[ref: trust deposit]] of `corporation` running the method and transfer the corresponding amount to `TrustDeposit` module. Set `applicant_perm.vp_validator_deposit` to `applicant_perm.vp_validator_deposit` + `applicant_perm.vp_current_deposit`.
+- transfer the full amount `applicant_participant.vp_current_fees` in the proper [[ref: denom]] from escrow [[ref: account]] to validator `corporation` [[ref: account]] `validator_participant.corporation`;
+- Increase validator perm trust deposit: use [MOD-TD-MSG-1] to increase by `applicant_participant.vp_current_deposit` the [[ref: trust deposit]] of `corporation` running the method and transfer the corresponding amount to `TrustDeposit` module. Set `applicant_participant.vp_validator_deposit` to `applicant_participant.vp_validator_deposit` + `applicant_participant.vp_current_deposit`.
 
-> Important: if `applicant_perm.vp_current_fees` is not in [[ref: native denom]], `corporation` account MUST have `applicant_perm.vp_current_deposit` available for paying the trust deposit.
+> Important: if `applicant_participant.vp_current_fees` is not in [[ref: native denom]], `corporation` account MUST have `applicant_participant.vp_current_deposit` available for paying the trust deposit.
 
-Update `Permission` `applicant_perm`:
+Update `Permission` `applicant_participant`:
 
-- set `applicant_perm.modified` to `now`.
-- set `applicant_perm.vp_state` to VALIDATED.
-- set `applicant_perm.vp_last_state_change` to `now`.
-- set `applicant_perm.vp_current_fees` to 0;
-- set `applicant_perm.vp_current_deposit` to 0;
-- set `applicant_perm.vp_summary_digest` to `vp_summary_digest`.
-- set `applicant_perm.vp_exp` to `vp_exp`.
-- set `applicant_perm.effective_until` to `effective_until`.
-- if `applicant_perm.effective_from` IS NULL (first time method is called for this perm, and thus we are not in a renewal):
-  - set `applicant_perm.validation_fees` to `validation_fees`;
-  - set `applicant_perm.issuance_fees` to `issuance_fees`;
-  - set `applicant_perm.verification_fees` to `verification_fees`;
-  - set `applicant_perm.effective_from` to `now`.
-  - set `applicant_perm.issuance_fee_discount` to `issuance_fee_discount`.
-  - set `applicant_perm.verification_fee_discount` to `verification_fee_discount`.
+- set `applicant_participant.modified` to `now`.
+- set `applicant_participant.vp_state` to VALIDATED.
+- set `applicant_participant.vp_last_state_change` to `now`.
+- set `applicant_participant.vp_current_fees` to 0;
+- set `applicant_participant.vp_current_deposit` to 0;
+- set `applicant_participant.vp_summary_digest` to `vp_summary_digest`.
+- set `applicant_participant.vp_exp` to `vp_exp`.
+- set `applicant_participant.effective_until` to `effective_until`.
+- if `applicant_participant.effective_from` IS NULL (first time method is called for this perm, and thus we are not in a renewal):
+  - set `applicant_participant.validation_fees` to `validation_fees`;
+  - set `applicant_participant.issuance_fees` to `issuance_fees`;
+  - set `applicant_participant.verification_fees` to `verification_fees`;
+  - set `applicant_participant.effective_from` to `now`.
+  - set `applicant_participant.issuance_fee_discount` to `issuance_fee_discount`.
+  - set `applicant_participant.verification_fee_discount` to `verification_fee_discount`.
 
 Activate VS Operator Authorization, if any. Call [[MOD-DE-MSG-9]](#mod-de-msg-9-update-vs-operator-authorization-expiration) Update VS Operator Authorization Expiration with:
 
-- `perm_id`: `applicant_perm.id`
-- `new_expiration`: `applicant_perm.effective_until`
+- `participant_id`: `applicant_participant.id`
+- `new_expiration`: `applicant_participant.effective_until`
 
-This call is a no-op if no record was created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) (i.e., the applicant did not declare `vs_operator_authz_msg_types`). If a record exists, its `expiration` is updated from `now` (disabled) to `applicant_perm.effective_until`, and the on-chain `FeeGrant` for the containing VSOA is granted for the first time (or refreshed) via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance).
+This call is a no-op if no record was created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) (i.e., the applicant did not declare `vs_operator_authz_msg_types`). If a record exists, its `expiration` is updated from `now` (disabled) to `applicant_participant.effective_until`, and the on-chain `FeeGrant` for the containing VSOA is granted for the first time (or refreshed) via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance).
 
 #### [MOD-PP-MSG-4] Void
 
@@ -3317,10 +3317,10 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `applicant_perm` with this id. It MUST exist.
-- `corporation` running the [[ref: transaction]] MUST be `applicant_perm.corporation`.
-- `applicant_perm.vp_state` MUST be PENDING.
-- if `applicant_perm.deposit` has been slashed and not repaid, MUST abort
+- Load `Permission` entry `applicant_participant` with this id. It MUST exist.
+- `corporation` running the [[ref: transaction]] MUST be `applicant_participant.corporation`.
+- `applicant_participant.vp_state` MUST be PENDING.
+- if `applicant_participant.deposit` has been slashed and not repaid, MUST abort
 
 ###### [MOD-PP-MSG-6-2-2] Cancel Permission VP Last Request fee checks
 
@@ -3332,21 +3332,21 @@ If all precondition checks passed, [[ref: transaction]] is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- Load `Permission` entry `applicant_perm` with `id`. It MUST exist.
+- Load `Permission` entry `applicant_participant` with `id`. It MUST exist.
 - define `now`: current timestamp.
 
-- set `applicant_perm.modified` to `now`.
-- if `applicant_perm.vp_exp` is null (validation never completed), set `applicant_perm.vp_state` to TERMINATED, else set `applicant_perm.vp_state` to VALIDATED.
-- set `applicant_perm.vp_last_state_change` to `now`.
-- if `applicant_perm.vp_current_fees` > 0:
-  - transfer `applicant_perm.vp_current_fees` in proper [[ref: denom]] back from escrow [[ref: account]] to [[ref: applicant]] [[ref: account]], `applicant_perm.corporation`.
-  - set `applicant_perm.vp_current_fees` to 0;
+- set `applicant_participant.modified` to `now`.
+- if `applicant_participant.vp_exp` is null (validation never completed), set `applicant_participant.vp_state` to TERMINATED, else set `applicant_participant.vp_state` to VALIDATED.
+- set `applicant_participant.vp_last_state_change` to `now`.
+- if `applicant_participant.vp_current_fees` > 0:
+  - transfer `applicant_participant.vp_current_fees` in proper [[ref: denom]] back from escrow [[ref: account]] to [[ref: applicant]] [[ref: account]], `applicant_participant.corporation`.
+  - set `applicant_participant.vp_current_fees` to 0;
 
-- if `applicant_perm.vp_current_deposit` > 0:
-  - call [MOD-TD-MSG-1] to reduce trust deposit of `applicant_perm.corporation` by `applicant_perm.vp_current_deposit`
-  - set `applicant_perm.vp_current_deposit` to 0.
+- if `applicant_participant.vp_current_deposit` > 0:
+  - call [MOD-TD-MSG-1] to reduce trust deposit of `applicant_participant.corporation` by `applicant_participant.vp_current_deposit`
+  - set `applicant_participant.vp_current_deposit` to 0.
 
-If `applicant_perm.vp_state` was set to TERMINATED (i.e. `applicant_perm.vp_exp` was null so validation never completed), call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `perm_id = applicant_perm.id` to remove any disabled authorization record created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp). The call is a no-op if no record exists. If `applicant_perm.vp_state` was set back to VALIDATED, no VSOA changes are needed (the existing record's `expiration` remains at the value set by the previous successful validation).
+If `applicant_participant.vp_state` was set to TERMINATED (i.e. `applicant_participant.vp_exp` was null so validation never completed), call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any disabled authorization record created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp). The call is a no-op if no record exists. If `applicant_participant.vp_state` was set back to VALIDATED, no VSOA changes are needed (the existing record's `expiration` remains at the value set by the previous successful validation).
 
 #### [MOD-PP-MSG-7] Create Root Permission
 
@@ -3408,8 +3408,8 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 To execute this method, [[ref: account]] MUST match at least one these rules, else [[ref: transaction]] MUST abort.
 
 - The related `CredentialSchema` entry is loaded with `schema_id`, and will be named `cs` in this section.
-- The related `TrustRegistry` entry `tr` is loaded from `cs.tr_id`.
-- `corporation` executing the method MUST be `tr.corporation`.
+- The related `TrustRegistry` entry `tr` is loaded from `cs.ecosystem_id`.
+- `corporation` executing the method MUST be `ecosystem.corporation`.
 - else MUST abort.
 
 ###### [MOD-PP-MSG-7-2-3] Create Root Permission fee checks
@@ -3420,11 +3420,11 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
 We want to make sure that 2 permissions cannot be active at the same time. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-permission) to set or adjust the `effective_until` value.
 
-Find all [[ref: active permissions]] `perms[]` (not revoked, not slashed, not repaid) for `schema_id`, ECOSYSTEM,  `corporation`.
+Find all [[ref: active permissions]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, ECOSYSTEM,  `corporation`.
 
-> Note: unlike overlap checks from other methods, here we do not need to check for `validator_perm_id`, as for ECOSYSTEM type permissions it is NULL.
+> Note: unlike overlap checks from other methods, here we do not need to check for `validator_participant_id`, as for ECOSYSTEM type permissions it is NULL.
 
-for each `Permission` entry `p` from `perms[]`:
+for each `Permission` entry `p` from `participants[]`:
 
 - if `p.effective_until` is greater than `effective_from`, method execution MUST abort.
 - if `p.effective_from` is lower than `effective_until`, method execution MUST abort.
@@ -3442,35 +3442,35 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 A new entry `Permission` `perm` MUST be created:
 
-- `perm.id`: auto-incremented uint64.
-- `perm.schema_id`: `schema_id`.
-- `perm.modified` to `now`.
-- `perm.type`: ECOSYSTEM.
-- `perm.did`: `did`.
-- `perm.corporation`: `corporation`.
-- `perm.vs_operator`: `vs_operator`.
-- `perm.created`: `now`
-- `perm.effective_from`: `effective_from`
-- `perm.effective_until`: `effective_until`
-- `perm.validation_fees`: `validation_fees`
-- `perm.issuance_fees`: `issuance_fees`
-- `perm.verification_fees`: `verification_fees`
-- `perm.deposit`: 0
+- `participant.id`: auto-incremented uint64.
+- `participant.schema_id`: `schema_id`.
+- `participant.modified` to `now`.
+- `participant.role`: ECOSYSTEM.
+- `participant.did`: `did`.
+- `participant.corporation`: `corporation`.
+- `participant.vs_operator`: `vs_operator`.
+- `participant.created`: `now`
+- `participant.effective_from`: `effective_from`
+- `participant.effective_until`: `effective_until`
+- `participant.validation_fees`: `validation_fees`
+- `participant.issuance_fees`: `issuance_fees`
+- `participant.verification_fees`: `verification_fees`
+- `participant.deposit`: 0
 
 If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizationRecord](#permissionauthorizationrecord) in **active** state by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
 
 - `corporation`: `corporation`
 - `vs_operator`: `vs_operator`
 - `record`:
-  - `record.perm_id`: `perm.id`
+  - `record.participant_id`: `participant.id`
   - `record.msg_types`: `vs_operator_authz_msg_types`
   - `record.spend_limit`: `vs_operator_authz_spend_limit`
   - `record.fee_spend_limit`: `vs_operator_authz_fee_spend_limit`
   - `record.with_feegrant`: `vs_operator_authz_with_feegrant` (default: false)
-  - `record.expiration`: `perm.effective_until`
+  - `record.expiration`: `participant.effective_until`
   - `record.period`: `vs_operator_authz_period`
 
-> Note: like [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission), the record is created with `expiration = perm.effective_until` and is therefore immediately active. If `with_feegrant` is true and `perm.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
+> Note: like [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission), the record is created with `expiration = participant.effective_until` and is therefore immediately active. If `with_feegrant` is true and `participant.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
 
 #### [MOD-PP-MSG-8] Adjust Permission
 
@@ -3478,8 +3478,8 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 This method can be called:
 
-- by `perm.corporation`, if permission is of type ECOSYSTEM.
-- by `perm.corporation`, if it is a self-created permission (schema configuration is open)
+- by `participant.corporation`, if permission is of type ECOSYSTEM.
+- by `participant.corporation`, if it is a self-created permission (schema configuration is open)
 - by a `corporation` of a validator permission (if permission is managed by a VP).
 
 ##### [MOD-PP-MSG-8-1] Adjust Permission parameters
@@ -3501,9 +3501,9 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `applicant_perm` from `id`. If no entry found, abort.
-- `applicant_perm` MUST be a [[ref: active permission]]
-- `applicant_perm.effective_until` MUST be greater than now().
+- Load `Permission` entry `applicant_participant` from `id`. If no entry found, abort.
+- `applicant_participant` MUST be a [[ref: active permission]]
+- `applicant_participant.effective_until` MUST be greater than now().
 - else MUST abort.
 
 > Note: This method can be used to both Extend or Reduce the `effective_until`, or set an `effective_until` if it was null,  which was not the case in spec v3.
@@ -3512,16 +3512,16 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 1. ECOSYSTEM permissions
 
-- if `applicant_perm.validator_perm_id` is null and `applicant_perm.type` is ECOSYSTEM, `corporation` running the method MUST be `applicant_perm.corporation`.
+- if `applicant_participant.validator_participant_id` is null and `applicant_participant.role` is ECOSYSTEM, `corporation` running the method MUST be `applicant_participant.corporation`.
 
 2. Self-created permissions
 
-- load `validator_perm` from `applicant_perm.validator_perm_id`. `validator_perm` MUST be a [[ref: active permission]] of type ECOSYSTEM. `corporation` running the method MUST be `applicant_perm.corporation`.
+- load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active permission]] of type ECOSYSTEM. `corporation` running the method MUST be `applicant_participant.corporation`.
 
 3. VP managed permissions
 
-- `effective_until` MUST be lower or equal to `applicant_perm.vp_exp` else MUST abort.
-- load `validator_perm` from `applicant_perm.validator_perm_id`. `validator_perm` MUST be a [[ref: active permission]]. `corporation` running the method MUST be `validator_perm.corporation`.
+- `effective_until` MUST be lower or equal to `applicant_participant.vp_exp` else MUST abort.
+- load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active permission]]. `corporation` running the method MUST be `validator_participant.corporation`.
 
 ###### [MOD-PP-MSG-8-2-3] Adjust Permission fee checks
 
@@ -3529,11 +3529,11 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[re
 
 ###### [MOD-PP-MSG-8-2-4] Adjust Permission overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time for the same `validator_perm_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-permission) to set or adjust the `effective_until` value.
+We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-permission) to set or adjust the `effective_until` value.
 
-Find all [[ref: active permissions]] `perms[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_perm_id`, `corporation`.
+Find all [[ref: active permissions]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_participant_id`, `corporation`.
 
-for each `Permission` entry `p` from `perms[]`:
+for each `Permission` entry `p` from `participants[]`:
 
 - if `p.effective_until` is greater than `effective_from`, method execution MUST abort.
 - if `p.effective_from` is lower than `effective_until`, method execution MUST abort.
@@ -3549,18 +3549,18 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - define `now`: current timestamp.
 
-- Load `Permission` entry `applicant_perm` from `id`.
-- set `applicant_perm.effective_until` to `effective_until`
-- set `applicant_perm.adjusted` to `now`
-- set `applicant_perm.modified` to `now`
+- Load `Permission` entry `applicant_participant` from `id`.
+- set `applicant_participant.effective_until` to `effective_until`
+- set `applicant_participant.adjusted` to `now`
+- set `applicant_participant.modified` to `now`
 
 
 Synchronise VS Operator Authorization expiration, if any. Call [[MOD-DE-MSG-9]](#mod-de-msg-9-update-vs-operator-authorization-expiration) Update VS Operator Authorization Expiration with:
 
-- `perm_id`: `applicant_perm.id`
-- `new_expiration`: `applicant_perm.effective_until`
+- `participant_id`: `applicant_participant.id`
+- `new_expiration`: `applicant_participant.effective_until`
 
-This call is a no-op if no record exists for `applicant_perm.id`. If a record exists, its `expiration` is updated and the on-chain `FeeGrant` for the containing VSOA is refreshed via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance). Adjust Permission does **not** accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission)). Adjust also cannot create a record that does not already exist.
+This call is a no-op if no record exists for `applicant_participant.id`. If a record exists, its `expiration` is updated and the on-chain `FeeGrant` for the containing VSOA is refreshed via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance). Adjust Permission does **not** accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission)). Adjust also cannot create a record that does not already exist.
 
 #### [MOD-PP-MSG-9] Revoke Permission
 
@@ -3590,8 +3590,8 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `applicant_perm` from `id`. If no entry found, abort.
-- `applicant_perm` MUST be a [[ref: active permission]]
+- Load `Permission` entry `applicant_participant` from `id`. If no entry found, abort.
+- `applicant_participant` MUST be a [[ref: active permission]]
 
 ###### [MOD-PP-MSG-9-2-2] Revoke Permission advanced checks
 
@@ -3599,23 +3599,23 @@ Either Option #1, #2 or #3 MUST return true, else abort.
 
 *Option #1*: executed by a validator ancestor
 
-if `applicant_perm.validator_perm_id` is defined:
+if `applicant_participant.validator_participant_id` is defined:
 
-- set `validator_perm` = `applicant_perm`
-- while `validator_perm.validator_perm_id` is defined, 
-  - load `validator_perm` from `validator_perm.validator_perm_id`.
-  - if `validator_perm` is a [[ref: active permission]] and `validator_perm.corporation` is who is running the method, => return true.
+- set `validator_participant` = `applicant_participant`
+- while `validator_participant.validator_participant_id` is defined, 
+  - load `validator_participant` from `validator_participant.validator_participant_id`.
+  - if `validator_participant` is a [[ref: active permission]] and `validator_participant.corporation` is who is running the method, => return true.
 - end
 - return false.
 
 *Option #2*: executed by `TrustRegistry` controller
 
-- load `CredentialSchema` `cs` from `applicant_perm.schema_id`
-- load `TrustRegistry` `tr` from `cs.tr_id`
-- if `corporation` running the method is `tr.corporation`, return true.
+- load `CredentialSchema` `cs` from `applicant_participant.schema_id`
+- load `TrustRegistry` `tr` from `cs.ecosystem_id`
+- if `corporation` running the method is `ecosystem.corporation`, return true.
 - else return false.
 
-*Option #3*: executed by `applicant_perm.corporation`: return true.
+*Option #3*: executed by `applicant_participant.corporation`: return true.
 
 Example:
 
@@ -3685,11 +3685,11 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - define `now`: current timestamp.
 
-- Load `Permission` entry `applicant_perm` from `id`.
-- set `applicant_perm.revoked` to `now`
-- set `applicant_perm.modified` to `now`
+- Load `Permission` entry `applicant_participant` from `id`.
+- set `applicant_participant.revoked` to `now`
+- set `applicant_participant.modified` to `now`
 
-Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `perm_id = applicant_perm.id` to remove any authorization record for this permission. The call is a no-op if no record exists.
+Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any authorization record for this permission. The call is a no-op if no record exists.
 
 #### [MOD-PP-MSG-10] Create or Update Permission Session
 
@@ -3700,16 +3700,16 @@ Any credential exchange that requires issuer or verifier to pay fees, register a
 If the peer wants to issue a credential, the `agent`, the Verifiable User Agent or Verifiable Service that receive the request MUST send to peer:
 
 - a `uuid` for session identification;
-- *optional*: the `agent_perm_id` permission id of the agent that will receive the credential, if peer is a **Verifiable User Agent**. it MUST NOT be set if peer is a **Verifiable Service**.
-- *optional*: the `wallet_agent_perm_id` permission id of the agent wallet that will store the credential. If this is the same software than the agent, then it should be equal to `agent_perm_id`. It MUST NOT be set if peer is a **Verifiable Service**.
+- *optional*: the `agent_participant_id` permission id of the agent that will receive the credential, if peer is a **Verifiable User Agent**. it MUST NOT be set if peer is a **Verifiable Service**.
+- *optional*: the `wallet_agent_participant_id` permission id of the agent wallet that will store the credential. If this is the same software than the agent, then it should be equal to `agent_participant_id`. It MUST NOT be set if peer is a **Verifiable Service**.
 
 If the peer wants to verify a credential, agent must send to peer:
 
 - a `uuid` for session identification;
-- *optional*: the `agent_perm_id` permission id of the agent that will receive the credential, if peer is a **Verifiable User Agent**. it MUST NOT be set if peer is a **Verifiable Service**.
-- *optional*: a map of compatible found credentials in available wallets for the requested schema_id: Map<uint64[] issuer_perm_ids, uint64: wallet_agent_perm_id>. wallet_agent_perm_id MUST NOT be set if peer is a **Verifiable Service**.
+- *optional*: the `agent_participant_id` permission id of the agent that will receive the credential, if peer is a **Verifiable User Agent**. it MUST NOT be set if peer is a **Verifiable Service**.
+- *optional*: a map of compatible found credentials in available wallets for the requested schema_id: Map<uint64[] issuer_participant_ids, uint64: wallet_agent_participant_id>. wallet_agent_participant_id MUST NOT be set if peer is a **Verifiable Service**.
 
-In case peer is a **Verifiable Service** and illegaly set `agent_perm_id` and/or `wallet_agent_perm_id`, the other end MUST refuse the request.
+In case peer is a **Verifiable Service** and illegaly set `agent_participant_id` and/or `wallet_agent_participant_id`, the other end MUST refuse the request.
 
 `payer` MUST create a Permission Session using the above information, then, `agent` MUST check session has been created and is valid before accepting the action (receive and store issued credential, or accept a presentation request).
 
@@ -3721,7 +3721,7 @@ participant "VPR" as vpr
 
 
 Issued <-- Issuer: I want to issue a credential from schema id ... to you
-Issued --> Issuer: Here is the session uuid and the wallet_agent_perm_id
+Issued --> Issuer: Here is the session uuid and the wallet_agent_participant_id
 Issuer --> vpr: create session
 Issued <-- Issuer: session created, you can verify
 Issued --> vpr: getSession(uuid)
@@ -3741,10 +3741,10 @@ An [[ref: account]] that would like to create or update a `PermissionSession` en
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uuid) (*mandatory*): id of the `PermissionSession`.
-- `issuer_perm_id` (uint64) (*optional*): the id of the perm of the issuer, if we are dealing with the issuance of a credential.
-- `verifier_perm_id` (uint64) (*optional*): the id of the perm of the verifier, if we are dealing with the verification of a credential.
-- `agent_perm_id` (uint64) (*optional*): the agent credential issuer permission id (extracted from the agent credential that VUA has in its wallet) of the agent that received the request (credential offer for issuance, presentation request for verification). Only set by VUAs, MUST NOT be specified when peer is a VS.
-- `wallet_agent_perm_id` (uint64) (*optional*): the wallet credential issuer permission id of the VUA where the credential will be or is stored. Can be the same perm than `agent_perm_id` if agent and wallet_agent are the same agent. Only set by VUAs, MUST NOT be specified when peer is a VS.
+- `issuer_participant_id` (uint64) (*optional*): the id of the perm of the issuer, if we are dealing with the issuance of a credential.
+- `verifier_participant_id` (uint64) (*optional*): the id of the perm of the verifier, if we are dealing with the verification of a credential.
+- `agent_participant_id` (uint64) (*optional*): the agent credential issuer permission id (extracted from the agent credential that VUA has in its wallet) of the agent that received the request (credential offer for issuance, presentation request for verification). Only set by VUAs, MUST NOT be specified when peer is a VS.
+- `wallet_agent_participant_id` (uint64) (*optional*): the wallet credential issuer permission id of the VUA where the credential will be or is stored. Can be the same perm than `agent_participant_id` if agent and wallet_agent are the same agent. Only set by VUAs, MUST NOT be specified when peer is a VS.
 - `digest` (string) (*optional*): digest derived from an issued or verified credential.
 
 ##### [MOD-PP-MSG-10-2] Create or Update Permission Session precondition checks
@@ -3755,45 +3755,45 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - `id` MUST be a valid uuid. If an entry `existing_entry` with `id` already exist, then  `existing_entry.corporation` MUST be equal to `corporation` AND `existing_entry.vs_operator` MUST be equal to `operator`, else abort.
 
-if `issuer_perm_id` is null AND `verifier_perm_id` is null, MUST abort.
+if `issuer_participant_id` is null AND `verifier_participant_id` is null, MUST abort.
 
-- define `issuer_perm` as null.
-- define `verifier_perm` as null.
+- define `issuer_participant` as null.
+- define `verifier_participant` as null.
 
-if `issuer_perm_id` is not null:
+if `issuer_participant_id` is not null:
 
-- Load `issuer_perm` from `issuer_perm_id`.
-- if `issuer_perm.type` is not ISSUER, abort.
-- if `issuer_perm` is not a [[ref: active permission]], abort.
-- if `issuer_perm.vs_operator` is not equal to `operator`, abort.
-- if `issuer_perm.corporation` is not equal to `corporation`, abort.
+- Load `issuer_participant` from `issuer_participant_id`.
+- if `issuer_participant.role` is not ISSUER, abort.
+- if `issuer_participant` is not a [[ref: active permission]], abort.
+- if `issuer_participant.vs_operator` is not equal to `operator`, abort.
+- if `issuer_participant.corporation` is not equal to `corporation`, abort.
 - if `digest_sri` is present but not a valid digest SRI, abort.
 
-if `verifier_perm_id` is not null:
+if `verifier_participant_id` is not null:
 
-- Load `verifier_perm` from `verifier_perm_id`.
-- if `verifier_perm.type` is not VERIFIER, abort.
-- if `verifier_perm` is not a [[ref: active permission]], abort.
-- if `verifier_perm.vs_operator` is not equal to `operator`, abort.
-- if `verifier_perm.corporation` is not equal to `corporation`, abort.
+- Load `verifier_participant` from `verifier_participant_id`.
+- if `verifier_participant.role` is not VERIFIER, abort.
+- if `verifier_participant` is not a [[ref: active permission]], abort.
+- if `verifier_participant.vs_operator` is not equal to `operator`, abort.
+- if `verifier_participant.corporation` is not equal to `corporation`, abort.
 - if `digest_sri` is present but not a valid digest SRI, abort.
 
-Define the **primary permission** `perm`: if `verifier_perm` is not null, `perm` = `verifier_perm` (the caller is the `vs_operator` of the verifier). Else, `perm` = `issuer_perm` (the caller is the `vs_operator` of the issuer).
+Define the **primary permission** `perm`: if `verifier_participant` is not null, `perm` = `verifier_participant` (the caller is the `vs_operator` of the verifier). Else, `perm` = `issuer_participant` (the caller is the `vs_operator` of the issuer).
 
 [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) MUST pass for this (`corporation`, `operator`, `perm`) tuple.
 [[AUTHZ-CHECK-4]](#authz-check-4-vs-operator-fee-grant-checks) MUST pass for this (`corporation`, `operator`, `perm`) tuple.
 
 agent:
 
-- Load `agent_perm` from `agent_perm_id`.
-- if `agent_perm.type` is not ISSUER, abort.
-- if `agent_perm` is not a [[ref: active permission]], abort.
+- Load `agent_participant` from `agent_participant_id`.
+- if `agent_participant.role` is not ISSUER, abort.
+- if `agent_participant` is not a [[ref: active permission]], abort.
 
 wallet_agent:
 
-- Load `wallet_agent_perm` from `wallet_agent_perm_id`.
-- if `wallet_agent_perm.type` is not ISSUER, abort.
-- if `wallet_agent_perm` is not a [[ref: active permission]], abort.
+- Load `wallet_agent_participant` from `wallet_agent_participant_id`.
+- if `wallet_agent_participant.role` is not ISSUER, abort.
+- if `wallet_agent_participant` is not a [[ref: active permission]], abort.
 
 :::warning
 we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a permission that is not controlled by its owner.
@@ -3801,26 +3801,26 @@ we might want to check that credential schema of agent and wallet_agent perms is
 
 ###### [MOD-PP-MSG-10-3] Create or Update Permission Session fee checks
 
-- Load `CredentialSchema` entry `cs` from `issuer_perm.schema_id` if `issuer_perm` is not null, else from `verifier_perm.schema_id`.
+- Load `CredentialSchema` entry `cs` from `issuer_participant.schema_id` if `issuer_participant` is not null, else from `verifier_participant.schema_id`.
 - Fee payer MUST have sufficient available balance for the required [[ref: estimated transaction fees]].
 
 For trust fees, `corporation` account MUST have sufficient available balance as explained below.
 
 **Step 1: Calculate total beneficiary fees in credential schema pricing asset**
 
-Use "Find Beneficiaries" query method to get the set of beneficiary permissions `found_perm_set` (all ancestors in the permission tree).
+Use "Find Beneficiaries" query method to get the set of beneficiary permissions `found_participant_set` (all ancestors in the permission tree).
 
 - define `total_beneficiary_fees` = 0
 
-If **Credential Issuance** (`issuer_perm` is NOT null):
+If **Credential Issuance** (`issuer_participant` is NOT null):
 
-- for each `perm` in `found_perm_set`:
-  - `total_beneficiary_fees` = `total_beneficiary_fees` + `perm.issuance_fees` × (1 - `issuer_perm.issuance_fee_discount`)
+- for each `perm` in `found_participant_set`:
+  - `total_beneficiary_fees` = `total_beneficiary_fees` + `participant.issuance_fees` × (1 - `issuer_participant.issuance_fee_discount`)
 
-If **Credential Verification** (`verifier_perm` is NOT null):
+If **Credential Verification** (`verifier_participant` is NOT null):
 
-- for each `perm` in `found_perm_set`:
-  - `total_beneficiary_fees` = `total_beneficiary_fees` + `perm.verification_fees` × (1 - `verifier_perm.verification_fee_discount`)
+- for each `perm` in `found_participant_set`:
+  - `total_beneficiary_fees` = `total_beneficiary_fees` + `participant.verification_fees` × (1 - `verifier_participant.verification_fee_discount`)
 
 > Note: `total_beneficiary_fees` is expressed in the credential schema pricing asset `(cs.pricing_asset_type, cs.pricing_asset)`.
 
@@ -3865,11 +3865,11 @@ Calculate:
 - `total_payees_trust_deposit` = `total_payer_trust_deposit`
 - `total_payees_fees_to_account` = `total_fees_in_native_denom` × (1 - `GlobalVariables.trust_deposit_rate`)
 
-if `agent_perm_id` is set:
+if `agent_participant_id` is set:
 
 - `total_user_agent_reward` = `total_fees_in_native_denom` × `GlobalVariables.user_agent_reward_rate`
 
-if `wallet_agent_perm_id` is set:
+if `wallet_agent_participant_id` is set:
 
 - `total_wallet_agent_reward` = `total_fees_in_native_denom` × `GlobalVariables.wallet_user_agent_reward_rate`
 
@@ -3890,11 +3890,11 @@ Calculate:
 - `total_payees_trust_deposit` = `total_payer_trust_deposit`
 - `total_payees_fees_to_account` = `total_fees_in_native_denom` × (1 - `GlobalVariables.trust_deposit_rate`)
 
-if `agent_perm_id` is set:
+if `agent_participant_id` is set:
 
 - `total_user_agent_reward` = `total_fees_in_native_denom` × `GlobalVariables.user_agent_reward_rate`
 
-if `wallet_agent_perm_id` is set:
+if `wallet_agent_participant_id` is set:
 
 - `total_wallet_agent_reward` = `total_fees_in_native_denom` × `GlobalVariables.wallet_user_agent_reward_rate`
 
@@ -3915,11 +3915,11 @@ Calculate:
 - `total_payees_trust_deposit` = `total_payer_trust_deposit`
 - `total_payees_fees_to_account` = `total_fees_in_pricing_asset` × (1 - `GlobalVariables.trust_deposit_rate`)
 
-if `agent_perm_id` is set:
+if `agent_participant_id` is set:
 
 - `total_user_agent_reward` = `total_fees_in_native_denom` × `GlobalVariables.user_agent_reward_rate`
 
-if `wallet_agent_perm_id` is set:
+if `wallet_agent_participant_id` is set:
 
 - `total_wallet_agent_reward` = `total_fees_in_native_denom` × `GlobalVariables.wallet_user_agent_reward_rate`
 
@@ -3941,11 +3941,11 @@ Calculate:
 - `total_payees_trust_deposit` = `total_payer_trust_deposit`
 - `total_payees_fees_to_account` = 0 (FIAT payments are managed off-chain)
 
-if `agent_perm_id` is set:
+if `agent_participant_id` is set:
 
 - `total_user_agent_reward` = `total_fees_in_native_denom` × `GlobalVariables.user_agent_reward_rate`
 
-if `wallet_agent_perm_id` is set:
+if `wallet_agent_participant_id` is set:
 
 - `total_wallet_agent_reward` = `total_fees_in_native_denom` × `GlobalVariables.wallet_user_agent_reward_rate`
 
@@ -3965,9 +3965,9 @@ Required balance check:
 If all precondition checks passed, method is executed.
 
 - Load all permissions as in basic checks.
-- Load `CredentialSchema` entry `cs` from `issuer_perm.schema_id` if `issuer_perm` is not null, else from `verifier_perm.schema_id`.
+- Load `CredentialSchema` entry `cs` from `issuer_participant.schema_id` if `issuer_participant` is not null, else from `verifier_participant.schema_id`.
 - define `now`: current timestamp.
-- use "Find Beneficiaries" to build `found_perm_set`.
+- use "Find Beneficiaries" to build `found_participant_set`.
 
 > Note: All funds are transferred from the `corporation` account executing the method. The steps below describe what each recipient must receive. Implementation details (batching, order of transfers) are left to the implementer.
 
@@ -3982,22 +3982,22 @@ Initialize accumulators for agent rewards:
 
 Determine the operation type and applicable discount:
 
-- If **Credential Issuance** (`issuer_perm` is NOT null):
+- If **Credential Issuance** (`issuer_participant` is NOT null):
   - `fee_field` = `issuance_fees`
-  - `discount` = `issuer_perm.issuance_fee_discount`
-  - `payer_perm` = `issuer_perm`
+  - `discount` = `issuer_participant.issuance_fee_discount`
+  - `payer_participant` = `issuer_participant`
 
-- Else if **Credential Verification** (`verifier_perm` is NOT null):
+- Else if **Credential Verification** (`verifier_participant` is NOT null):
   - `fee_field` = `verification_fees`
-  - `discount` = `verifier_perm.verification_fee_discount`
-  - `payer_perm` = `verifier_perm`
+  - `discount` = `verifier_participant.verification_fee_discount`
+  - `payer_participant` = `verifier_participant`
 
-**For each beneficiary permission `perm` in `found_perm_set`:**
+**For each beneficiary permission `perm` in `found_participant_set`:**
 
-If `perm.[fee_field]` > 0:
+If `participant.[fee_field]` > 0:
 
 1. Calculate the discounted fee for this beneficiary:
-   - `beneficiary_fee_in_pricing_asset` = `perm.[fee_field]` × (1 - `discount`)
+   - `beneficiary_fee_in_pricing_asset` = `participant.[fee_field]` × (1 - `discount`)
 
 2. Calculate amounts based on pricing configuration (same logic as fee checks):
 
@@ -4008,10 +4008,10 @@ If `perm.[fee_field]` > 0:
    - `payee_trust_deposit` = `payer_trust_deposit`
    - `payee_fees_to_account` = `fee_in_native_denom` × (1 - `GlobalVariables.trust_deposit_rate`)
 
-  if `agent_perm_id` is set:
+  if `agent_participant_id` is set:
     - `user_agent_reward_portion` = `fee_in_native_denom` × `GlobalVariables.user_agent_reward_rate`
 
-  if `wallet_agent_perm_id` is set:
+  if `wallet_agent_participant_id` is set:
     - `wallet_agent_reward_portion` = `fee_in_native_denom` × `GlobalVariables.wallet_user_agent_reward_rate`
 
   
@@ -4022,10 +4022,10 @@ If `perm.[fee_field]` > 0:
    - `payee_trust_deposit` = `payer_trust_deposit`
    - `payee_fees_to_account` = `fee_in_native_denom` × (1 - `GlobalVariables.trust_deposit_rate`)
 
-  if `agent_perm_id` is set:
+  if `agent_participant_id` is set:
     - `user_agent_reward_portion` = `fee_in_native_denom` × `GlobalVariables.user_agent_reward_rate`
 
-  if `wallet_agent_perm_id` is set:
+  if `wallet_agent_participant_id` is set:
     - `wallet_agent_reward_portion` = `fee_in_native_denom` × `GlobalVariables.wallet_user_agent_reward_rate`
 
    **Case C: `(cs.pricing_asset_type, cs.pricing_asset)` = `(COIN, <arbitrary_denom>)`**
@@ -4035,10 +4035,10 @@ If `perm.[fee_field]` > 0:
    - `payee_trust_deposit` = `payer_trust_deposit`
    - `payee_fees_to_account` = `beneficiary_fee_in_pricing_asset` × (1 - `GlobalVariables.trust_deposit_rate`) *(in `<arbitrary_denom>`)*
 
-  if `agent_perm_id` is set:
+  if `agent_participant_id` is set:
     - `user_agent_reward_portion` = `fee_in_native_denom` × `GlobalVariables.user_agent_reward_rate`
 
-  if `wallet_agent_perm_id` is set:
+  if `wallet_agent_participant_id` is set:
     - `wallet_agent_reward_portion` = `fee_in_native_denom` × `GlobalVariables.wallet_user_agent_reward_rate`
 
 
@@ -4049,17 +4049,17 @@ If `perm.[fee_field]` > 0:
    - `payee_trust_deposit` = `payer_trust_deposit`
    - `payee_fees_to_account` = 0 *(FIAT payments are managed off-chain)*
 
-  if `agent_perm_id` is set:
+  if `agent_participant_id` is set:
     - `user_agent_reward_portion` = `fee_in_native_denom` × `GlobalVariables.user_agent_reward_rate`
 
-  if `wallet_agent_perm_id` is set:
+  if `wallet_agent_participant_id` is set:
     - `wallet_agent_reward_portion` = `fee_in_native_denom` × `GlobalVariables.wallet_user_agent_reward_rate`
 
 3. Execute transfers and deposits for this beneficiary:
 
-   - If `payee_fees_to_account` > 0: transfer `payee_fees_to_account` to `perm.corporation` (in the appropriate denom).
-   - Use [MOD-TD-MSG-1] to increase the [[ref: trust deposit]] of `perm.corporation` by `payee_trust_deposit`. Increase `perm.deposit` by the same value.
-   - Use [MOD-TD-MSG-1] to increase the [[ref: trust deposit]] of `corporation` (payer) by `payer_trust_deposit`. Increase `payer_perm.deposit` by the same value.
+   - If `payee_fees_to_account` > 0: transfer `payee_fees_to_account` to `participant.corporation` (in the appropriate denom).
+   - Use [MOD-TD-MSG-1] to increase the [[ref: trust deposit]] of `participant.corporation` by `payee_trust_deposit`. Increase `participant.deposit` by the same value.
+   - Use [MOD-TD-MSG-1] to increase the [[ref: trust deposit]] of `corporation` (payer) by `payer_trust_deposit`. Increase `payer_participant.deposit` by the same value.
 
 4. Accumulate agent rewards:
 
@@ -4074,21 +4074,21 @@ After processing all beneficiaries, distribute accumulated rewards to agents.
 
 **User Agent Reward:**
 
-If `agent_perm_id` is set AND `accumulated_user_agent_reward` > 0:
+If `agent_participant_id` is set AND `accumulated_user_agent_reward` > 0:
 
 - `agent_trust_deposit` = `accumulated_user_agent_reward` × `GlobalVariables.trust_deposit_rate`
 - `agent_fees_to_account` = `accumulated_user_agent_reward` - `agent_trust_deposit`
-- Transfer `agent_fees_to_account` to `agent_perm.corporation` in [[ref: native denom]].
-- Use [MOD-TD-MSG-1] to increase the [[ref: trust deposit]] of `agent_perm.corporation` by `agent_trust_deposit`. Increase `agent_perm.deposit` by the same value.
+- Transfer `agent_fees_to_account` to `agent_participant.corporation` in [[ref: native denom]].
+- Use [MOD-TD-MSG-1] to increase the [[ref: trust deposit]] of `agent_participant.corporation` by `agent_trust_deposit`. Increase `agent_participant.deposit` by the same value.
 
 **Wallet Agent Reward:**
 
-If `wallet_agent_perm_id` is set AND `accumulated_wallet_agent_reward` > 0:
+If `wallet_agent_participant_id` is set AND `accumulated_wallet_agent_reward` > 0:
 
 - `wallet_agent_trust_deposit` = `accumulated_wallet_agent_reward` × `GlobalVariables.trust_deposit_rate`
 - `wallet_agent_fees_to_account` = `accumulated_wallet_agent_reward` - `wallet_agent_trust_deposit`
-- Transfer `wallet_agent_fees_to_account` to `wallet_agent_perm.corporation` in [[ref: native denom]].
-- Use [MOD-TD-MSG-1] to increase the [[ref: trust deposit]] of `wallet_agent_perm.corporation` by `wallet_agent_trust_deposit`. Increase `wallet_agent_perm.deposit` by the same value.
+- Transfer `wallet_agent_fees_to_account` to `wallet_agent_participant.corporation` in [[ref: native denom]].
+- Use [MOD-TD-MSG-1] to increase the [[ref: trust deposit]] of `wallet_agent_participant.corporation` by `wallet_agent_trust_deposit`. Increase `wallet_agent_participant.deposit` by the same value.
 
 ---
 
@@ -4099,10 +4099,10 @@ If `wallet_agent_perm_id` is set AND `accumulated_wallet_agent_reward` > 0:
 Create a `PermissionSessionRecord` `cspsr`:
 
 - `cspsr.created`: `now`
-- `cspsr.issuer_perm_id`: `issuer_perm_id`
-- `cspsr.verifier_perm_id`: `verifier_perm_id`
-- `cspsr.agent_perm_id`: `agent_perm_id`
-- `cspsr.wallet_agent_perm_id`: `wallet_agent_perm_id`
+- `cspsr.issuer_participant_id`: `issuer_participant_id`
+- `cspsr.verifier_participant_id`: `verifier_participant_id`
+- `cspsr.agent_participant_id`: `agent_participant_id`
+- `cspsr.wallet_agent_participant_id`: `wallet_agent_participant_id`
 
 If new, create entry `PermissionSession` `session`:
 
@@ -4121,7 +4121,7 @@ then, add the `cspsr` to `session.session_records`
 if current transaction if for issuance of a credential, persist the digest SRI by calling [[MOD-DI-MSG-1]](#mod-di-msg-1-store-digest).
 
 :::warning
-`session.authz[]` can contain null `issuer_perm_id` OR `verifier_perm_id`
+`session.authz[]` can contain null `issuer_participant_id` OR `verifier_participant_id`
 :::
 
 #### [MOD-PP-MSG-11] Update Permission Module Parameters
@@ -4182,8 +4182,8 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `applicant_perm` from `id`. If no entry found, abort.
-- `amount` MUST be lower or equal to `applicant_perm.deposit` else MUST abort.
+- Load `Permission` entry `applicant_participant` from `id`. If no entry found, abort.
+- `amount` MUST be lower or equal to `applicant_participant.deposit` else MUST abort.
 
 :::note
 Even if the permission has expired or is revoked, it is still possible to slash it.
@@ -4195,20 +4195,20 @@ Either Option #1, or #2 MUST return true, else abort.
 
 *Option #1*: executed by a validator ancestor
 
-if `applicant_perm.validator_perm_id` is defined:
+if `applicant_participant.validator_participant_id` is defined:
 
-- set `validator_perm` = `applicant_perm`
-- while `validator_perm.validator_perm_id` is defined, 
-  - load `validator_perm` from `validator_perm.validator_perm_id`.
-  - if `validator_perm` is a [[ref: active permission]] and `validator_perm.corporation` is who is running the method, => return true.
+- set `validator_participant` = `applicant_participant`
+- while `validator_participant.validator_participant_id` is defined, 
+  - load `validator_participant` from `validator_participant.validator_participant_id`.
+  - if `validator_participant` is a [[ref: active permission]] and `validator_participant.corporation` is who is running the method, => return true.
 - end
 - return false.
 
 *Option #2*: executed by `TrustRegistry` controller
 
-- load `CredentialSchema` `cs` from `applicant_perm.schema_id`
-- load `TrustRegistry` `tr` from `cs.tr_id`
-- if `corporation` running the method is `tr.corporation`, return true.
+- load `CredentialSchema` `cs` from `applicant_participant.schema_id`
+- load `TrustRegistry` `tr` from `cs.ecosystem_id`
+- if `corporation` running the method is `ecosystem.corporation`, return true.
 - else return false.
 
 ###### [MOD-PP-MSG-12-2-3] Slash Permission Trust Deposit fee checks
@@ -4223,15 +4223,15 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - define `now`: current timestamp.
 
-- Load `Permission` entry `applicant_perm` from `id`.
-- Load `Permission` entry `validator_perm` from `applicant_perm.validator_perm_id`.
-- set `applicant_perm.slashed` to `now`
-- set `applicant_perm.modified` to `now`
-- set `applicant_perm.slashed_deposit` to `applicant_perm.slashed_deposit` + `amount`
+- Load `Permission` entry `applicant_participant` from `id`.
+- Load `Permission` entry `validator_participant` from `applicant_participant.validator_participant_id`.
+- set `applicant_participant.slashed` to `now`
+- set `applicant_participant.modified` to `now`
+- set `applicant_participant.slashed_deposit` to `applicant_participant.slashed_deposit` + `amount`
 
-use [MOD-TD-MSG-7](#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit) to burn the slashed `amount` from the trust deposit of `applicant_perm.corporation`.
+use [MOD-TD-MSG-7](#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit) to burn the slashed `amount` from the trust deposit of `applicant_participant.corporation`.
 
-Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `perm_id = applicant_perm.id` to remove any authorization record for this permission. The call is a no-op if no record exists.
+Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any authorization record for this permission. The call is a no-op if no record exists.
 
 #### [MOD-PP-MSG-13] Repay Permission Slashed Trust Deposit
 
@@ -4257,13 +4257,13 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `applicant_perm` from `id`. If no entry found, abort.
-- if `applicant_perm.corporation` is not equal to `corporation`, abort.
+- Load `Permission` entry `applicant_participant` from `id`. If no entry found, abort.
+- if `applicant_participant.corporation` is not equal to `corporation`, abort.
 
 ###### [MOD-PP-MSG-13-2-2] Repay Permission Slashed Trust Deposit fee checks
 
 - Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]];
-- `corporation` MUST have at least `applicant_perm.slashed_deposit` in its account balance, else [[ref: transaction]] MUST abort.
+- `corporation` MUST have at least `applicant_participant.slashed_deposit` in its account balance, else [[ref: transaction]] MUST abort.
 
 ##### [MOD-PP-MSG-13-3] Repay Permission Slashed Trust Deposit execution
 
@@ -4273,12 +4273,12 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - define `now`: current timestamp.
 
-use [Adjust Trust Deposit](#mod-td-msg-1-adjust-trust-deposit) to transfer `applicant_perm.slashed_deposit` to trust deposit of `applicant_perm.corporation`.
+use [Adjust Trust Deposit](#mod-td-msg-1-adjust-trust-deposit) to transfer `applicant_participant.slashed_deposit` to trust deposit of `applicant_participant.corporation`.
 
-- Load `Permission` entry `applicant_perm` from `id`.
-- set `applicant_perm.repaid` to `now`
-- set `applicant_perm.modified` to `now`
-- set `applicant_perm.repaid_deposit` to `applicant_perm.slashed_deposit`.
+- Load `Permission` entry `applicant_participant` from `id`.
+- set `applicant_participant.repaid` to `now`
+- set `applicant_participant.modified` to `now`
+- set `applicant_participant.repaid_deposit` to `applicant_participant.slashed_deposit`.
 
 #### [MOD-PP-MSG-14] Self Create Permission
 
@@ -4295,7 +4295,7 @@ Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `type` (PermissionType) (*mandatory*): ISSUER or VERIFIER.
-- `validator_perm_id` (uint64) (*mandatory*): MUST be an ECOSYSTEM [[ref: active permission]] or [[ref: future permission]].
+- `validator_participant_id` (uint64) (*mandatory*): MUST be an ECOSYSTEM [[ref: active permission]] or [[ref: future permission]].
 - `vs_operator` (account) (*optional*): the account we want to authorize to create permission sessions linked to this permission. **Required** for payment delegation.
 - `did` (string) (*mandatory*): [[ref: DID]] of the VS grantee service.
 - `effective_from` (timestamp) (*optional*): timestamp from when (exclusive) this Perm is effective. MUST be in the future.
@@ -4327,21 +4327,21 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-Load `Permission` `validator_perm` from `validator_perm_id`.
+Load `Permission` `validator_participant` from `validator_participant_id`.
 
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `type` (PermissionType) (*mandatory*): MUST be ISSUER or VERIFIER, else abort.
-- `validator_perm_id` (uint64) (*mandatory*): `validator_perm` MUST be an ECOSYSTEM [[ref: active permission]] or [[ref: future permission]].
+- `validator_participant_id` (uint64) (*mandatory*): `validator_participant` MUST be an ECOSYSTEM [[ref: active permission]] or [[ref: future permission]].
 - `vs_operator` (account) (*optional*): no check required.
 - `did`, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
 - `effective_from` MUST be in the future AND
-  - MUST be greater or equal to `validator_perm.effective_from` AND
-  - if `validator_perm.effective_until` is not null, MUST be lower than `validator_perm.effective_until`
+  - MUST be greater or equal to `validator_participant.effective_from` AND
+  - if `validator_participant.effective_until` is not null, MUST be lower than `validator_participant.effective_until`
 - `effective_until`:
-  - if null, `validator_perm.effective_until` MUST be NULL
-  - else if not null, must be greater than `effective_from` AND if `validator_perm.effective_until` is not null, MUST be lower or equal to `validator_perm.effective_until`
+  - if null, `validator_participant.effective_until` MUST be NULL
+  - else if not null, must be greater than `effective_from` AND if `validator_participant.effective_until` is not null, MUST be lower or equal to `validator_participant.effective_until`
 - `verification_fees` (number) (*optional*): If specified, MUST be >= 0 and MUST be a ISSUER permission.
 - `validation_fees` (number) (*optional*): If specified, MUST be >= 0 and MUST be a ISSUER permission.
 - VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-14-1](#mod-pp-msg-14-1-self-create-permission-parameters).
@@ -4350,7 +4350,7 @@ Load `Permission` `validator_perm` from `validator_perm_id`.
 
 To execute this method, [[ref: account]] MUST match at least one these rules, else [[ref: transaction]] MUST abort.
 
-- The related `CredentialSchema` entry is loaded with `validator_perm.schema_id`, and will be named `cs` in this section.
+- The related `CredentialSchema` entry is loaded with `validator_participant.schema_id`, and will be named `cs` in this section.
 - if `type` is equal to ISSUER: if `cs.issuer_onboarding_mode` is not equal to OPEN, MUST abort.
 - if `type` is equal to VERIFIER: if `cs.verifier_onboarding_mode` is not equal to OPEN, MUST abort.
 - if `type` is equal to VERIFIER and `validation_fees` is specified and different than 0, MUST abort.
@@ -4362,11 +4362,11 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
 ###### [MOD-PP-MSG-14-2-4] Self Create Permission overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time for the same `validator_perm_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-permission) to set or adjust the `effective_until` value.
+We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-permission) to set or adjust the `effective_until` value.
 
-Find all [[ref: active permissions]] `perms[]` (not revoked, not slashed, not repaid) for `cs.id`, `type`, `validator_perm_id`, `corporation`.
+Find all [[ref: active permissions]] `participants[]` (not revoked, not slashed, not repaid) for `cs.id`, `type`, `validator_participant_id`, `corporation`.
 
-for each `Permission` entry `p` from `perms[]`:
+for each `Permission` entry `p` from `participants[]`:
 
 - if `p.effective_until` is greater than `effective_from`, method execution MUST abort.
 - if `p.effective_from` is lower than `effective_until`, method execution MUST abort.
@@ -4381,46 +4381,46 @@ If all precondition checks passed, method is executed.
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
 - define `now`: current timestamp.
-- Load `Permission` `validator_perm` from `validator_perm_id`.
+- Load `Permission` `validator_participant` from `validator_participant_id`.
 
 A new entry `Permission` `perm` MUST be created:
 
-- `perm.id`: auto-incremented uint64.
-- `perm.validator_perm_id`: `validator_perm_id`
-- `perm.schema_id`: `validator_perm.schema_id`
-- `perm.modified` to `now`.
-- `perm.type`: `type`.
-- `perm.did`: `did`.
-- `perm.corporation`: `corporation`.
-- `perm.vs_operator`: `vs_operator`.
-- `perm.created`: `now`
-- `perm.effective_from`: `effective_from`
-- `perm.effective_until`: `effective_until`
-- `perm.validation_fees`: `validation_fees` if specified and `type` is ISSUER, else 0.
-- `perm.issuance_fees`: 0
-- `perm.verification_fees`: `verification_fees` if specified and `type` is ISSUER, else 0.
-- `perm.deposit`: 0
+- `participant.id`: auto-incremented uint64.
+- `participant.validator_participant_id`: `validator_participant_id`
+- `participant.schema_id`: `validator_participant.schema_id`
+- `participant.modified` to `now`.
+- `participant.role`: `type`.
+- `participant.did`: `did`.
+- `participant.corporation`: `corporation`.
+- `participant.vs_operator`: `vs_operator`.
+- `participant.created`: `now`
+- `participant.effective_from`: `effective_from`
+- `participant.effective_until`: `effective_until`
+- `participant.validation_fees`: `validation_fees` if specified and `type` is ISSUER, else 0.
+- `participant.issuance_fees`: 0
+- `participant.verification_fees`: `verification_fees` if specified and `type` is ISSUER, else 0.
+- `participant.deposit`: 0
 
 If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizationRecord](#permissionauthorizationrecord) in **active** state by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
 
 - `corporation`: `corporation`
 - `vs_operator`: `vs_operator`
 - `record`:
-  - `record.perm_id`: `perm.id`
+  - `record.participant_id`: `participant.id`
   - `record.msg_types`: `vs_operator_authz_msg_types`
   - `record.spend_limit`: `vs_operator_authz_spend_limit`
   - `record.fee_spend_limit`: `vs_operator_authz_fee_spend_limit`
   - `record.with_feegrant`: `vs_operator_authz_with_feegrant` (default: false)
-  - `record.expiration`: `perm.effective_until`
+  - `record.expiration`: `participant.effective_until`
   - `record.period`: `vs_operator_authz_period`
 
-> Note: unlike [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp), the record is created with `expiration = perm.effective_until` and is therefore immediately active. If `with_feegrant` is true and `perm.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
+> Note: unlike [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp), the record is created with `expiration = participant.effective_until` and is therefore immediately active. If `with_feegrant` is true and `participant.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
 
 #### [MOD-PP-MSG-15] Trigger Resolver
 
 This method CAN be executed by:
 
-- the `vs_operator` of the permission, acting on behalf of `perm.corporation`; or
+- the `vs_operator` of the permission, acting on behalf of `participant.corporation`; or
 - any ancestor validator of the permission in the permission tree (from the direct parent up to the root permission). For an ancestor validator `v`, the method CAN be executed by the `vs_operator` defined in `v`, or by any `operator` authorized by `v.corporation` for this message type.
 
 This method is intended to be used by external services (such as the Verana indexer) to be notified that a trust resolution must be performed for the `did` registered in the permission. Typical use cases include:
@@ -4450,7 +4450,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `id` MUST be a valid uint64.
 - Load `Permission` entry `perm` from `id`. If no entry found, abort.
 - `perm` MUST be an [[ref: active permission]], else abort.
-- `perm.did` MUST NOT be null, else abort.
+- `participant.did` MUST NOT be null, else abort.
 
 ###### [MOD-PP-MSG-15-2-2] Trigger Resolver authorization checks
 
@@ -4458,8 +4458,8 @@ At least one of the two authorization paths below MUST pass, else [[ref: transac
 
 *Path 1 — vs_operator of the target permission*
 
-- `corporation` MUST be equal to `perm.corporation`.
-- `operator` MUST be equal to `perm.vs_operator`.
+- `corporation` MUST be equal to `participant.corporation`.
+- `operator` MUST be equal to `participant.vs_operator`.
 - [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) MUST pass for this (`corporation`, `operator`, `perm`) tuple.
 - [[AUTHZ-CHECK-4]](#authz-check-4-vs-operator-fee-grant-checks) MUST pass for this (`corporation`, `operator`, `perm`) tuple.
 
@@ -4468,8 +4468,8 @@ At least one of the two authorization paths below MUST pass, else [[ref: transac
 The target `perm` itself is excluded from this walk; only its ancestors (from the direct parent up to the root) are considered. Walk the tree:
 
 - set `v` = `perm`.
-- while `v.validator_perm_id` is defined and != `perm.id` :
-  - load `v` from `v.validator_perm_id`.
+- while `v.validator_participant_id` is defined and != `participant.id` :
+  - load `v` from `v.validator_participant_id`.
   - if `v` is not an [[ref: active permission]], continue with the next iteration.
   - if corporation != v.corporation, continue with the next iteration.
   - if [AUTHZ-CHECK-1](#authz-check-1-operator-authorization-checks) pass for this (`corporation`, `operator`) tuple and message `TriggerResolver` AND [AUTHZ-CHECK-2](#authz-check-2-fee-grant-checks) pass for this (`corporation`, `operator`) tuple and message `TriggerResolver`, then authorization is granted => match.
@@ -4486,9 +4486,9 @@ If all precondition checks passed, [[ref: transaction]] is executed.
 
 This method does not modify the state of the [[ref: VPR]]. It MUST emit an event signaling that a trust resolution has been triggered for `perm`. The event MUST include at least:
 
-- `perm_id`: equal to `id`.
+- `participant_id`: equal to `id`.
 
-> Note: the identity of the signers (`corporation`, `operator`), the fee payer, the block height and timestamp, and the full Msg payload are already observable from the transaction itself. Indexers MAY use the `Permission` entry queried by `perm_id` to resolve `did`, `corporation`, `vs_operator`, and ancestor chain without duplicating them in the event payload.
+> Note: the identity of the signers (`corporation`, `operator`), the fee payer, the block height and timestamp, and the full Msg payload are already observable from the transaction itself. Indexers MAY use the `Permission` entry queried by `participant_id` to resolve `did`, `corporation`, `vs_operator`, and ancestor chain without duplicating them in the event payload.
 
 #### [MOD-PP-QRY-1] List Permissions
 
@@ -4508,7 +4508,7 @@ Generic query used for (at least):
 - `schema_id` (number) (*optional*): the schema id.
 - `grantee` (account) (*optional*): the grantee account.
 - `did` (string) (*optional*): the did the permission refers to.
-- `perm_id` (number) (*optional*): limit to permissions where the `validator_perm_id` is `perm_id`.
+- `participant_id` (number) (*optional*): limit to permissions where the `validator_participant_id` is `participant_id`.
 - `type` (PermissionType) (*optional*): if we want to limit to a specific permission type.
 - `only_valid` (boolean) (*optional*): if set to true, only return active permissions.
 - `only_slashed` (boolean) (*optional*): if set to true, only return slashed permissions.
@@ -4554,22 +4554,22 @@ Obsoleted by [MOD-PP-QRY-1].
 
 Anyone can execute this method.
 
-To calculate the fees required for paying the beneficiaries, it is needed to recurse all involved perms until the root of the permission tree (which is the trust registry perm), starting from the 2 branches `issuer_perm` and `verifier_perm`. As both branches may have common ancestors, we can create a Set (unordered collection with no duplicates), and recurse over the 2 branches, adding found perms. If `verifier_perm` is null, `issuer_perm` is never added to the set. If `verifier_perm` is NOT null, `issuer_perm` is added to the set if it exists but `verifier_perm` is not added to the set.
+To calculate the fees required for paying the beneficiaries, it is needed to recurse all involved perms until the root of the permission tree (which is the trust registry perm), starting from the 2 branches `issuer_participant` and `verifier_participant`. As both branches may have common ancestors, we can create a Set (unordered collection with no duplicates), and recurse over the 2 branches, adding found perms. If `verifier_participant` is null, `issuer_participant` is never added to the set. If `verifier_participant` is NOT null, `issuer_participant` is added to the set if it exists but `verifier_participant` is not added to the set.
 
-Example 1: `verifier_perm`: is not set: it's a credential offer, schema configured to have Issuer Grantors.
+Example 1: `verifier_participant`: is not set: it's a credential offer, schema configured to have Issuer Grantors.
 
 ```plantuml
 
 @startuml
 scale max 800 width
 object "ECOSYSTEM executor ancestor perm" as tr #3fbdb6 {
-  add me to found_perm_set
+  add me to found_participant_set
 }
 object "ISSUER_GRANTOR executor ancestor perm" as ig #3fbdb6 {
-  add me to found_perm_set
+  add me to found_participant_set
 }
 object "ISSUER executor perm" as i #7677ed {
-  don't add me to found_perm_set
+  don't add me to found_participant_set
 }
 
 ig --> tr
@@ -4578,17 +4578,17 @@ i --> ig
 
 ```
 
-Example 2: `verifier_perm`: is not set: it's a credential offer. Schema configured to NOT have Issuer Grantors.
+Example 2: `verifier_participant`: is not set: it's a credential offer. Schema configured to NOT have Issuer Grantors.
 
 ```plantuml
 
 @startuml
 scale max 800 width
 object "ECOSYSTEM executor ancestor perm" as tr #3fbdb6 {
-  add me to found_perm_set
+  add me to found_participant_set
 }
 object "ISSUER executor perm" as i #7677ed {
-  don't add me to found_perm_set
+  don't add me to found_participant_set
 }
 
 
@@ -4597,27 +4597,27 @@ i --> tr
 
 ```
 
-Example 3: `verifier_perm` is set, it's a presentation request. Schema configured to have Verifier and Issuer Grantors.
+Example 3: `verifier_participant` is set, it's a presentation request. Schema configured to have Verifier and Issuer Grantors.
 
 ```plantuml
 
 @startuml
 scale max 800 width
 object "ECOSYSTEM beneficiary ancestor perm" as tr #3fbdb6 {
-  add me to found_perm_set
+  add me to found_participant_set
 }
 object "ISSUER_GRANTOR beneficiary ancestor perm" as ig #3fbdb6 {
-  add me to found_perm_set
+  add me to found_participant_set
 }
 object "ISSUER beneficiary perm" as i #3fbdb6 {
-  add me to found_perm_set
+  add me to found_participant_set
 }
 
 object "VERIFIER_GRANTOR executor ancestor perm" as vg #3fbdb6 {
-  add me to found_perm_set
+  add me to found_participant_set
 }
 object "VERIFIER executor perm" as v #7677ed {
-  don't add me to found_perm_set
+  don't add me to found_participant_set
 }
 
 ig --> tr
@@ -4631,39 +4631,39 @@ v --> vg
 
 ##### [MOD-PP-QRY-4-1] Find Beneficiaries parameters
 
-- `issuer_perm_id` (uint64) (*optional*): id of issuer permission.
-- `verifier_perm_id` (uint64) (*optional*): id of verifier permission.
+- `issuer_participant_id` (uint64) (*optional*): id of issuer permission.
+- `verifier_participant_id` (uint64) (*optional*): id of verifier permission.
 
 ##### [MOD-PP-QRY-4-2] Find Beneficiaries checks
 
-- if `issuer_perm_id` and `verifier_perm_id` are unset then MUST abort.
-- if `issuer_perm_id` is specified, load `issuer_perm` from `issuer_perm_id`, Permission MUST exist and MUST be a [[ref: active permission]].
-- if `verifier_perm_id` is specified, load `verifier_perm` from `verifier_perm_id`, Permission MUST exist and MUST be a [[ref: active permission]].
+- if `issuer_participant_id` and `verifier_participant_id` are unset then MUST abort.
+- if `issuer_participant_id` is specified, load `issuer_participant` from `issuer_participant_id`, Permission MUST exist and MUST be a [[ref: active permission]].
+- if `verifier_participant_id` is specified, load `verifier_participant` from `verifier_participant_id`, Permission MUST exist and MUST be a [[ref: active permission]].
 
 ##### [MOD-PP-QRY-4-3] Find Beneficiaries execution
 
 Example: Let's build the set. Revoked and slashed permissions will not be added to the set. Expired permissions, if not revoked/slashed, will be considered.
 
-- create Set `found_perm_set`.
+- create Set `found_participant_set`.
 
-- define permission `current_perm` as null.
+- define permission `current_participant` as null.
 
-- load perms `issuer_perm` and optional `verifier_perm` as specified in basic checks above.
+- load perms `issuer_participant` and optional `verifier_participant` as specified in basic checks above.
 
-if `issuer_perm` is not null:
+if `issuer_participant` is not null:
 
-- set `current_perm` = `issuer_perm`
-- while `current_perm.validator_perm_id` is not null:
-  - current_perm = load(`current_perm.validator_perm_id`)
-  - if `current_perm.revoked` is NULL AND `current_perm.slashed` is NULL, Add `current_perm` to `found_perm_set`.
+- set `current_participant` = `issuer_participant`
+- while `current_participant.validator_participant_id` is not null:
+  - current_participant = load(`current_participant.validator_participant_id`)
+  - if `current_participant.revoked` is NULL AND `current_participant.slashed` is NULL, Add `current_participant` to `found_participant_set`.
 
-Additionally, if `verifier_perm` is not null:
+Additionally, if `verifier_participant` is not null:
 
-- if `issuer_perm` is not null, add `issuer_perm` to `found_perm_set`
-- set `current_perm` = `verifier_perm`
-- while `current_perm.validator_perm_id` != null:
-  - current_perm = load(`current_perm.validator_perm_id`)
-  - if `current_perm.revoked` is NULL AND `current_perm.slashed` is NULL, Add `current_perm` to `found_perm_set`.
+- if `issuer_participant` is not null, add `issuer_participant` to `found_participant_set`
+- set `current_participant` = `verifier_participant`
+- while `current_participant.validator_participant_id` != null:
+  - current_participant = load(`current_participant.validator_participant_id`)
+  - if `current_participant.revoked` is NULL AND `current_participant.slashed` is NULL, Add `current_participant` to `found_participant_set`.
 
 return `found_perms`.
 
@@ -4758,12 +4758,12 @@ participant "Verifiable Public Registry" as VPR #3fbdb6
 
 ApplicantAccount --> VPR: Start Permission VP
 VPR <-- VPR: create permission entry.
-ApplicantAccount <-- VPR: permission entry created,\nassigned perm.validator_perm_id from ISSUER_GRANTOR permissions.
-ApplicantBrowser --> ValidatorVS: connect to validator VS DID found in validator_perm.did\nby creating a DIDComm connection
+ApplicantAccount <-- VPR: permission entry created,\nassigned participant.validator_participant_id from ISSUER_GRANTOR permissions.
+ApplicantBrowser --> ValidatorVS: connect to validator VS DID found in validator_participant.did\nby creating a DIDComm connection
 ApplicantBrowser <-- ValidatorVS: DIDComm connection established.
-ApplicantBrowser --> ValidatorVS: I want to proceed with perm.id=...
-ValidatorVS --> ValidatorVS: load perm with id=...\nand verify the associated perm.validator_perm_id is referring to me
-ApplicantBrowser <-- ValidatorVS: request proof of control\nof perm.applicant account (blind sign)
+ApplicantBrowser --> ValidatorVS: I want to proceed with participant.id=...
+ValidatorVS --> ValidatorVS: load perm with id=...\nand verify the associated participant.validator_participant_id is referring to me
+ApplicantBrowser <-- ValidatorVS: request proof of control\nof participant.applicant account (blind sign)
 ApplicantBrowser --> ValidatorVS: send blind sign proof of account
 ApplicantBrowser <-- ValidatorVS: proof accepted, you are the controller\nof validation entry, I trust you.
 ApplicantBrowser <-- ValidatorVS: which DID do you want to register as an issuer?
@@ -5312,7 +5312,7 @@ if any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 - Check if a **VS Operator Authorization** exists for `corporation` and `grantee`. If this is the case, MUST abort.
 
 ::: warning
-An **Operator Authorization** CAN be granted ONLY IF no **VS Operator Authorization** exists for `perm.corporation` and `perm.vs_operator`. **Operator Authorization** and **VS Operator Authorization** are mutually exclusive for a given grantee.
+An **Operator Authorization** CAN be granted ONLY IF no **VS Operator Authorization** exists for `participant.corporation` and `participant.vs_operator`. **Operator Authorization** and **VS Operator Authorization** are mutually exclusive for a given grantee.
 :::
 
 ##### [MOD-DE-MSG-3-3] Grant Operator Authorization fee checks
@@ -5392,7 +5392,7 @@ This method does NOT read `Permission` state. All authorization configuration is
 If any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 
 - `corporation` and `vs_operator` MUST NOT be null.
-- `record.perm_id` MUST NOT match an existing `PermissionAuthorizationRecord` anywhere in the store (each record is globally unique by `perm_id`).
+- `record.participant_id` MUST NOT match an existing `PermissionAuthorizationRecord` anywhere in the store (each record is globally unique by `participant_id`).
 - `record.msg_types` MUST be non-empty and MUST contain only VPR delegable message types.
 - No `OperatorAuthorization` `oauthz` where `oauthz.corporation` = `corporation` and `oauthz.operator` = `vs_operator` MUST exist.
 - No other `VSOperatorAuthorization` `vsoauthz'` where `vsoauthz'.vs_operator` = `vs_operator` AND `vsoauthz'.corporation` != `corporation` MUST exist. In other words, a vs-agent VPR account cannot be controlled by multiple corporations.
@@ -5439,19 +5439,19 @@ This method can only be called directly by the following Permission module metho
 - [Revoke Permission](#mod-pp-msg-9-revoke-permission)
 - [Slash Permission Trust Deposit](#mod-pp-msg-12-slash-permission-trust-deposit)
 
-It removes the unique [PermissionAuthorizationRecord](#permissionauthorizationrecord) identified by `perm_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no such record exists.
+It removes the unique [PermissionAuthorizationRecord](#permissionauthorizationrecord) identified by `participant_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no such record exists.
 
 This method does NOT read `Permission` state.
 
 ##### [MOD-DE-MSG-6-1] Revoke VS Operator Authorization method parameters
 
-- `perm_id` (uint64) (*mandatory*): id of the permission whose authorization record must be removed.
+- `participant_id` (uint64) (*mandatory*): id of the permission whose authorization record must be removed.
 
 ##### [MOD-DE-MSG-6-2] Revoke VS Operator Authorization basic checks
 
-- `perm_id` MUST be a valid uint64.
+- `participant_id` MUST be a valid uint64.
 
-> Note: absence of a record for `perm_id` is NOT an error. The method is a no-op in that case (the permission was never VS-operator-authorized, or was already revoked).
+> Note: absence of a record for `participant_id` is NOT an error. The method is a no-op in that case (the permission was never VS-operator-authorized, or was already revoked).
 
 ##### [MOD-DE-MSG-6-3] Revoke VS Operator Authorization fee checks
 
@@ -5459,7 +5459,7 @@ This method does NOT read `Permission` state.
 
 ##### [MOD-DE-MSG-6-4] Revoke VS Operator Authorization execution of the method
 
-- Locate the unique `PermissionAuthorizationRecord` `record` with `record.perm_id = perm_id`. If none exists, EXIT (no-op).
+- Locate the unique `PermissionAuthorizationRecord` `record` with `record.participant_id = participant_id`. If none exists, EXIT (no-op).
 - Let `vsoa` = the `VSOperatorAuthorization` that contains `record`.
 - Remove `record` from `vsoa.records`.
 - Call **[Recompute VS Operator Fee Allowance](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance)** for `vsoa`.
@@ -5472,21 +5472,21 @@ This method can only be called directly by the following Permission module metho
 - [Set Permission VP to Validated](#mod-pp-msg-3-set-permission-vp-to-validated)
 - [Adjust Permission](#mod-pp-msg-8-adjust-permission)
 
-It updates the `expiration` of the unique record identified by `perm_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no record exists for `perm_id`.
+It updates the `expiration` of the unique record identified by `participant_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no record exists for `participant_id`.
 
 This method does NOT read `Permission` state; the caller supplies the new expiration value directly.
 
 ##### [MOD-DE-MSG-9-1] Update VS Operator Authorization Expiration method parameters
 
-- `perm_id` (uint64) (*mandatory*): id of the permission whose authorization record's `expiration` must be updated.
+- `participant_id` (uint64) (*mandatory*): id of the permission whose authorization record's `expiration` must be updated.
 - `new_expiration` (timestamp) (*mandatory*): the new value of `record.expiration`.
 
 ##### [MOD-DE-MSG-9-2] Update VS Operator Authorization Expiration basic checks
 
-- `perm_id` MUST be a valid uint64.
+- `participant_id` MUST be a valid uint64.
 - `new_expiration` MUST be a valid timestamp.
 
-> Note: absence of a record for `perm_id` is NOT an error. The method is a no-op in that case (the permission does not enable VS operator authorization).
+> Note: absence of a record for `participant_id` is NOT an error. The method is a no-op in that case (the permission does not enable VS operator authorization).
 
 ##### [MOD-DE-MSG-9-3] Update VS Operator Authorization Expiration fee checks
 
@@ -5494,7 +5494,7 @@ This method does NOT read `Permission` state; the caller supplies the new expira
 
 ##### [MOD-DE-MSG-9-4] Update VS Operator Authorization Expiration execution of the method
 
-- Locate the unique `PermissionAuthorizationRecord` `record` with `record.perm_id = perm_id`. If none exists, EXIT (no-op).
+- Locate the unique `PermissionAuthorizationRecord` `record` with `record.participant_id = participant_id`. If none exists, EXIT (no-op).
 - Set `record.expiration = new_expiration`.
 - Call **[Recompute VS Operator Fee Allowance](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance)** for the VSOA containing `record`.
 

--- a/spec.md
+++ b/spec.md
@@ -554,30 +554,77 @@ The same `Corporation` entry is the single entry point for the corporation's gov
 
 *This section is non-normative.*
 
-The `Participant` registry CAN be used by crawlers to index the metadata associated with [[ref: verifiable services]].
+The `Participant` registry is the foundation for building **searchable indexes of [[ref: verifiable services]] and the verifiable metadata they expose**. Crawlers iterate over `Participant` entries, resolve each service identifier (currently a [[ref: DID]], extensible in the future), verify that the service is a [[ref: verifiable service]], and extract its verifiable metadata — most notably the credentials presented through [[ref: linked-vp]] — together with the [[ref: ecosystem]] memberships, [[ref: credential schema]] permissions, and [[ref: trust deposit]] level associated with the controlling [[ref: corporation]].
 
-Search engines can iterate over `Participant` entries and index [[ref: VSs]] by resolving the service identifier (currently a [[ref: DID]], extensible in the future), verify whether the service is a [[ref: verifiable service]], and in that case extract its verifiable metadata, such as [[ref: linked-vp]] presented credentials.
+Unlike a traditional web index, this index is **trust-typed**: every entry carries cryptographically verifiable claims about *what* the service is, *who* operates it, and *under which governance frameworks* it is accredited. This unlocks a class of discovery use cases that traditional search engines cannot serve.
 
-The index is particularly important for [[ref: verifiable user agents]], such as social browsers, CDN enabled browser, or any service or AI agent that wants to search for a specific service and connect to it. However, it can also be leveraged by **traditional, form-based search engines**, which may return simple links for accessing [[ref: VSs]].
+#### AI agent discovery
+
+AI agents are first-class consumers of the index. Before delegating a task or accepting a connection, an agent needs to find counterparts whose **presented credentials match the capabilities required for the interaction**. Querying the index, an AI agent can:
+
+- find [[ref: verifiable services]] qualified for a specific task — for example, a payment processor accredited in a given jurisdiction, a KYC issuer recognized by a target [[ref: ecosystem]], or an MCP-style service whose operator holds a recognized organization credential;
+- discover other AI agents whose credentials prove the right scope, authority, or operator;
+- restrict the search to a specific [[ref: ecosystem]] or to services that comply with a chosen [[ref: credential schema]];
+- rank candidates by [[ref: trust deposit]] size, accreditations held, slashing history, or credential freshness, in order to bias selection toward parties with stronger economic accountability.
+
+Because every indexed claim is anchored in the [[ref: VPR]], an AI agent can verify a counterpart end-to-end *before* initiating the interaction, avoiding spoofed services and unaccredited issuers.
+
+#### Verifiable User Agent content discovery
+
+[[ref: Verifiable user agents]] (VUAs) — such as social browsers, agentic browsers, or CDN-aware clients — use the index to **find content and services that are compatible with the user's context**: the credentials the user holds, the [[ref: ecosystems]] the user trusts, the jurisdictions and languages that apply, and the schemas that the user's wallet can satisfy.
+
+Typical VUA queries include:
+
+- *"Show only services accredited under ecosystem X"* — filter by [[ref: ecosystem]] membership.
+- *"Show services that accept the credentials currently in my wallet"* — match the holder's credentials against each [[ref: VS]]'s expected presentations.
+- *"Show issuers of schema Y operating in jurisdiction Z"* — combine [[ref: credential schema]] permissions with corporation metadata.
+- *"Show services my user has previously interacted with successfully"* — combine the index with the VUA's local history.
+
+The result is a feed of [[ref: VSs]] for which a proof of trust can be displayed to the user *before* connection, in line with the VUA enforcement obligations defined in this spec and in the [[ref: VT Spec]].
+
+#### Other consumers
+
+The same index serves additional consumers:
+
+- **Trust-aware and traditional, form-based search engines**, which can return ordinary links to [[ref: VSs]] enriched with verifiable trust signals (issuer accreditations, [[ref: ecosystem]] memberships, [[ref: trust deposit]] level).
+- **Ecosystem operators and governance authorities**, which use the index to monitor accredited issuers, verifiers, and grantors, observe schema adoption across [[ref: ecosystems]], and detect rogue or expired participants.
+- **Auditors, regulators, and compliance tools**, which rely on the index to map the supply chain of trust behind a given service or credential, and to verify that participants are still in good standing.
+- **Analytics and reputation services**, which combine indexed metadata with on-chain history (trust-deposit movements, slashing events, session volumes) to produce reputational signals at the [[ref: corporation]] level.
+
+#### Indexing pipeline
 
 
 ```plantuml
 
 @startuml
-scale max 800 width
+scale max 1000 width
+
 object "Participant registry" as didd
 object "Crawler" as crawler #3fbdb6
 object "Index" as index #3fbdb6
+
 object "VS #1" as dts1 #7677ed
 object "VS #2" as dts2 #7677ed
+
+object "AI agent" as aiagent #ffb347
 object "VUA" as browser #00b0f0
+object "Search engine" as search #d3d3d3
+object "Governance /\nAudit / Analytics" as gov #f5b7b1
+
 object "User" as user
-didd <|-- crawler : iterate over Participant registry
-crawler --|> dts1 : resolve DID, get linked-vps, index data
-crawler --|> dts2 : resolve DID, get linked-vps, index data
-browser --|> index: query index
-crawler --|> index: create/update index 
-user <|-- browser : show result
+
+didd <|-- crawler : iterate Participant registry
+crawler --|> dts1 : resolve DID, fetch linked-vps,\nindex verifiable metadata
+crawler --|> dts2 : resolve DID, fetch linked-vps,\nindex verifiable metadata
+crawler --|> index : create / update index
+
+aiagent --|> index : query (find counterparts\nby credentials presented)
+browser --|> index : query (find content\ncompatible with user context)
+search --|> index : query (enrich links\nwith trust signals)
+gov --|> index : query (monitor accreditations,\naudit, build reputation)
+
+user <|-- browser : show feed of\nverifiable services
+user <|-- search : show enriched\nsearch results
 @enduml
 
 ```

--- a/spec.md
+++ b/spec.md
@@ -3285,7 +3285,7 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 
 - else if `role` (ParticipantRole) is equal to VERIFIER:
 
-  - if `cs.verifier_onboarding_mode` is equal to GRANTOR: `validator_participant.role` MUST be VERIFIER_GRANTOR, else MUST abort.
+  - if `cs.verifier_onboarding_mode` is equal to GRANTOR_ONBOARDING_PROCESS: `validator_participant.role` MUST be VERIFIER_GRANTOR, else MUST abort.
   
   - else if `cs.verifier_onboarding_mode` is equal to ECOSYSTEM_ONBOARDING_PROCESS: `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
 

--- a/spec.md
+++ b/spec.md
@@ -1180,7 +1180,7 @@ entity "TrustDeposit" as td {
   slash_count: number
 }
 
-corp --o fg: grantor
+group --o fg: grantor
 account --o fg: grantee
 fg "1" --- "0..n" da: spend_limit
 fg "1" --- "0..n" da: remaining_spend
@@ -1195,10 +1195,10 @@ xr --- "1..n" account: update_whitelist
 
 cs o-- pricingassettype: pricing_asset_type 
 
-corp --o oauthz: corporation
+group --o oauthz: corporation
 account --o oauthz: operator
 
-corp --o vsoauthz: corporation
+group --o vsoauthz: corporation
 account --o vsoauthz: vs_operator
 vsoauthz "1" --- "1..n" par: records
 par o-- csp: participant_id
@@ -1237,16 +1237,16 @@ gfv "1" --- "1..n" gfd: documents
 
 group "1" --- "1" corp
 
-corp --o tr: corporation
-corp --o csp: corporation
-corp --o csps: corporation
+group --o tr: corporation
+group --o csp: corporation
+group --o csps: corporation
 
 account --o csp: vs_operator
 
 csps o-- account: vs_operator
 
 valstate --o csp: op_state
-corp --o td: corporation
+group --o td: corporation
 
 @enduml
 
@@ -1273,7 +1273,7 @@ A `Corporation` is the VPR-level entity that extends a Cosmos SDK [[ref: group]]
 
 - `id` (uint64) (*mandatory*): the id of the ecosystem.
 - `did` (string) (*mandatory*): the did of the ecosystem.
-- `corporation` (Corporation) (*mandatory*): [[ref: corporation]] that controls this entry.
+- `corporation` (group) (*mandatory*): [[ref: corporation]] that controls this entry.
 - `created` (timestamp) (*mandatory*): timestamp this Ecosystem has been created.
 - `modified` (timestamp) (*mandatory*): timestamp this Ecosystem has been modified.
 - `archived` (timestamp) (*mandatory*): timestamp this Ecosystem has been archived.
@@ -1352,7 +1352,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 - `schema_id` (uint64) (*mandatory*): the id of the related `CredentialSchema` entry.
 - `type` (ParticipantRole): ISSUER, VERIFIER, ISSUER_GRANTOR, VERIFIER_GRANTOR, ECOSYSTEM, HOLDER
 - `did` (string) (*optional*): [[ref: DID]] this permission refers to. MUST conform to [[spec-norm:RFC3986]].
-- `corporation` (Corporation) (*mandatory*): [[ref: corporation]] that owns this permission.
+- `corporation` (group) (*mandatory*): [[ref: corporation]] that owns this permission.
 - `vs_operator` (account) (*mandatory*): verifiable service agent account. This is the account that will have the right to create or update permission sessions.
 - `created` (timestamp) (*mandatory*): timestamp this `Participant` has been created.
 - `adjusted` (timestamp) (*mandatory*): timestamp this `Participant` has been adjusted.
@@ -1386,7 +1386,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 `ParticipantSession`:
 
 - `id` (uuid) (*mandatory*): session uuid.
-- `corporation` (Corporation) (*mandatory*): corporation that controls the entry.
+- `corporation` (group) (*mandatory*): corporation that controls the entry.
 - `vs_operator` (account) (*mandatory*): verifiable service agent account that controls the entry (agent crypto account).
 - `created` (timestamp) (*mandatory*): timestamp this ParticipantSession has been created.
 - `modified` (timestamp) (*mandatory*): timestamp this ParticipantSession has been modified.
@@ -1407,7 +1407,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 `TrustDeposit`:
 
 - `share` (number) (*mandatory*): share of the module total deposit.
-- `corporation` (Corporation) (*mandatory*) (key): the [[ref: corporation]]
+- `corporation` (group) (*mandatory*) (key): the [[ref: corporation]]
 - `deposit` (number) (*mandatory*): amount of deposit in `denom`.
 - `refunded` (number) (*mandatory*): amount of refunded trust deposit, in `denom`. Refunded trust deposit is reused as funding for the next trust deposit spending before drawing additional funds from the corporation account.
 - `slashed_deposit` (number) (*optional*): amount of slashed deposit in `denom`.
@@ -1428,7 +1428,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 
 ### OperatorAuthorization
 
-- `corporation` (Corporation) (*mandatory*): the [[ref: corporation]] granting the authorization.
+- `corporation` (group) (*mandatory*): the [[ref: corporation]] granting the authorization.
 - `operator` (account) (*mandatory*): the operator account receiving the authorization.
 - `msg_types` (msg_type[]) (*mandatory*): list of module message types this authorization applies to.
 - `spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds that the grantee is allowed to spend
@@ -1443,7 +1443,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 
 `FeeGrant`:
 
-- `grantor` (Corporation) (*mandatory*): the [[ref: corporation]] granting the fee allowance.
+- `grantor` (group) (*mandatory*): the [[ref: corporation]] granting the fee allowance.
 - `grantee` (account) (*mandatory*): the account that receives the fee grant from `grantor`.
 - `msg_types` (msg_type[]) (*mandatory*): list of VPR delegable message types for which the fee allowance applies.
 - `spend_limit` (DenomAmount[]) (*optional*): maximum amount of fees that can be spent using this grant.
@@ -1455,7 +1455,7 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 
 A `VSOperatorAuthorization` groups all `ParticipantAuthorizationRecord` entries delegated by one `corporation` to one `vs_operator`. It is keyed by the `(corporation, vs_operator)` pair. The entry exists if, and only if, it has at least one record.
 
-- `corporation` (Corporation) (*mandatory*): the [[ref: corporation]] granting the authorization.
+- `corporation` (group) (*mandatory*): the [[ref: corporation]] granting the authorization.
 - `vs_operator` (account) (*mandatory*): the operator account receiving the authorization.
 - `records` (ParticipantAuthorizationRecord[]) (*mandatory*): per-permission authorization records granted to `vs_operator` by `corporation`.
 
@@ -1660,7 +1660,7 @@ Delegable messages are defined as messages that can be executed by an `operator`
 
 Such messages conceptually involve **two roles**:
 
-- `corporation` (Corporation):  
+- `corporation` (group):  
   The `group` that owns the created or manipulated resource.  
   The corporation is represented in the Msg through an authorization granted to an `operator` account.
 
@@ -1689,7 +1689,7 @@ It is entirely up to the `corporation` group to decide **which accounts may exec
 
 Some module messages specify only a `corporation`:
 
-- `corporation` (Corporation):  
+- `corporation` (group):  
   The `group` that owns the manipulated resource.
 
 Such messages **cannot be delegated** and MUST be executed exclusively through a **group proposal**.
@@ -1878,7 +1878,7 @@ Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR /
 
 ### Corporation Module
 
-This module manages [[ref: corporation]] entries — the VPR-level entity that extends a Cosmos SDK [[ref: group]] with a DID, a governance framework, and lifecycle attributes. A `Corporation` entry MUST exist before its underlying group can be referenced as the `corporation` (Corporation) in any other VPR Create-* method (see [[MOD-CO-MSG-1]](#mod-co-msg-1-create-new-corporation)).
+This module manages [[ref: corporation]] entries — the VPR-level entity that extends a Cosmos SDK [[ref: group]] with a DID, a governance framework, and lifecycle attributes. A `Corporation` entry MUST exist before its underlying group can be referenced as the `corporation` (group) in any other VPR Create-* method (see [[MOD-CO-MSG-1]](#mod-co-msg-1-create-new-corporation)).
 
 #### [MOD-CO-MSG-1] Create New Corporation
 
@@ -1888,7 +1888,7 @@ Any authorized `operator` CAN execute this method on behalf of a Cosmos SDK [[re
 
 An authorized `operator` that would like to register a Cosmos SDK [[ref: group]] as a `Corporation` MUST call this method by specifying:
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed. For this method specifically, the underlying Cosmos SDK [[ref: group]] of `corporation` is the group that wants to register itself — no `Corporation` entry exists for that group yet.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed. For this method specifically, the underlying Cosmos SDK [[ref: group]] of `corporation` is the group that wants to register itself — no `Corporation` entry exists for that group yet.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `did` (string) (*mandatory*): the DID of the Corporation.
 - `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this Corporation.
@@ -1905,7 +1905,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - A `Corporation` entry for the signing [[ref: group]] MUST NOT exist; if one exists, method MUST abort (a group MAY register itself as a `Corporation` at most once).
@@ -1959,7 +1959,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-CO-MSG-2-1] Update Corporation parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `did` (string) (*mandatory*): the new DID of the Corporation.
 - `language` (string) (*mandatory*): primary language tag of this Corporation.
@@ -1972,7 +1972,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - A `Corporation` entry `co` for the signing `corporation` MUST exist; if none exists, method MUST abort.
@@ -2001,7 +2001,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-CO-MSG-3-1] Archive Corporation parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `archive` (boolean) (*mandatory*): true means archive, false means unarchive.
 
@@ -2013,7 +2013,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - load `Corporation` `co` from the id of the signing `corporation`. If none exists, MUST abort.
@@ -2138,7 +2138,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 An authorized `operator` that would like to create a [[ref: ecosystem]] MUST call this method by specifying:
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `did` (string) (*mandatory*): the did of the ecosystem that is creating the ecosystem.
 - `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this ecosystem.
@@ -2155,7 +2155,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
@@ -2213,7 +2213,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-ES-MSG-2-1] Update Ecosystem parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): the id of the ecosystem.
 - `did` (string) (*mandatory*): the did of the ecosystem.
@@ -2226,7 +2226,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` (uint64) (*mandatory*): a `Ecosystem` entry `tr` with id `id` MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry `tr`.
@@ -2253,7 +2253,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-ES-MSG-3-1] Archive Ecosystem parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*) id of the ecosystem (*mandatory*);
 - `archive` (boolean) (*mandatory*), true means archive, false means unarchive.
@@ -2266,7 +2266,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - load `Ecosystem` `tr` from `id`. `ecosystem.corporation` MUST be the corporation executing the method, else MUST abort.
@@ -2343,7 +2343,7 @@ return found `Ecosystem` entry (if any), as well as *all its nested* `Governance
 
 The following parameters are optional:
 
-- `corporation` (Corporation) (*optional*): if specified, filter by corporation.
+- `corporation` (group) (*optional*): if specified, filter by corporation.
 - `modified_after` (timestamp) (*optional*): if specified, returns only `Ecosystem` entries with `Ecosystem.modified` greater than `modified`.
 - `active_gf_only` (boolean) (*optional*): if true, include only current governance framework data. If false or null, returns everything.
 - `preferred_language` (string) (*optional*): if set, return only one document per version, with language=`preferred_language` when possible, else if no document exist with this language, return language. If not set, return all documents of all languages.
@@ -2396,7 +2396,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-GF-MSG-1-1] Add Governance Framework Document parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]] whose governance framework will be modified. MUST be set if `corporation_id` is null.
 - `corporation_id` (uint64) (*conditional*): id of the target [[ref: corporation]] whose governance framework will be modified. MUST be set if `ecosystem_id` is null.
@@ -2415,7 +2415,7 @@ If any of these precondition checks fail, method MUST abort.
 
 if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - Exactly one of `ecosystem_id` and `corporation_id` MUST be set; if both are set or both are null, method MUST abort.
@@ -2462,7 +2462,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-GF-MSG-2-1] Increase Active Governance Framework Version parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]]. MUST be set if `corporation_id` is null.
 - `corporation_id` (uint64) (*conditional*): id of the target [[ref: corporation]]. MUST be set if `ecosystem_id` is null.
@@ -2475,7 +2475,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - Exactly one of `ecosystem_id` and `corporation_id` MUST be set; if both are set or both are null, method MUST abort.
@@ -2556,7 +2556,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 An [[ref: account]] that would like to create a [[ref: credential schema]] MUST call this method by specifying:
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `ecosystem_id` id of the ecosystem (*mandatory*);
 - `json_schema` the [[ref: Json Schema]] of the credential (*mandatory*).
@@ -2580,7 +2580,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `ecosystem_id` MUST represent an existing `Ecosystem` entry `tr` and `ecosystem.corporation` MUST be the `corporation` executing the method.
@@ -2646,7 +2646,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 An [[ref: account]] that would like to update a [[ref: credential schema]] MUST call this method by specifying:
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` id of the credential schema (*mandatory*);
 - `issuer_grantor_validation_validity_period` (*mandatory*), default to 0 (days).
@@ -2665,7 +2665,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST represent an existing `CredentialSchema` entry `cs`.
@@ -2703,7 +2703,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 An [[ref: account]] that would like to archive or unarchive a [[ref: credential schema]] MUST call this method by specifying:
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*) id of the credential schema (*mandatory*);
 - `archive` (boolean) (*mandatory*), true means archive, false means unarchive.
@@ -2716,7 +2716,7 @@ If any of these precondition checks fail, method MUST abort.
 
 - if a mandatory parameter is not present, method MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST represent an existing `CredentialSchema` entry `cs`.
@@ -2784,7 +2784,7 @@ Accordingly, if a credential schema defines one or more active policies for the 
 
 ##### [MOD-CS-MSG-5-1] Create Schema Authorization Policy parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `schema_id` (uint64): id of the related `CredentialSchema` (*mandatory*).
 - `role` (SchemaAuthorizationPolicyRole): `ISSUER` or `VERIFIER` (*mandatory*).
@@ -2798,7 +2798,7 @@ If any of these precondition checks fail, method MUST abort.
 ###### [MOD-CS-MSG-5-2-1] Create Schema Authorization Policy basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `schema_id` MUST reference an existing `CredentialSchema` entry controlled by `corporation`.
@@ -2841,7 +2841,7 @@ This message activates the current draft `SchemaAuthorizationPolicy` for the giv
 
 ##### [MOD-CS-MSG-6-1] Increase Active Schema Authorization Policy Version parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `schema_id` (uint64): id of the related `CredentialSchema` (*mandatory*).
 - `role` (SchemaAuthorizationPolicyRole): `ISSUER` or `VERIFIER` (*mandatory*).
@@ -2853,7 +2853,7 @@ If any of these precondition checks fail, method MUST abort.
 ###### [MOD-CS-MSG-6-2-1] Basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `schema_id` MUST reference an existing `CredentialSchema` entry controlled by `corporation`.
@@ -2884,7 +2884,7 @@ This message revokes a previously enabled `SchemaAuthorizationPolicy` version. R
 
 ##### [MOD-CS-MSG-7-1] Revoke Schema Authorization Policy parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `schema_id` (uint64): id of the related `CredentialSchema` (*mandatory*).
 - `role` (SchemaAuthorizationPolicyRole): `ISSUER` or `VERIFIER` (*mandatory*).
@@ -2897,7 +2897,7 @@ If any of these precondition checks fail, method MUST abort.
 ###### [MOD-CS-MSG-7-2-1] Basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - a policy MUST exist for `(schema_id, role, version)`.
@@ -3120,10 +3120,10 @@ issuer --> holder: granted schema permission
 
 ```
 
-`ECOSYSTEM` Participants are created directly by the [[ref: credential schema]] owner. All other Participants are created by running an [[ref: onboarding process]] — except for permissions whose onboarding mode is `OPEN`, which any account CAN create directly:
+`ECOSYSTEM` Participants are created directly by the [[ref: credential schema]] owner. All other Participants are created by running an [[ref: onboarding process]] — except when onboarding mode is set to `OPEN` for ISSUER and/or VERIFIER Participants, which any account CAN create directly:
 
-- `ISSUER` permissions when `issuer_onboarding_mode` is `OPEN`;
-- `VERIFIER` permissions when `verifier_onboarding_mode` is `OPEN`.
+- `ISSUER` Participants when `issuer_onboarding_mode` is `OPEN`;
+- `VERIFIER` Participants when `verifier_onboarding_mode` is `OPEN`.
 
 An [[ref: onboarding process]] (OP) involves an [[ref: applicant]] (the [[ref: corporation]] of a given Participant entry) and a [[ref: validator]] Participant. It MAY require the applicant to pay `validation_fees` in addition to [[ref: transaction fees]].
 
@@ -3165,7 +3165,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 An Applicant that would like to start a permission onboarding process MUST execute this method by specifying:
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `vs_operator` (account) (*optional*): the account of the Veriable Service we want to authorize to create permission sessions linked to this permission. If not specified, Verifiable Service will not be able to use the payment delegation feature. **Required** to use the payment delegation feature.
 - `type` (ParticipantRole) (*mandatory*): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the permission that the applicant would like to get;
@@ -3205,7 +3205,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `type` (ParticipantRole) (*mandatory*) MUST be a valid ParticipantRole: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.
@@ -3399,7 +3399,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-PP-MSG-2-1] Renew Participant OP parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission for which applicant would like to renew the onboarding process;
 
@@ -3411,7 +3411,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64 and a permission entry with the same id MUST exist.
@@ -3492,7 +3492,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 An [[ref: account]] that would like to set a validation entry to VALIDATED MUST execute this method by specifying:
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the onboarding process;
 - `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this `Participant` is effective, null if no time limit should been set for this permission or if we want it to be aligned with the onboarding process expiration timestamp calculated by this method.
@@ -3511,7 +3511,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - `id` MUST be a valid uint64.
 - Load `Participant` entry `applicant_participant` from `id`. If no entry found, abort.
@@ -3669,7 +3669,7 @@ At any time, [[ref: applicant]] of a permission onboarding process may request c
 
 ##### [MOD-PP-MSG-6-1] Cancel Participant OP Last Request parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the `Participant` entry;
 
@@ -3681,7 +3681,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
@@ -3726,7 +3726,7 @@ This method is used by controller authorities of Ecosystems. When they create a 
 
 An [[ref: account]] that would like to create a `Participant` entry MUST call this method by specifying:
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `schema_id` (uint64) (*mandatory*)
 - `vs_operator` (account) (*optional*): the account we want to authorize to act on behalf of `corporation` in the context of this permission. **Required** for payment delegation.
@@ -3759,7 +3759,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `schema_id` MUST be a valid uint64 and a [[ref: credential schema]] entry with this id MUST exist.
@@ -3852,7 +3852,7 @@ This method can be called:
 
 ##### [MOD-PP-MSG-8-1] Adjust Participant parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
 - `effective_until` (timestamp) (*mandatory*): timestamp until when (exclusive) this `Participant` will be effective.
@@ -3865,7 +3865,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
@@ -3942,7 +3942,7 @@ This method can only be called:
 
 ##### [MOD-PP-MSG-9-1] Revoke Participant parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
 
@@ -3954,7 +3954,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
@@ -4106,7 +4106,7 @@ See [[ref: VT spec]].
 
 An [[ref: account]] that would like to create or update a `ParticipantSession` entry MUST send a Msg by specifying:
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uuid) (*mandatory*): id of the `ParticipantSession`.
 - `issuer_participant_id` (uint64) (*optional*): the id of the perm of the issuer, if we are dealing with the issuance of a credential.
@@ -4119,7 +4119,7 @@ An [[ref: account]] that would like to create or update a `ParticipantSession` e
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - `id` MUST be a valid uuid. If an entry `existing_entry` with `id` already exist, then  `existing_entry.corporation` MUST be equal to `corporation` AND `existing_entry.vs_operator` MUST be equal to `operator`, else abort.
 
@@ -4533,7 +4533,7 @@ This method can only be called by either:
 
 ##### [MOD-PP-MSG-12-1] Slash Participant Trust Deposit parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
 - `amount` (number) (*mandatory*): the amount to slash
@@ -4546,7 +4546,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
@@ -4609,7 +4609,7 @@ Nevertheless, to get a new permission for a given ecosystem, it is needed, using
 
 ##### [MOD-PP-MSG-13-1] Repay Participant Slashed Trust Deposit parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission
 
@@ -4621,7 +4621,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
@@ -4660,7 +4660,7 @@ Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else
 
 ##### [MOD-PP-MSG-14-1] Self Create Participant parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `type` (ParticipantRole) (*mandatory*): ISSUER or VERIFIER.
 - `validator_participant_id` (uint64) (*mandatory*): MUST be an ECOSYSTEM [[ref: active participant]] or [[ref: future participant]].
@@ -4697,7 +4697,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 Load `Participant` `validator_participant` from `validator_participant_id`.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `type` (ParticipantRole) (*mandatory*): MUST be ISSUER or VERIFIER, else abort.
@@ -4801,7 +4801,7 @@ The method does not modify the [[ref: VPR]] state; it only emits an event that o
 
 ##### [MOD-PP-MSG-15-1] Trigger Resolver parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission for which a trust resolution must be triggered.
 
@@ -4813,7 +4813,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - `id` MUST be a valid uint64.
 - Load `Participant` entry `perm` from `id`. If no entry found, abort.
@@ -5239,7 +5239,7 @@ Only the modules that require trust deposit manipulation CAN call this method. I
 
 ##### [MOD-TD-MSG-1-1] Adjust Trust Deposit method parameters
 
-- `corporation` (Corporation) (*mandatory*): corporation owner of the [[ref: trust deposit]] we want to adjust.
+- `corporation` (group) (*mandatory*): corporation owner of the [[ref: trust deposit]] we want to adjust.
 - `augend` (number) (*mandatory*): value to add to the deposit, in [[ref: denom]].
 
 ##### [MOD-TD-MSG-1-2] Adjust Trust Deposit precondition checks
@@ -5332,12 +5332,12 @@ If `claimable_yield` is positive, it can be claimed.
 
 ##### [MOD-TD-MSG-2-1] Reclaim Trust Deposit Yield method parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 
 ##### [MOD-TD-MSG-2-2] Reclaim Trust Deposit Yield precondition checks
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 
@@ -5408,7 +5408,7 @@ This method is for network governance authority slash. For ecosystem slash, see 
 
 ##### [MOD-TD-MSG-5-1] Slash Trust Deposit method parameters
 
-- `corporation` (Corporation) (*mandatory*): corporation we want to slash.
+- `corporation` (group) (*mandatory*): corporation we want to slash.
 - `amount` (number) (*mandatory*): value to slash, in [[ref: denom]].
 
 ##### [MOD-TD-MSG-5-2] Slash Trust Deposit precondition checks
@@ -5447,7 +5447,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-TD-MSG-6-1] Repay Slashed Trust Deposit method parameters
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `amount` (number) (*mandatory*): value to repay, in [[ref: denom]].
 
@@ -5459,7 +5459,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `amount` must be > 0.
@@ -5494,7 +5494,7 @@ Make sure to **properly protect access to the execution of this method** else it
 
 ##### [MOD-TD-MSG-7-1] Burn Ecosystem Slashed Trust Deposit method parameters
 
-- `corporation` (Corporation) (*mandatory*): corporation of the [[ref: trust deposit]] we want to burn.
+- `corporation` (group) (*mandatory*): corporation of the [[ref: trust deposit]] we want to burn.
 - `amount` (number) (*mandatory*): value to burn, in [[ref: denom]].
 
 :::warning
@@ -5581,7 +5581,7 @@ This method can only be called directly by the following methods:
 
 ##### [MOD-DE-MSG-1-1] Grant Fee Allowance method parameters
 
-- `corporation` (Corporation) (*mandatory*): the corporation that grants the fees.
+- `corporation` (group) (*mandatory*): the corporation that grants the fees.
 - `grantee` (account) (*mandatory*): the account that receives the fee grant from `corporation`.
 - `msg_types` (Msg[]) (*mandatory*): the type of messages for which we want to grant the fee allowance.
 - `expiration` (timestamp) (*optional*): when the grant expires.
@@ -5626,14 +5626,14 @@ This method can only be called directly by the following methods:
 
 ##### [MOD-DE-MSG-2-1] Revoke Allowance method parameters
 
-- `corporation` (Corporation) (*mandatory*): the corporation.
+- `corporation` (group) (*mandatory*): the corporation.
 - `grantee` (account) (*mandatory*): the grantee we want to revoke.
 
 ##### [MOD-DE-MSG-2-2] Revoke Fee Allowance basic checks
 
 MUST abort if one of these conditions fails:
 
-- `corporation` (Corporation) (*mandatory*): MUST be specified.
+- `corporation` (group) (*mandatory*): MUST be specified.
 - `grantee` (account) (*mandatory*): MUST be specified.
 
 ##### [MOD-DE-MSG-2-3] Revoke Fee Allowance fee checks
@@ -5651,7 +5651,7 @@ If FeeGrant entry for this (`corporation`, `grantee`) exist, delete it, else do 
 
 ##### [MOD-DE-MSG-3-1] Grant Operator Authorization method parameters
 
-- `corporation` (Corporation) (*mandatory*): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group) (*mandatory*): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account) (*optional*): (Signer) the account authorized by the `corporation` to run this Msg.
 - `grantee` (account) (*mandatory*): the account that receives the authorization from `corporation`.
 - `msg_types` (Msg[]) (*mandatory*): the type of messages for which we want to grant the fee allowance.
@@ -5666,7 +5666,7 @@ If FeeGrant entry for this (`corporation`, `grantee`) exist, delete it, else do 
 
 if any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `msg_types` (Msg[]) (*mandatory*): MUST be a list of **VPR delegable messages only**, excepted `CreateOrUpdateParticipantSession` which is not allowed.
@@ -5716,7 +5716,7 @@ else if `with_feegrant` is true:
 
 ##### [MOD-DE-MSG-4-1] Revoke Operator Authorization method parameters
 
-- `corporation` (Corporation) (*mandatory*): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group) (*mandatory*): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account) (*mandatory*): (Signer) the account authorized by the `corporation` to run this Msg.
 - `grantee` (account) (*mandatory*): the account that will be revoked its authorization`.
 
@@ -5724,7 +5724,7 @@ else if `with_feegrant` is true:
 
 MUST abort if one of these conditions fails:
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - An Authorization entry MUST exist for this (`corporation`, `grantee`)
@@ -5751,7 +5751,7 @@ This method does NOT read `Participant` state. All authorization configuration i
 
 ##### [MOD-DE-MSG-5-1] Grant VS Operator Authorization method parameters
 
-- `corporation` (Corporation) (*mandatory*): the corporation delegating the authorization.
+- `corporation` (group) (*mandatory*): the corporation delegating the authorization.
 - `vs_operator` (account) (*mandatory*): the account receiving the authorization.
 - `record` ([ParticipantAuthorizationRecord](#participantauthorizationrecord)) (*mandatory*): the full record to store.
 
@@ -5872,7 +5872,7 @@ Anyone CAN execute this method.
 
 ##### [MOD-DE-QRY-1-1] List Operator Authorizations parameters
 
-- `corporation` (Corporation) (*optional*): filter by the corporation group that granted the authorization.
+- `corporation` (group) (*optional*): filter by the corporation group that granted the authorization.
 - `operator` (account) (*optional*): filter by the operator account that received the authorization.
 - `response_max_size` (small number) (*optional*): limit to `response_max_size` results. Must be min 1, max 1,024. Default to 64.
 
@@ -5894,7 +5894,7 @@ Anyone CAN execute this method.
 
 ##### [MOD-DE-QRY-2-1] List VS Operator Authorizations parameters
 
-- `corporation` (Corporation) (*optional*): filter by the corporation group that granted the authorization.
+- `corporation` (group) (*optional*): filter by the corporation group that granted the authorization.
 - `vs_operator` (account) (*optional*): filter by the VS operator account that received the authorization.
 - `response_max_size` (small number) (*optional*): limit to `response_max_size` results. Must be min 1, max 1,024. Default to 64.
 
@@ -5917,7 +5917,7 @@ Return a list of `VSOperatorAuthorization` entries matching the filter criteria,
 
 ##### [MOD-DI-MSG-1-1] Store Digest method parameters
 
-- `corporation` (Corporation) (*mandatory*): (Signer) the signing corporation on whose behalf this message is executed.
+- `corporation` (group) (*mandatory*): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account) (*mandatory*): (Signer) the account authorized by the `corporation` to run this Msg.
 - `digest` (string) (*mandatory*): digest to store.
 
@@ -5929,7 +5929,7 @@ If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
 if any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 
-- `corporation` (Corporation): (Signer) signature must be verified.
+- `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - if `digest` is not present, abort.

--- a/spec.md
+++ b/spec.md
@@ -1,6 +1,6 @@
 # Verifiable Public Registry v4 Specification
 
-**Latest draft:** [spec v4-draft19](https://verana-labs.github.io/verifiable-trust-vpr-spec/)
+**Latest draft:** [spec v4-draft20](https://verana-labs.github.io/verifiable-trust-vpr-spec/)
 
 **Latest stable:** [spec v3](https://verana-labs.github.io/verifiable-trust-vpr-spec/index-v3.html)
 
@@ -2758,7 +2758,7 @@ issuer --> holder: granted schema permission
 
 The ECOSYSTEM type permissions are created by the Credential Schema owner. All other permissions are created by running an Onboarding Process (or by any account: - for `ISSUER` permissions if issuer_onboarding_mode is equal to `OPEN`, - for `VERIFIER` permissions if verifier_onboarding_mode is equal to `OPEN`).
 
-A Onboarding Process (VP) is a process which involves an [[ref: applicant]] (which is the [[ref: corporation]] of validation entry stored in a validation [[ref: keeper]]), a [[ref: validator]] permission, and optional validation fees plus transaction fees.
+An Onboarding Process (OP) is a process which involves an [[ref: applicant]] (which is the [[ref: corporation]] of validation entry stored in a validation [[ref: keeper]]), a [[ref: validator]] permission, and optional validation fees plus transaction fees.
 
 Validation is used by [[ref: applicants]] that want to:
 
@@ -2935,7 +2935,7 @@ Trust deposit MUST always be paid in [[ref: native denom]]
 
 ###### [MOD-PP-MSG-1-2-4] Start Participant OP overlap checks
 
-We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different VP with differents validators for the same `schema_id`, `type`.
+We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different OP with differents validators for the same `schema_id`, `type`.
 
 Find all permission `participants[]` for `schema_id`, `type`, `validator_participant_id`, `corporation` with op_state = VALIDATED or PENDING.
 
@@ -3481,7 +3481,7 @@ This method can be called:
 
 - by `participant.corporation`, if permission is of type ECOSYSTEM.
 - by `participant.corporation`, if it is a self-created permission (schema configuration is open)
-- by a `corporation` of a validator permission (if permission is managed by a VP).
+- by a `corporation` of a validator permission (if permission is managed by an OP).
 
 ##### [MOD-PP-MSG-8-1] Adjust Participant parameters
 
@@ -3519,7 +3519,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 - load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active participant]] of type ECOSYSTEM. `corporation` running the method MUST be `applicant_participant.corporation`.
 
-3. VP managed permissions
+3. OP managed permissions
 
 - `effective_until` MUST be lower or equal to `applicant_participant.op_exp` else MUST abort.
 - load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active participant]]. `corporation` running the method MUST be `validator_participant.corporation`.

--- a/spec.md
+++ b/spec.md
@@ -1281,7 +1281,7 @@ csp "1" --- "0..n" da: vs_operator_fee_spend_limit
 
 
 tr "1" --- "0..n" gfv: versions (ecosystem_id)
-corp "1" --- "0..n" gfv: versions (corporation_id)
+corp "1" --- "0..n" gfv: versions (corporation)
 gfv "1" --- "1..n" gfd: documents
 
 group "1" --- "1" corp
@@ -1331,17 +1331,17 @@ A `Corporation` is the VPR-level entity that extends a Cosmos SDK [[ref: group]]
 
 ### GovernanceFrameworkVersion
 
-A `GovernanceFrameworkVersion` represents a single version of either an [[ref: EGF]] or a [[ref: CGF]]. Its owning subject is identified by exactly one of `ecosystem_id` or `corporation_id` (XOR).
+A `GovernanceFrameworkVersion` represents a single version of either an [[ref: EGF]] or a [[ref: CGF]]. Its owning subject is identified by exactly one of `ecosystem_id` or `corporation` (XOR).
 
 `GovernanceFrameworkVersion`:
 
 - `id` (uint64) (*mandatory*): the id of the GFV.
-- `ecosystem_id` (uint64) (*conditional*): the id of the [[ref: ecosystem]] that controls this `GovernanceFrameworkVersion` entry. MUST be set if `corporation_id` is null.
-- `corporation_id` (uint64) (*conditional*): the id of the [[ref: corporation]] that controls this `GovernanceFrameworkVersion` entry. MUST be set if `ecosystem_id` is null.
+- `ecosystem_id` (uint64) (*conditional*): the id of the [[ref: ecosystem]] that controls this `GovernanceFrameworkVersion` entry. MUST be set if `corporation` is null.
+- `corporation` (group) (*conditional*): the [[ref: corporation]] that controls this `GovernanceFrameworkVersion` entry (i.e., the underlying Cosmos SDK [[ref: group]] of the owning `Corporation`). MUST be set if `ecosystem_id` is null.
 - `created` (timestamp) (*mandatory*): timestamp this GovernanceFrameworkVersion has been created.
 - `version` (int) (*mandatory*): version of this GF. MUST Starts with 1.
 
-> Constraint: exactly one of `ecosystem_id` and `corporation_id` MUST be set.
+> Constraint: exactly one of `ecosystem_id` and `corporation` MUST be set.
 
 ### GovernanceFrameworkDocument
 
@@ -1986,7 +1986,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - `gfv.id`: auto-incremented uint64
 - `gfv.ecosystem_id`: null
-- `gfv.corporation_id`: id of the signing [[ref: group]] (i.e., the key of `co`)
+- `gfv.corporation`: the signing `corporation` (i.e., the underlying [[ref: group]] of `co`)
 - `gfv.created`: current timestamp
 - `gfv.version`: 1
 - `gfv.active_since`: current timestamp
@@ -2239,7 +2239,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - `gfv.id`: auto-incremented uint64
 - `gfv.ecosystem_id`: `ecosystem.id`
-- `gfv.corporation_id`: null
+- `gfv.corporation`: null
 - `gfv.created`: current timestamp
 - `gfv.version`: 1
 - `gfv.active_since`: current timestamp
@@ -2434,7 +2434,7 @@ Return the list of the existing parameters and their values.
 
 ### Governance Framework Module
 
-This module handles [[ref: governance framework]] documents and version activation for both [[ref: ecosystems]] and [[ref: corporations]]. Methods are polymorphic over the owning subject: every message specifies exactly one of `ecosystem_id` or `corporation_id` to designate whose governance framework is being modified.
+This module handles [[ref: governance framework]] documents and version activation for both [[ref: ecosystems]] and [[ref: corporations]]. Methods are polymorphic over the owning subject: every message takes an optional `ecosystem_id` parameter to designate whose governance framework is being modified — if set, the target subject is that `Ecosystem` (and the signing `corporation` MUST be its controller); if not set, the target subject is the signing `corporation`'s own [[ref: CGF]] (a Corporation may only edit its own CGF, so no extra parameter is needed).
 
 The initial `GovernanceFrameworkVersion` and its first `GovernanceFrameworkDocument` are created atomically by [Create New Ecosystem](#mod-es-msg-1-create-new-ecosystem) (and, by parallel construction, by [Create New Corporation](#mod-co-msg-1-create-new-corporation)). After that, subsequent versions and documents are added through this module.
 
@@ -2446,8 +2446,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]] whose governance framework will be modified. MUST be set if `corporation_id` is null.
-- `corporation_id` (uint64) (*conditional*): id of the target [[ref: corporation]] whose governance framework will be modified. MUST be set if `ecosystem_id` is null.
+- `ecosystem_id` (uint64) (*optional*): id of the target [[ref: ecosystem]] whose governance framework will be modified. If set, the signing `corporation` MUST be the controller of the target `Ecosystem`. If not set, the target subject is the signing `corporation`'s own [[ref: CGF]].
 - `doc_language` (string) (*mandatory*): language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of the governance framework document.
 - `doc_url` (string) (*mandatory*): URL where the document is published.
 - `doc_digest_sri` (string) (*mandatory*): digest_sri of the document.
@@ -2466,11 +2465,10 @@ if a mandatory parameter is not present, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- Exactly one of `ecosystem_id` and `corporation_id` MUST be set; if both are set or both are null, method MUST abort.
 - Define `subject` as:
-  - if `ecosystem_id` is set: the `Ecosystem` entry with this id. The entry MUST exist and `subject.corporation` MUST be equal to the `corporation` executing the method.
-  - if `corporation_id` is set: the `Corporation` entry keyed by `corporation_id` (i.e., the Corporation whose underlying [[ref: group]] has id `corporation_id`). The entry MUST exist, and `corporation_id` MUST equal the [[ref: group]] id of the signing `corporation` (a Corporation may only edit its own governance framework).
-- `version`: there MUST exist a `GovernanceFrameworkVersion` entry `gfv` whose owner matches `subject` (i.e., `gfv.ecosystem_id = ecosystem_id` if subject is an Ecosystem, else `gfv.corporation_id = corporation_id`) and `gfv.version = version`, OR `version` MUST be exactly equal to the biggest `gfv.version` + 1 of all `GovernanceFrameworkVersion` entries owned by `subject`. `version` MUST be greater than `subject.active_version`.
+  - if `ecosystem_id` is set: the `Ecosystem` entry with this id. The entry MUST exist and `subject.corporation` MUST be equal to the signing `corporation`.
+  - if `ecosystem_id` is not set: the `Corporation` entry whose underlying [[ref: group]] is the signing `corporation`. The entry MUST exist (a Corporation may only edit its own governance framework, so no further check is required).
+- `version`: there MUST exist a `GovernanceFrameworkVersion` entry `gfv` whose owner matches `subject` (i.e., `gfv.ecosystem_id = ecosystem_id` if subject is an Ecosystem, else `gfv.corporation = corporation`) and `gfv.version = version`, OR `version` MUST be exactly equal to the biggest `gfv.version` + 1 of all `GovernanceFrameworkVersion` entries owned by `subject`. `version` MUST be greater than `subject.active_version`.
 - `doc_language` (string) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 - `doc_url` (string) (*mandatory*): MUST be a valid URL.
 - `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
@@ -2488,7 +2486,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - if a `GovernanceFrameworkVersion` entry `gfv` matching `subject` and `version` does not exist, create and persist a new one:
   - `gfv.id`: auto-incremented uint64
   - `gfv.ecosystem_id`: `ecosystem_id` (or null if subject is a Corporation)
-  - `gfv.corporation_id`: `corporation_id` (or null if subject is an Ecosystem)
+  - `gfv.corporation`: the signing `corporation` (or null if subject is an Ecosystem)
   - `gfv.created`: current timestamp
   - `gfv.version`: `version`
 
@@ -2512,8 +2510,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `ecosystem_id` (uint64) (*conditional*): id of the target [[ref: ecosystem]]. MUST be set if `corporation_id` is null.
-- `corporation_id` (uint64) (*conditional*): id of the target [[ref: corporation]]. MUST be set if `ecosystem_id` is null.
+- `ecosystem_id` (uint64) (*optional*): id of the target [[ref: ecosystem]]. If set, the signing `corporation` MUST be its controller. If not set, the target subject is the signing `corporation`'s own [[ref: CGF]].
 
 ##### [MOD-GF-MSG-2-2] Increase Active Governance Framework Version precondition checks
 
@@ -2526,11 +2523,10 @@ If any of these precondition checks fail, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- Exactly one of `ecosystem_id` and `corporation_id` MUST be set; if both are set or both are null, method MUST abort.
 - Define `subject` as:
-  - if `ecosystem_id` is set: the `Ecosystem` entry with this id. The entry MUST exist and `subject.corporation` MUST be equal to the `corporation` executing the method.
-  - if `corporation_id` is set: the `Corporation` entry keyed by `corporation_id` (i.e., the Corporation whose underlying [[ref: group]] has id `corporation_id`). The entry MUST exist, and `corporation_id` MUST equal the [[ref: group]] id of the signing `corporation`.
-- Find a `GovernanceFrameworkVersion` entry `gfv` owned by `subject` (matching `gfv.ecosystem_id` or `gfv.corporation_id` as appropriate) whose `gfv.version` is equal to `subject.active_version` + 1. If none is found, transaction MUST abort.
+  - if `ecosystem_id` is set: the `Ecosystem` entry with this id. The entry MUST exist and `subject.corporation` MUST be equal to the signing `corporation`.
+  - if `ecosystem_id` is not set: the `Corporation` entry whose underlying [[ref: group]] is the signing `corporation`. The entry MUST exist.
+- Find a `GovernanceFrameworkVersion` entry `gfv` owned by `subject` (matching `gfv.ecosystem_id` or `gfv.corporation` as appropriate) whose `gfv.version` is equal to `subject.active_version` + 1. If none is found, transaction MUST abort.
 - Find a `GovernanceFrameworkDocument` `gfd` for `gfd.gfv_id` = `gfv.id` and `gfd.language` = `subject.language`. If no document is found (and thus no document exists for the default language of this version for this subject), transaction MUST abort.
 
 ###### [MOD-GF-MSG-2-2-2] Increase Active Governance Framework Version fee checks
@@ -2567,7 +2563,7 @@ If any of these checks fail, [[ref: query]] MUST fail.
 
 ##### [MOD-GF-QRY-1-3] Get Governance Framework Version execution
 
-Return the `GovernanceFrameworkVersion` entry with `id`, including its owning subject reference (`ecosystem_id` or `corporation_id`) and its nested `GovernanceFrameworkDocument` entries (filtered by `preferred_language` if set).
+Return the `GovernanceFrameworkVersion` entry with `id`, including its owning subject reference (`ecosystem_id` or `corporation`) and its nested `GovernanceFrameworkDocument` entries (filtered by `preferred_language` if set).
 
 #### [MOD-GF-QRY-2] List Governance Framework Versions
 
@@ -2575,10 +2571,10 @@ Anyone CAN execute this method.
 
 ##### [MOD-GF-QRY-2-1] List Governance Framework Versions query parameters
 
-Exactly one of `ecosystem_id` and `corporation_id` MUST be set:
+Exactly one of `ecosystem_id` and `corporation` MUST be set:
 
-- `ecosystem_id` (uint64) (*conditional*): filter by ecosystem. MUST be set if `corporation_id` is null.
-- `corporation_id` (uint64) (*conditional*): filter by corporation. MUST be set if `ecosystem_id` is null.
+- `ecosystem_id` (uint64) (*conditional*): filter by ecosystem. MUST be set if `corporation` is null.
+- `corporation` (group) (*conditional*): filter by corporation (the underlying Cosmos SDK [[ref: group]] of the target `Corporation`). MUST be set if `ecosystem_id` is null.
 - `active_only` (boolean) (*optional*): if true, return only the entry corresponding to the subject's `active_version`.
 - `preferred_language` (string) (*optional*): if set, return only one document per version, preferring `preferred_language`.
 - `response_max_size` (small number) (*optional*): default to 64. Max 1,024.
@@ -2587,7 +2583,7 @@ Exactly one of `ecosystem_id` and `corporation_id` MUST be set:
 
 If any of these checks fail, [[ref: query]] MUST fail.
 
-- Exactly one of `ecosystem_id` and `corporation_id` MUST be set.
+- Exactly one of `ecosystem_id` and `corporation` MUST be set.
 - `response_max_size` must be between 1 and 1,024. Default to 64 if unspecified.
 
 ##### [MOD-GF-QRY-2-3] List Governance Framework Versions execution
@@ -3156,13 +3152,13 @@ package "Example Credential Schema Participant Tree" as cs {
 
 
 
-tr --> ig : creates schema participant
-ig --> issuer : creates schema participant
+tr --> ig 
+ig --> issuer
 
-tr --> vg : creates schema participant
-vg --> verifier : creates schema participant
+tr --> vg
+vg --> verifier
 
-issuer --> holder: creates schema participant
+issuer --> holder
 
 @enduml
 

--- a/spec.md
+++ b/spec.md
@@ -2011,7 +2011,8 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `did` (string) (*mandatory*): the new DID of the Corporation.
-- `language` (string) (*mandatory*): primary language tag of this Corporation.
+
+> Note: `language` is set at creation time by [[MOD-CO-MSG-1]](#mod-co-msg-1-create-new-corporation) and is **immutable** thereafter; it cannot be updated through this method.
 
 ##### [MOD-CO-MSG-2-2] Update Corporation precondition checks
 
@@ -2026,7 +2027,6 @@ If any of these precondition checks fail, method MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - A `Corporation` entry `co` for the signing `corporation` MUST exist; if none exists, method MUST abort.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- `language` (string(17)) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 
 ###### [MOD-CO-MSG-2-2-2] Update Corporation fee checks
 
@@ -2041,7 +2041,6 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - load `Corporation` entry `co` for the signing `corporation` and set:
 
 - `co.did`: `did`
-- `co.language`: `language`
 - `co.modified`: current timestamp
 
 #### [MOD-CO-MSG-3] Archive Corporation

--- a/spec.md
+++ b/spec.md
@@ -1096,12 +1096,12 @@ entity "Participant" as csp {
   +slashed_deposit: number
   +repaid_deposit: number
   revoked: timestamp
-  +vp_exp: timestamp
-  +vp_last_state_change: timestamp
-  +vp_validator_deposit: number
-  +vp_current_fees: number
-  +vp_current_deposit: number
-  +vp_summary_digest: string
+  +op_exp: timestamp
+  +op_last_state_change: timestamp
+  +op_validator_deposit: number
+  +op_current_fees: number
+  +op_current_deposit: number
+  +op_summary_digest: string
   +issuance_fee_discount: number
   +verification_fee_discount: number
 }
@@ -1228,7 +1228,7 @@ account --o csp: vs_operator
 
 csps o-- account: vs_operator
 
-valstate --o csp: vp_state
+valstate --o csp: op_state
 group  --o td: corporation
 
 @enduml
@@ -1333,13 +1333,13 @@ group  --o td: corporation
 - `repaid_deposit` (number) (*mandatory*): part of the slashed deposit in [[ ref: native denom ]] that has been repaid.
 - `revoked` (timestamp) (*optional*): manual revocation timestamp of this Perm.
 - `validator_participant_id` (uint64) (*optional*): permission of the validator assigned to the onboarding process of this permission, ie *parent node* in the `Participant` tree.
-- `vp_state` (enum) (*mandatory*): one of PENDING, VALIDATED, TERMINATED.
-- `vp_exp` (timestamp) (*optional*): validation expiration timestamp. This expiration timestamp is for the onboarding process itself, not for the issued credential or `Participant` expiration timestamp.
-- `vp_last_state_change` (timestamp) (*mandatory*)
-- `vp_validator_deposit`: number (*optional*): accumulated validator trust deposit, in [[ref: denom]].
-- `vp_current_fees` (number) (*mandatory*): current action escrowed fees that will be paid to [[ref: validator]] upon onboarding process completion, in [[ref: denom]].
-- `vp_current_deposit` (number) (*mandatory*): current action trust deposit, in [[ref: denom]].
-- `vp_summary_digest` (string) (*optional*): an optional digest SRI, set by [[ref: validator]], of a summary of the information, proofs... provided by the [[ref: applicant]].
+- `op_state` (enum) (*mandatory*): one of PENDING, VALIDATED, TERMINATED.
+- `op_exp` (timestamp) (*optional*): validation expiration timestamp. This expiration timestamp is for the onboarding process itself, not for the issued credential or `Participant` expiration timestamp.
+- `op_last_state_change` (timestamp) (*mandatory*)
+- `op_validator_deposit`: number (*optional*): accumulated validator trust deposit, in [[ref: denom]].
+- `op_current_fees` (number) (*mandatory*): current action escrowed fees that will be paid to [[ref: validator]] upon onboarding process completion, in [[ref: denom]].
+- `op_current_deposit` (number) (*mandatory*): current action trust deposit, in [[ref: denom]].
+- `op_summary_digest` (string) (*optional*): an optional digest SRI, set by [[ref: validator]], of a summary of the information, proofs... provided by the [[ref: applicant]].
 - `issuance_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_ONBOARDING_PROCESS mode) or an ISSUER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 - `verification_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_ONBOARDING_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 
@@ -2937,7 +2937,7 @@ Trust deposit MUST always be paid in [[ref: native denom]]
 
 We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different VP with differents validators for the same `schema_id`, `type`.
 
-Find all permission `participants[]` for `schema_id`, `type`, `validator_participant_id`, `corporation` with vp_state = VALIDATED or PENDING.
+Find all permission `participants[]` for `schema_id`, `type`, `validator_participant_id`, `corporation` with op_state = VALIDATED or PENDING.
 
 if size of `participants[]` > 0, it means there is already an existing onboarding process in this context, so MUST abort.
 
@@ -2971,12 +2971,12 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - `applicant_participant.issuance_fees`: `issuance_fees`.
   - `applicant_participant.verification_fees`: `verification_fees`.
   - `applicant_participant.validator_participant_id`: `validator_participant_id`.
-  - `applicant_participant.vp_last_state_change`: `now`
-  - `applicant_participant.vp_state`: PENDING.
-  - `applicant_participant.vp_current_fees` (number): `validation_fees_in_denom`.
-  - `applicant_participant.vp_current_deposit` (number): `validation_trust_deposit_in_native_denom`.
-  - `applicant_participant.vp_summary_digest`: null.
-  - `applicant_participant.vp_validator_deposit`: 0.
+  - `applicant_participant.op_last_state_change`: `now`
+  - `applicant_participant.op_state`: PENDING.
+  - `applicant_participant.op_current_fees` (number): `validation_fees_in_denom`.
+  - `applicant_participant.op_current_deposit` (number): `validation_trust_deposit_in_native_denom`.
+  - `applicant_participant.op_summary_digest`: null.
+  - `applicant_participant.op_validator_deposit`: 0.
 
 If `vs_operator_authz_msg_types` is provided, create the [ParticipantAuthorizationRecord](#participantauthorizationrecord) in **disabled** state (`expiration = now`) by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
 
@@ -3016,7 +3016,7 @@ Once the [[ref: validator]] determines that the process is complete, they may te
 
 The [[ref: validator]] may compile a summary file of the onboarding process, documenting exchanged data, proofs, and decisions, and share it with the [[ref: applicant]] via the [[ref: VS]] connection or another secure channel.
 
-For audit or governance purposes, the [[ref: validator]] should register a digest (e.g., hash or SRI) of this summary in `applicant_participant.vp_summary_digest`.
+For audit or governance purposes, the [[ref: validator]] should register a digest (e.g., hash or SRI) of this summary in `applicant_participant.op_summary_digest`.
 
 #### [MOD-PP-MSG-2] Renew Participant OP
 
@@ -3110,11 +3110,11 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - update permission entry:
 
-  - `applicant_participant.vp_state`: PENDING.
-  - `applicant_participant.vp_last_state_change`: current timestamp.
+  - `applicant_participant.op_state`: PENDING.
+  - `applicant_participant.op_last_state_change`: current timestamp.
   - `applicant_participant.deposit`: `applicant_participant.deposit` + `validation_trust_deposit_in_native_denom`.
-  - `applicant_participant.vp_current_fees` (number): `validation_fees_in_denom`.
-  - `applicant_participant.vp_current_deposit` (number): `validation_trust_deposit_in_native_denom`.
+  - `applicant_participant.op_current_fees` (number): `validation_fees_in_denom`.
+  - `applicant_participant.op_current_deposit` (number): `validation_trust_deposit_in_native_denom`.
   - `applicant_participant.modified`: `now`
 
 #### [MOD-PP-MSG-3] Set Participant OP to Validated
@@ -3132,7 +3132,7 @@ An [[ref: account]] that would like to set a validation entry to VALIDATED MUST 
 - `validation_fees` (number) (*mandatory*): Agreed validation_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
 - `issuance_fees` (number) (*mandatory*): Agreed issuance_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
 - `verification_fees` (number) (*mandatory*): Agreed verification_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
-- `vp_summary_digest` (string) (*optional*): an optional digest, set by [[ref: validator]], of a summary of the information, proofs... provided by the [[ref: applicant]].
+- `op_summary_digest` (string) (*optional*): an optional digest, set by [[ref: validator]], of a summary of the information, proofs... provided by the [[ref: applicant]].
 - `issuance_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_ONBOARDING_PROCESS mode) or an ISSUER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 - `verification_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_ONBOARDING_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 
@@ -3159,11 +3159,11 @@ OR (executed by vs-agent account defined in validator permission):
 [[AUTHZ-CHECK-4]](#authz-check-4-vs-operator-fee-grant-checks) MUST pass for this (`corporation`, `operator`, `validator_participant`) tuple.
 else MUST abort.
 
-- `applicant_participant.vp_state` MUST be equal to PENDING, else abort.
+- `applicant_participant.op_state` MUST be equal to PENDING, else abort.
 - `validation_fees` (number) (*mandatory*): MUST be zero or a positive integer. If `applicant_participant.effective_from` is not null (we are in renewal) `validation_fees` MUST be equal to `applicant_participant.validation_fees`, else abort.
 - `issuance_fees` (number) (*mandatory*): MUST be zero or a positive integer.  If `applicant_participant.effective_from` is not null (we are in renewal) `issuance_fees` MUST be equal to `applicant_participant.issuance_fees` or, else abort.
 - `verification_fees` (number) (*mandatory*): MUST be zero or a positive integer.  If `applicant_participant.effective_from` is not null (we are in renewal) `verification_fees` MUST be equal to `applicant_participant.verification_fees`, else abort.
-- `vp_summary_digest` (string) (*optional*): MUST be null if `validation.type` is set to HOLDER (for HOLDER, proofs can be stored in credentials). Else, MUST be a valid digest. Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
+- `op_summary_digest` (string) (*optional*): MUST be null if `validation.type` is set to HOLDER (for HOLDER, proofs can be stored in credentials). Else, MUST be a valid digest. Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
 
 - Load `CredentialSchema` `cs` from `applicant_participant.schema_id`.
 - Load `Participant` `validator_participant` from `applicant_participant.validator_participant_id`.
@@ -3186,19 +3186,19 @@ else MUST abort.
     - if `applicant_participant.role` == VERIFIER: `verification_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
   - else MUST abort.
 
-Calculation of `vp_exp`, the onboarding process expiration timestamp, required to verify provided `effective_until`:
+Calculation of `op_exp`, the onboarding process expiration timestamp, required to verify provided `effective_until`:
 
 - let's define `validity_period` = `cs.issuer_grantor_validation_validity_period` (if `applicant_participant.role` is ISSUER_GRANTOR), `cs.verifier_grantor_validation_validity_period` (if `applicant_participant.role` is VERIFIER_GRANTOR), `cs.issuer_validation_validity_period` (if `applicant_participant.role` is ISSUER), `cs.verifier_validation_validity_period` (if `applicant_participant.role` is VERIFIER), or `cs.holder_validation_validity_period` (if `applicant_participant.role` is HOLDER).
 
-- if `validity_period` is NULL:  `vp_exp` = NULL.
-- else if `applicant_participant.vp_exp` is null, `vp_exp` =  timestamp of now() plus `validity_period`.
-- else `vp_exp` =  `applicant_participant.vp_exp` plus `validity_period`
+- if `validity_period` is NULL:  `op_exp` = NULL.
+- else if `applicant_participant.op_exp` is null, `op_exp` =  timestamp of now() plus `validity_period`.
+- else `op_exp` =  `applicant_participant.op_exp` plus `validity_period`
 
 Now, let's verify `effective_until`:
 
 - if `effective_until` is NULL, no issue.
-- else if `applicant_participant.effective_until` is NULL, `effective_until` MUST be greater than current current timestamp AND, if `vp_exp` is not null, lower or equal to `vp_exp`.
-- else `effective_until` MUST be greater than `applicant_participant.effective_until` AND, if `vp_exp` is not null, lower or equal to `vp_exp`.
+- else if `applicant_participant.effective_until` is NULL, `effective_until` MUST be greater than current current timestamp AND, if `op_exp` is not null, lower or equal to `op_exp`.
+- else `effective_until` MUST be greater than `applicant_participant.effective_until` AND, if `op_exp` is not null, lower or equal to `op_exp`.
 
 ###### [MOD-PP-MSG-3-2-2] Set Participant OP to Validated validator perms
 
@@ -3210,7 +3210,7 @@ If `validator_participant` is not a [[ref: active participant]] (expired, revoke
 ###### [MOD-PP-MSG-3-2-3] Set Participant OP to Validated fee checks
 
 - Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
-- if `applicant_participant.vp_current_fees` is not in [[ref: native denom]], `corporation` account MUST have `applicant_participant.vp_current_deposit` available in [[ref: native denom]] on its account for paying the trust deposit.
+- if `applicant_participant.op_current_fees` is not in [[ref: native denom]], `corporation` account MUST have `applicant_participant.op_current_deposit` available in [[ref: native denom]] on its account for paying the trust deposit.
 
 ###### [MOD-PP-MSG-3-2-4] Set Participant OP to Validated overlap checks
 
@@ -3236,44 +3236,44 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - Load `Participant` entry `validator_participant` from `applicant_participant.validator_participant_id`.
 - define `now` timestamp of now().
 
-Calculate `vp_exp`:
+Calculate `op_exp`:
 
 - Load `CredentialSchema` `cs` from `applicant_participant.schema_id`.
 - let's define `validity_period` = `cs.issuer_grantor_validation_validity_period` (if `applicant_participant.role` is ISSUER_GRANTOR), `cs.verifier_grantor_validation_validity_period` (if `applicant_participant.role` is VERIFIER_GRANTOR), `cs.issuer_validation_validity_period` (if `applicant_participant.role` is ISSUER), `cs.verifier_validation_validity_period` (if `applicant_participant.role` is VERIFIER), or `cs.holder_validation_validity_period` (if `applicant_participant.role` is HOLDER).
 
-- if `validity_period` is NULL:  `vp_exp` = NULL.
-- else if `applicant_participant.vp_exp` is null, `vp_exp` =  timestamp of now() plus `validity_period`.
-- else `vp_exp` =  `applicant_participant.vp_exp` plus `validity_period`.
+- if `validity_period` is NULL:  `op_exp` = NULL.
+- else if `applicant_participant.op_exp` is null, `op_exp` =  timestamp of now() plus `validity_period`.
+- else `op_exp` =  `applicant_participant.op_exp` plus `validity_period`.
 
 Change value of provided `effective_until` if needed, and abort if needed:
 
 - if provided  `effective_until` is NULL:
-  - change value of provided `effective_until` to `vp_exp`.
+  - change value of provided `effective_until` to `op_exp`.
 
 - else if `applicant_participant.effective_until` is NULL:
   - verify that provided `effective_until` is greater than `now` else MUST abort
-  - if `vp_exp` is not null, verify that provided `effective_until` is lower or equal to `vp_exp` else MUST abort
+  - if `op_exp` is not null, verify that provided `effective_until` is lower or equal to `op_exp` else MUST abort
 
 - else:
   - `effective_until` MUST be greater than `applicant_participant.effective_until` else MUST abort
-  - if `vp_exp` is not null, verify that provided `effective_until` is lower or equal to `vp_exp` else MUST abort.
+  - if `op_exp` is not null, verify that provided `effective_until` is lower or equal to `op_exp` else MUST abort.
 
 Fees and Trust Deposits:
 
-- transfer the full amount `applicant_participant.vp_current_fees` in the proper [[ref: denom]] from escrow [[ref: account]] to validator `corporation` [[ref: account]] `validator_participant.corporation`;
-- Increase validator perm trust deposit: use [MOD-TD-MSG-1] to increase by `applicant_participant.vp_current_deposit` the [[ref: trust deposit]] of `corporation` running the method and transfer the corresponding amount to `TrustDeposit` module. Set `applicant_participant.vp_validator_deposit` to `applicant_participant.vp_validator_deposit` + `applicant_participant.vp_current_deposit`.
+- transfer the full amount `applicant_participant.op_current_fees` in the proper [[ref: denom]] from escrow [[ref: account]] to validator `corporation` [[ref: account]] `validator_participant.corporation`;
+- Increase validator perm trust deposit: use [MOD-TD-MSG-1] to increase by `applicant_participant.op_current_deposit` the [[ref: trust deposit]] of `corporation` running the method and transfer the corresponding amount to `TrustDeposit` module. Set `applicant_participant.op_validator_deposit` to `applicant_participant.op_validator_deposit` + `applicant_participant.op_current_deposit`.
 
-> Important: if `applicant_participant.vp_current_fees` is not in [[ref: native denom]], `corporation` account MUST have `applicant_participant.vp_current_deposit` available for paying the trust deposit.
+> Important: if `applicant_participant.op_current_fees` is not in [[ref: native denom]], `corporation` account MUST have `applicant_participant.op_current_deposit` available for paying the trust deposit.
 
 Update `Participant` `applicant_participant`:
 
 - set `applicant_participant.modified` to `now`.
-- set `applicant_participant.vp_state` to VALIDATED.
-- set `applicant_participant.vp_last_state_change` to `now`.
-- set `applicant_participant.vp_current_fees` to 0;
-- set `applicant_participant.vp_current_deposit` to 0;
-- set `applicant_participant.vp_summary_digest` to `vp_summary_digest`.
-- set `applicant_participant.vp_exp` to `vp_exp`.
+- set `applicant_participant.op_state` to VALIDATED.
+- set `applicant_participant.op_last_state_change` to `now`.
+- set `applicant_participant.op_current_fees` to 0;
+- set `applicant_participant.op_current_deposit` to 0;
+- set `applicant_participant.op_summary_digest` to `op_summary_digest`.
+- set `applicant_participant.op_exp` to `op_exp`.
 - set `applicant_participant.effective_until` to `effective_until`.
 - if `applicant_participant.effective_from` IS NULL (first time method is called for this perm, and thus we are not in a renewal):
   - set `applicant_participant.validation_fees` to `validation_fees`;
@@ -3298,7 +3298,7 @@ This call is a no-op if no record was created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-At any time, [[ref: applicant]] of a permission onboarding process may request cancellation of the process, provided state is PENDING. Upon method execution, the pending validation is cancelled and escrewed [[ref: trust fees]] are refunded. If `vp_exp` is not null, `vp_state` is set back to VALIDATED, else `vp_state` is set to TERMINATED.
+At any time, [[ref: applicant]] of a permission onboarding process may request cancellation of the process, provided state is PENDING. Upon method execution, the pending validation is cancelled and escrewed [[ref: trust fees]] are refunded. If `op_exp` is not null, `op_state` is set back to VALIDATED, else `op_state` is set to TERMINATED.
 
 ##### [MOD-PP-MSG-6-1] Cancel Participant OP Last Request parameters
 
@@ -3320,7 +3320,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `id` MUST be a valid uint64.
 - Load `Participant` entry `applicant_participant` with this id. It MUST exist.
 - `corporation` running the [[ref: transaction]] MUST be `applicant_participant.corporation`.
-- `applicant_participant.vp_state` MUST be PENDING.
+- `applicant_participant.op_state` MUST be PENDING.
 - if `applicant_participant.deposit` has been slashed and not repaid, MUST abort
 
 ###### [MOD-PP-MSG-6-2-2] Cancel Participant OP Last Request fee checks
@@ -3337,17 +3337,17 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - define `now`: current timestamp.
 
 - set `applicant_participant.modified` to `now`.
-- if `applicant_participant.vp_exp` is null (validation never completed), set `applicant_participant.vp_state` to TERMINATED, else set `applicant_participant.vp_state` to VALIDATED.
-- set `applicant_participant.vp_last_state_change` to `now`.
-- if `applicant_participant.vp_current_fees` > 0:
-  - transfer `applicant_participant.vp_current_fees` in proper [[ref: denom]] back from escrow [[ref: account]] to [[ref: applicant]] [[ref: account]], `applicant_participant.corporation`.
-  - set `applicant_participant.vp_current_fees` to 0;
+- if `applicant_participant.op_exp` is null (validation never completed), set `applicant_participant.op_state` to TERMINATED, else set `applicant_participant.op_state` to VALIDATED.
+- set `applicant_participant.op_last_state_change` to `now`.
+- if `applicant_participant.op_current_fees` > 0:
+  - transfer `applicant_participant.op_current_fees` in proper [[ref: denom]] back from escrow [[ref: account]] to [[ref: applicant]] [[ref: account]], `applicant_participant.corporation`.
+  - set `applicant_participant.op_current_fees` to 0;
 
-- if `applicant_participant.vp_current_deposit` > 0:
-  - call [MOD-TD-MSG-1] to reduce trust deposit of `applicant_participant.corporation` by `applicant_participant.vp_current_deposit`
-  - set `applicant_participant.vp_current_deposit` to 0.
+- if `applicant_participant.op_current_deposit` > 0:
+  - call [MOD-TD-MSG-1] to reduce trust deposit of `applicant_participant.corporation` by `applicant_participant.op_current_deposit`
+  - set `applicant_participant.op_current_deposit` to 0.
 
-If `applicant_participant.vp_state` was set to TERMINATED (i.e. `applicant_participant.vp_exp` was null so validation never completed), call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any disabled authorization record created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op). The call is a no-op if no record exists. If `applicant_participant.vp_state` was set back to VALIDATED, no VSOA changes are needed (the existing record's `expiration` remains at the value set by the previous successful validation).
+If `applicant_participant.op_state` was set to TERMINATED (i.e. `applicant_participant.op_exp` was null so validation never completed), call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any disabled authorization record created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op). The call is a no-op if no record exists. If `applicant_participant.op_state` was set back to VALIDATED, no VSOA changes are needed (the existing record's `expiration` remains at the value set by the previous successful validation).
 
 #### [MOD-PP-MSG-7] Create Root Participant
 
@@ -3521,7 +3521,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 3. VP managed permissions
 
-- `effective_until` MUST be lower or equal to `applicant_participant.vp_exp` else MUST abort.
+- `effective_until` MUST be lower or equal to `applicant_participant.op_exp` else MUST abort.
 - load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active participant]]. `corporation` running the method MUST be `validator_participant.corporation`.
 
 ###### [MOD-PP-MSG-8-2-3] Adjust Participant fee checks
@@ -4515,7 +4515,7 @@ Generic query used for (at least):
 - `only_slashed` (boolean) (*optional*): if set to true, only return slashed permissions.
 - `only_repaid` (boolean) (*optional*): if set to true, only return repaid slashed permissions.
 - `modified_after` (timestamp) (*optional*): limit to permissions modified after (or equal to) `modified_after`.
-- `vp_state` (ValidationState) (*optional*): limit to permissions with a `vp_state` not null and equal to `vp_state`.
+- `op_state` (ValidationState) (*optional*): limit to permissions with a `op_state` not null and equal to `op_state`.
 - `response_max_size` (small number) (*optional*): limit to `response_max_size` results. Must be min 1, max 1,024. Default to 64.
 - `when` (timestamp) (*optional*): if set, query *at* `when`, else query *at* now(). Used to query the VPR state at a previous datetime.
 

--- a/spec.md
+++ b/spec.md
@@ -1427,13 +1427,13 @@ A `VSOperatorAuthorization` groups all `PermissionAuthorizationRecord` entries d
 A `PermissionAuthorizationRecord` carries the per-permission authorization configuration that was previously stored on `Permission.vs_operator_authz_*` fields. Each record is globally unique by `perm_id`: for any `Permission.id`, at most one record exists system-wide, so `(corporation, vs_operator)` can be derived from `perm_id` via a direct lookup.
 
 - `perm_id` (uint64) (*mandatory*): id of the `Permission` this authorization record applies to. Globally unique across all `PermissionAuthorizationRecord` entries.
-- `msg_types` (msg_type[]) (*mandatory*): list of delegable message types for which the `vs_operator` is authorized on behalf of `corporation` when acting in the context of `perm_id`. Declared by the applicant at record creation time (see [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp) and [[MOD-PERM-MSG-14]](#mod-perm-msg-14-self-create-permission)). Frozen after creation.
+- `msg_types` (msg_type[]) (*mandatory*): list of delegable message types for which the `vs_operator` is authorized on behalf of `corporation` when acting in the context of `perm_id`. Declared by the applicant at record creation time (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission)). Frozen after creation.
 - `spend_limit` (DenomAmount[]) (*optional*): maximum amount the `vs_operator` is allowed to spend, in the context of this permission, as a direct consequence of executing authorized messages.
 - `remaining_spend` (DenomAmount[]) (*conditional*): runtime balance for `spend_limit`. Present iff `spend_limit` is set. Initialized to `spend_limit` at create time. Decremented per matching `denom` after each authorized operation. Reset to `spend_limit` when the current cycle ends (see `expiration` and `period` below).
 - `fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
 - `remaining_fee_spend` (DenomAmount[]) (*conditional*): runtime balance for `fee_spend_limit`. Present iff `fee_spend_limit` is set. Initialized, decremented and reset following the same rules as `remaining_spend`.
 - `with_feegrant` (bool) (*mandatory*): if true, `corporation` pays the transaction fees for `vs_operator` when executing authorized messages in the context of this permission, through an on-chain `FeeGrant`.
-- `expiration` (timestamp) (*mandatory*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the record is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the record auto-renews until removed via [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)). Initially written to `now` at [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp) (disabled until validation) and to `Permission.effective_until` at [[MOD-PERM-MSG-3]](#mod-perm-msg-3-set-permission-vp-to-validated) / [[MOD-PERM-MSG-8]](#mod-perm-msg-8-adjust-permission) / [[MOD-PERM-MSG-14]](#mod-perm-msg-14-self-create-permission).
+- `expiration` (timestamp) (*mandatory*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the record is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the record auto-renews until removed via [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)). Initially written to `now` at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) (disabled until validation) and to `Permission.effective_until` at [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-permission-vp-to-validated) / [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-permission) / [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission).
 - `period` (duration) (*optional*): reset period for `spend_limit` and `fee_spend_limit` in the context of this permission.
 
 ### ExchangeRate
@@ -1613,7 +1613,7 @@ For Msg methods, all precondition checks MUST be verified first for accepting th
 A VPR implementation MUST implement all the following requirements.
 
 :::note
-The relative REST path is the path suffix. Implementer can set any prefix, like https://example/verana/tr/v1/get.
+The relative REST path is the path suffix. Implementer can set any prefix, like https://example/verana/es/v1/get.
 :::
 
 ### Authorization and Fee Grants
@@ -1705,7 +1705,7 @@ If the transaction fees are paid by the `corporation` account (via fee grant) in
 
 A second authorization grant mode exists for vs-agents. It is used when a corporation delegates a specific permission (and a specific set of message types, scoped to that permission) to a `vs_operator` account. The authorization model differs from other delegable messages: it relies on [VSOperatorAuthorization](#vsoperatorauthorization) / [PermissionAuthorizationRecord](#permissionauthorizationrecord) instead of `OperatorAuthorization`.
 
-> Note: the set of messages a `vs_operator` is authorized to execute in the context of a permission is declared by the applicant at permission creation time (see [[MOD-PERM-MSG-1-1]](#mod-perm-msg-1-1-start-permission-vp-parameters) and [[MOD-PERM-MSG-14-1]](#mod-perm-msg-14-1-self-create-permission-parameters)) and stored in `record.msg_types`. It is frozen for the lifetime of the record and can only be changed by revoking the permission and starting a new one.
+> Note: the set of messages a `vs_operator` is authorized to execute in the context of a permission is declared by the applicant at permission creation time (see [[MOD-PP-MSG-1-1]](#mod-pp-msg-1-1-start-permission-vp-parameters) and [[MOD-PP-MSG-14-1]](#mod-pp-msg-14-1-self-create-permission-parameters)) and stored in `record.msg_types`. It is frozen for the lifetime of the record and can only be changed by revoking the permission and starting a new one.
 
 Given a `corporation`, an `operator` (the `vs_operator`), a **primary permission id** `perm_id` (determined by the calling method), and the current message type `msg_type`:
 
@@ -1731,9 +1731,9 @@ If the [[ref: transaction]] fees are paid by the `corporation` account (via fee 
 #### Example
 
 A corporation group `corporationABC` wants to authorize an operator account `accountABC` to execute the  
-[`mod-perm-msg-10-create-or-update-permission-session`](#mod-perm-msg-10-create-or-update-permission-session),
-[`mod-perm-msg-3-set-permission-vp-to-validated`](#mod-perm-msg-3-set-permission-vp-to-validated), and
-[`mod-perm-msg-15-trigger-resolver`](#mod-perm-msg-15-trigger-resolver)
+[`mod-pp-msg-10-create-or-update-permission-session`](#mod-pp-msg-10-create-or-update-permission-session),
+[`mod-pp-msg-3-set-permission-vp-to-validated`](#mod-pp-msg-3-set-permission-vp-to-validated), and
+[`mod-pp-msg-15-trigger-resolver`](#mod-pp-msg-15-trigger-resolver)
  messages.
 
 Additionally, the corporation wants `accountABC` to pay the transaction fees for this message using the corporation's funds.
@@ -1741,9 +1741,9 @@ Additionally, the corporation wants `accountABC` to pay the transaction fees for
 To achieve this, `corporationABC` MUST:
 
 - create an **authorization** from `corporationABC` to `accountABC` for the  
-  [`mod-perm-msg-10-create-or-update-permission-session`](#mod-perm-msg-10-create-or-update-permission-session),
-[`mod-perm-msg-3-set-permission-vp-to-validated`](#mod-perm-msg-3-set-permission-vp-to-validated), and
-[`mod-perm-msg-15-trigger-resolver`](#mod-perm-msg-15-trigger-resolver) message types, optionally enabling an associated fee grant.
+  [`mod-pp-msg-10-create-or-update-permission-session`](#mod-pp-msg-10-create-or-update-permission-session),
+[`mod-pp-msg-3-set-permission-vp-to-validated`](#mod-pp-msg-3-set-permission-vp-to-validated), and
+[`mod-pp-msg-15-trigger-resolver`](#mod-pp-msg-15-trigger-resolver) message types, optionally enabling an associated fee grant.
 
 As a result, `accountABC` is authorized to:
 
@@ -1754,15 +1754,15 @@ As a result, `accountABC` is authorized to:
 
 | Module                         | Method Name                             | Relative REST API path           | Type   |Requirements      | Signers |
 |--------------------------------|-----------------------------------------|----------------------------------|--------|------------------|---|
-| Trust Registry                 | Create a Trust Registry                 |    N/A (Tx)                    | Msg    | [[MOD-TR-MSG-1]](#mod-tr-msg-1-create-new-trust-registry)   | corporation + operator |
-|                                | Add Governance Framework Document       |     N/A (Tx)                      | Msg    | [[MOD-TR-MSG-2]](#mod-tr-msg-2-add-governance-framework-document)   |corporation + operator |
-|                                | Increase Active Governance Framework Version |      N/A (Tx)                   | Msg    | [[MOD-TR-MSG-3]](#mod-tr-msg-3-increase-active-governance-framework-version)   |corporation + operator |
-|                                | Update Trust Registry                   |       N/A (Tx)                   | Msg    | [[MOD-TR-MSG-4]](#mod-tr-msg-4-update-trust-registry)   |corporation + operator |
-|                                | Archive Trust Registry                  |        N/A (Tx)                 | Msg    | [[MOD-TR-MSG-5]](#mod-tr-msg-5-archive-trust-registry)   |corporation + operator |
-|                                | Update TR Module Parameters             |         N/A (Tx)                 | Msg    | [[MOD-TR-MSG-6]](#mod-tr-msg-6-update-module-parameters)   |governance proposal |
-|                                | Get Trust Registry                      | /tr/v1/get                  | Query  | [[MOD-TR-QRY-1]](#mod-tr-qry-1-get-trust-registry)   |N/A |
-|                                | List Trust Registries                   | /tr/v1/list                 | Query  | [[MOD-TR-QRY-2]](#mod-tr-qry-2-list-trust-registries)   |N/A |
-|                                | List TR Module Parameters               | /tr/v1/params                 | Query  | [[MOD-TR-QRY-3]](#mod-tr-qry-3-list-module-parameters)   |N/A |
+| Trust Registry                 | Create a Trust Registry                 |    N/A (Tx)                    | Msg    | [[MOD-ES-MSG-1]](#mod-es-msg-1-create-new-trust-registry)   | corporation + operator |
+|                                | Add Governance Framework Document       |     N/A (Tx)                      | Msg    | [[MOD-ES-MSG-2]](#mod-es-msg-2-add-governance-framework-document)   |corporation + operator |
+|                                | Increase Active Governance Framework Version |      N/A (Tx)                   | Msg    | [[MOD-ES-MSG-3]](#mod-es-msg-3-increase-active-governance-framework-version)   |corporation + operator |
+|                                | Update Trust Registry                   |       N/A (Tx)                   | Msg    | [[MOD-ES-MSG-4]](#mod-es-msg-4-update-trust-registry)   |corporation + operator |
+|                                | Archive Trust Registry                  |        N/A (Tx)                 | Msg    | [[MOD-ES-MSG-5]](#mod-es-msg-5-archive-trust-registry)   |corporation + operator |
+|                                | Update TR Module Parameters             |         N/A (Tx)                 | Msg    | [[MOD-ES-MSG-6]](#mod-es-msg-6-update-module-parameters)   |governance proposal |
+|                                | Get Trust Registry                      | /es/v1/get                  | Query  | [[MOD-ES-QRY-1]](#mod-es-qry-1-get-trust-registry)   |N/A |
+|                                | List Trust Registries                   | /es/v1/list                 | Query  | [[MOD-ES-QRY-2]](#mod-es-qry-2-list-trust-registries)   |N/A |
+|                                | List TR Module Parameters               | /es/v1/params                 | Query  | [[MOD-ES-QRY-3]](#mod-es-qry-3-list-module-parameters)   |N/A |
 | Credential Schema              | Create a Credential Schema              |       N/A (Tx)                   | Msg    | [[MOD-CS-MSG-1]](#mod-cs-msg-1-create-new-credential-schema)   |corporation + operator |
 |                                | Update a Credential Schema              |      N/A (Tx)                     | Msg    | [[MOD-CS-MSG-2]](#mod-cs-msg-2-update-credential-schema)   |corporation + operator |
 |                                | Archive Credential Schema               |       N/A (Tx)                      | Msg    | [[MOD-CS-MSG-3]](#mod-cs-msg-3-archive-credential-schema)   |corporation + operator |
@@ -1776,24 +1776,24 @@ As a result, `accountABC` is authorized to:
 |                                | List CS Module Parameters               | /cs/v1/params                 | Query  | [[MOD-CS-QRY-4]](#mod-cs-qry-4-list-module-parameters)   |N/A  |
 |                  | Get Schema Authorization Policy                         | /cs/v1/sap/get         | Query | [[MOD-CS-QRY-5]](#mod-cs-qry-5-get-schema-authorization-policy) | N/A |
 |                  | List Schema Authorization Policies                      | /cs/v1/sap/list        | Query | [[MOD-CS-QRY-6]](#mod-cs-qry-6-list-schema-authorization-policies) | N/A |
-| Permission                     | Start Permission VP                     |     N/A (Tx)                       | Msg    | [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp)    |corporation + operator |
-|                                | Renew a Permission VP                   |       N/A (Tx)                     | Msg    | [[MOD-PERM-MSG-2]](#mod-perm-msg-2-renew-permission-vp)    |corporation + operator |
-|                                | Set Permission VP to Validated          |        N/A (Tx)                     | Msg    | [[MOD-PERM-MSG-3]](#mod-perm-msg-3-set-permission-vp-to-validated)    |corporation + operator |
-|                                | Cancel Permission VP Last Request       |         N/A (Tx)                    | Msg    | [[MOD-PERM-MSG-6]](#mod-perm-msg-6-cancel-permission-vp-last-request)    |corporation + operator |
-|                                | Create Root Permission                  |         N/A (Tx)                | Msg    | [[MOD-PERM-MSG-7]](#mod-perm-msg-7-create-root-permission)   |corporation + operator |
-|                                | Adjust Permission                       |         N/A (Tx)            | Msg    | [[MOD-PERM-MSG-8]](#mod-perm-msg-8-adjust-permission)  |corporation + operator |
-|                                | Revoke Permission                       |          N/A (Tx)              | Msg    | [[MOD-PERM-MSG-9]](#mod-perm-msg-9-revoke-permission)  |corporation + operator |
-|                                | Create or update Permission Session     |           N/A (Tx)              | Msg    | [[MOD-PERM-MSG-10]](#mod-perm-msg-10-create-or-update-permission-session)  |corporation + operator |
-|                                | Update Permission Module Parameters     |           N/A (Tx)             | Msg    | [[MOD-PERM-MSG-11]](#mod-perm-msg-11-update-permission-module-parameters) |governance proposal |
-|                                | Slash Permission Trust Deposit          |                N/A (Tx)       | Msg    | [[MOD-PERM-MSG-12]](#mod-perm-msg-12-slash-permission-trust-deposit) |corporation + operator |
-|                                | Repay Permission Slashed Trust Deposit  |     N/A (Tx)                | Msg    | [[MOD-PERM-MSG-13]](#mod-perm-msg-13-repay-permission-slashed-trust-deposit) |corporation + operator |
-|                                | Self Create Permission (OPEN mode)      |         N/A (Tx)              | Msg    | [[MOD-PERM-MSG-14]](#mod-perm-msg-14-self-create-permission) |corporation + operator  |
-|                                | Trigger Resolver                        |         N/A (Tx)              | Msg    | [[MOD-PERM-MSG-15]](#mod-perm-msg-15-trigger-resolver) |corporation + operator |
-|                                | List Permissions                        | /perm/v1/list                | Query  | [[MOD-PERM-QRY-1]](#mod-perm-qry-1-list-permissions)    |N/A |
-|                                | Get a Permission                        | /perm/v1/get                 | Query  | [[MOD-PERM-QRY-2]](#mod-perm-qry-2-get-permission)    |N/A |
-|                                | Find Beneficiaries                      | /perm/v1/beneficiaries       | Query  | [[MOD-PERM-QRY-4]](#mod-perm-qry-4-find-beneficiaries)  |N/A |
-|                                | Get Permission Session                  | /perm/v1/session/get         | Query  | [[MOD-PERM-QRY-5]](#mod-perm-qry-5-get-permissionsession) |N/A |
-|                                | List Permission Module Parameters     |  /perm/v1/params         | Query    | [[MOD-PERM-QRY-6]](#mod-perm-qry-6-list-permission-module-parameters)   |N/A |
+| Permission                     | Start Permission VP                     |     N/A (Tx)                       | Msg    | [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp)    |corporation + operator |
+|                                | Renew a Permission VP                   |       N/A (Tx)                     | Msg    | [[MOD-PP-MSG-2]](#mod-pp-msg-2-renew-permission-vp)    |corporation + operator |
+|                                | Set Permission VP to Validated          |        N/A (Tx)                     | Msg    | [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-permission-vp-to-validated)    |corporation + operator |
+|                                | Cancel Permission VP Last Request       |         N/A (Tx)                    | Msg    | [[MOD-PP-MSG-6]](#mod-pp-msg-6-cancel-permission-vp-last-request)    |corporation + operator |
+|                                | Create Root Permission                  |         N/A (Tx)                | Msg    | [[MOD-PP-MSG-7]](#mod-pp-msg-7-create-root-permission)   |corporation + operator |
+|                                | Adjust Permission                       |         N/A (Tx)            | Msg    | [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-permission)  |corporation + operator |
+|                                | Revoke Permission                       |          N/A (Tx)              | Msg    | [[MOD-PP-MSG-9]](#mod-pp-msg-9-revoke-permission)  |corporation + operator |
+|                                | Create or update Permission Session     |           N/A (Tx)              | Msg    | [[MOD-PP-MSG-10]](#mod-pp-msg-10-create-or-update-permission-session)  |corporation + operator |
+|                                | Update Permission Module Parameters     |           N/A (Tx)             | Msg    | [[MOD-PP-MSG-11]](#mod-pp-msg-11-update-permission-module-parameters) |governance proposal |
+|                                | Slash Permission Trust Deposit          |                N/A (Tx)       | Msg    | [[MOD-PP-MSG-12]](#mod-pp-msg-12-slash-permission-trust-deposit) |corporation + operator |
+|                                | Repay Permission Slashed Trust Deposit  |     N/A (Tx)                | Msg    | [[MOD-PP-MSG-13]](#mod-pp-msg-13-repay-permission-slashed-trust-deposit) |corporation + operator |
+|                                | Self Create Permission (OPEN mode)      |         N/A (Tx)              | Msg    | [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission) |corporation + operator  |
+|                                | Trigger Resolver                        |         N/A (Tx)              | Msg    | [[MOD-PP-MSG-15]](#mod-pp-msg-15-trigger-resolver) |corporation + operator |
+|                                | List Permissions                        | /pp/v1/list                | Query  | [[MOD-PP-QRY-1]](#mod-pp-qry-1-list-permissions)    |N/A |
+|                                | Get a Permission                        | /pp/v1/get                 | Query  | [[MOD-PP-QRY-2]](#mod-pp-qry-2-get-permission)    |N/A |
+|                                | Find Beneficiaries                      | /pp/v1/beneficiaries       | Query  | [[MOD-PP-QRY-4]](#mod-pp-qry-4-find-beneficiaries)  |N/A |
+|                                | Get Permission Session                  | /pp/v1/session/get         | Query  | [[MOD-PP-QRY-5]](#mod-pp-qry-5-get-permissionsession) |N/A |
+|                                | List Permission Module Parameters     |  /pp/v1/params         | Query    | [[MOD-PP-QRY-6]](#mod-pp-qry-6-list-permission-module-parameters)   |N/A |
 | Trust Deposit                  | Adjust Trust Deposit                    |   N/A (Tx)                       | Msg    | [[MOD-TD-MSG-1]](#mod-td-msg-1-adjust-trust-deposit)   | module call |
 |                                | Reclaim Trust Deposit Yield         |     N/A (Tx)           | Msg    | [[MOD-TD-MSG-2]](#mod-td-msg-2-reclaim-trust-deposit-yield)   |corporation + operator |
 |                                | Update TD Module Parameters             |      N/A (Tx)               | Msg  | [[MOD-TD-MSG-4]](#mod-td-msg-4-update-module-parameters)   |governance proposal |
@@ -1827,11 +1827,11 @@ Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR /
 
 ### Trust Registry Module
 
-#### [MOD-TR-MSG-1] Create New Trust Registry
+#### [MOD-ES-MSG-1] Create New Trust Registry
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-TR-MSG-1-1] Create New Trust Registry parameters
+##### [MOD-ES-MSG-1-1] Create New Trust Registry parameters
 
 An authorized `operator` that would like to create a [[ref: trust registry]] MUST call this method by specifying:
 
@@ -1845,11 +1845,11 @@ An authorized `operator` that would like to create a [[ref: trust registry]] MUS
 
 Provided document must be of the same language that the primary language of the trust registry.
 
-##### [MOD-TR-MSG-1-2] Create New Trust Registry precondition checks
+##### [MOD-ES-MSG-1-2] Create New Trust Registry precondition checks
 
 If any of these precondition checks fail, method MUST abort.
 
-###### [MOD-TR-MSG-1-2-1] Create New Trust Registry basic checks
+###### [MOD-ES-MSG-1-2-1] Create New Trust Registry basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
 
@@ -1866,11 +1866,11 @@ If any of these precondition checks fail, method MUST abort.
 It is not a problem if several trust registries are created with the same ecosystem DID. Identifier of a `TrustRegistry` is its id, and the Verifiable Trust Spec includes the id of the `TrustRegistry` in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.
 :::
 
-###### [MOD-TR-MSG-1-2-2] Create New Trust Registry fee checks
+###### [MOD-ES-MSG-1-2-2] Create New Trust Registry fee checks
 
 Fee payer MUST have an available balance to cover the [[ref: estimated transaction fees]].
 
-##### [MOD-TR-MSG-1-3] Create New Trust Registry execution
+##### [MOD-ES-MSG-1-3] Create New Trust Registry execution
 
 If all precondition checks passed, method is executed.
 
@@ -1904,11 +1904,11 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - `gfd.url`: `doc_url`
 - `gfd.digest_sri`: `doc_digest_sri`
 
-#### [MOD-TR-MSG-2] Add Governance Framework Document
+#### [MOD-ES-MSG-2] Add Governance Framework Document
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-TR-MSG-2-1] Add Governance Framework Document parameters
+##### [MOD-ES-MSG-2-1] Add Governance Framework Document parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
@@ -1920,11 +1920,11 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 If for a given language, a document already exists, the execution of this transaction will replace the corresponding entry. Else, a new entry is created. It is only possible to edit future versions. Active version cannot be modified.
 
-##### [MOD-TR-MSG-2-2] Add Governance Framework Document precondition checks
+##### [MOD-ES-MSG-2-2] Add Governance Framework Document precondition checks
 
 If any of these precondition checks fail, method MUST abort.
 
-###### [MOD-TR-MSG-2-2-1] Add Governance Framework Document basic checks
+###### [MOD-ES-MSG-2-2-1] Add Governance Framework Document basic checks
 
 if a mandatory parameter is not present, method MUST abort.
 
@@ -1937,11 +1937,11 @@ if a mandatory parameter is not present, method MUST abort.
 - `doc_url` (string) (*mandatory*): MUST be a valid URL.
 - `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
 
-###### [MOD-TR-MSG-2-2-2] Add Governance Framework Document fee checks
+###### [MOD-ES-MSG-2-2-2] Add Governance Framework Document fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]].
 
-##### [MOD-TR-MSG-2-3] Add Governance Framework Document execution
+##### [MOD-ES-MSG-2-3] Add Governance Framework Document execution
 
 If all precondition checks passed, method is executed.
 
@@ -1964,21 +1964,21 @@ load `GovernanceFrameworkVersion` entry `gfv` for the requested version, or crea
 - `gfd.url`: `doc_url`
 - `gfd.digest_sri`: `doc_digest_sri`
 
-#### [MOD-TR-MSG-3] Increase Active Governance Framework Version
+#### [MOD-ES-MSG-3] Increase Active Governance Framework Version
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-TR-MSG-3-1] Increase Active Governance Framework Version parameters
+##### [MOD-ES-MSG-3-1] Increase Active Governance Framework Version parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): the id of the trust registry.
 
-##### [MOD-TR-MSG-3-2] Increase Active Governance Framework Version precondition checks
+##### [MOD-ES-MSG-3-2] Increase Active Governance Framework Version precondition checks
 
 If any of these precondition checks fail, method MUST abort.
 
-###### [MOD-TR-MSG-3-2-1] Increase Active Governance Framework Version basic checks
+###### [MOD-ES-MSG-3-2-1] Increase Active Governance Framework Version basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
 
@@ -1989,11 +1989,11 @@ If any of these precondition checks fail, method MUST abort.
 - load `TrustRegistry` entry `tr` from its `id`. Find a `GovernanceFrameworkVersion` entry `gfv` where version is equal to `tr.active_version` + 1. If none is found, transaction MUST abort.
 - find `GovernanceFrameworkDocument` `gfd` for `gfd.gfv_id` = `gfv.id` and `gfd.language` = `tr.language`. If no document is found (and thus no document exist for the default language of this version for this trust registry), transaction MUST abort.
 
-###### [MOD-TR-MSG-3-2-2] Increase Active Governance Framework Version fee checks
+###### [MOD-ES-MSG-3-2-2] Increase Active Governance Framework Version fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]].
 
-##### [MOD-TR-MSG-3-3] Increase Active Governance Framework Version execution
+##### [MOD-ES-MSG-3-3] Increase Active Governance Framework Version execution
 
 If all precondition checks passed, method is executed.
 
@@ -2001,11 +2001,11 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - load `TrustRegistry` entry `tr` from its `id`. Find a `GovernanceFrameworkVersion` entry `gfv` where version is equal to `tr.active_version` + 1. If none is found, transaction MUST abort. Else, update `tr.active_version` to `tr.active_version` + 1. Set `tr.modified` to current timestamp, and set `gfv.active_since` to current timestamp and persist changes.
 
-#### [MOD-TR-MSG-4] Update Trust Registry
+#### [MOD-ES-MSG-4] Update Trust Registry
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-TR-MSG-4-1] Update Trust Registry parameters
+##### [MOD-ES-MSG-4-1] Update Trust Registry parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
@@ -2013,11 +2013,11 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 - `did` (string) (*mandatory*): the did of the trust registry.
 - `aka` (string) (*optional*): optional additional URI of this trust registry. If null, it means replace existing value with null.
 
-##### [MOD-TR-MSG-4-2] Update Trust Registry precondition checks
+##### [MOD-ES-MSG-4-2] Update Trust Registry precondition checks
 
 If any of these precondition checks fail, method MUST abort.
 
-###### [MOD-TR-MSG-4-2-1] Update Trust Registry basic checks
+###### [MOD-ES-MSG-4-2-1] Update Trust Registry basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
 
@@ -2028,11 +2028,11 @@ If any of these precondition checks fail, method MUST abort.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
 - `aka` (string) (*optional*): optional additional URI of this trust registry. MUST be an [[ref: URI]] or null.
 
-###### [MOD-TR-MSG-4-2-2] Update Trust Registry fee checks
+###### [MOD-ES-MSG-4-2-2] Update Trust Registry fee checks
 
 Fee payer must have available balance in its [[ref: account]] to cover the required [[ref: transaction fees]].
 
-##### [MOD-TR-MSG-4-3] Update Trust Registry execution
+##### [MOD-ES-MSG-4-3] Update Trust Registry execution
 
 If all precondition checks passed, method is executed.
 
@@ -2044,22 +2044,22 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - `tr.aka`: `aka`
 - `tr.modified`: current timestamp
 
-#### [MOD-TR-MSG-5] Archive Trust Registry
+#### [MOD-ES-MSG-5] Archive Trust Registry
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-TR-MSG-5-1] Archive Trust Registry parameters
+##### [MOD-ES-MSG-5-1] Archive Trust Registry parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*) id of the trust registry (*mandatory*);
 - `archive` (boolean) (*mandatory*), true means archive, false means unarchive.
 
-##### [MOD-TR-MSG-5-2] Archive Trust Registry precondition checks
+##### [MOD-ES-MSG-5-2] Archive Trust Registry precondition checks
 
 If any of these precondition checks fail, method MUST abort.
 
-###### [MOD-TR-MSG-5-2-1] Archive Trust Registry basic checks
+###### [MOD-ES-MSG-5-2-1] Archive Trust Registry basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
 
@@ -2071,11 +2071,11 @@ If any of these precondition checks fail, method MUST abort.
   - If `archive` is true and `tr.archived` is not null, MUST abort as `TrustRegistry` is already archived.
   - If `archive` is false and `tr.archived` is null, MUST abort as `TrustRegistry` is already not archived.
 
-###### [MOD-TR-MSG-5-2-2] Archive Trust Registry fee checks
+###### [MOD-ES-MSG-5-2-2] Archive Trust Registry fee checks
 
 Fee payer MUST have an available balance in its [[ref: account]] to cover the required [[ref: transaction fees]].
 
-##### [MOD-TR-MSG-5-3] Archive Trust Registry execution
+##### [MOD-ES-MSG-5-3] Archive Trust Registry execution
 
 If all precondition checks passed, method is executed.
 
@@ -2086,29 +2086,29 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - if `archived` is false: set `tr.archived` to null.
 - `tr.modified`: current timestamp
 
-#### [MOD-TR-MSG-6] Update Module Parameters
+#### [MOD-ES-MSG-6] Update Module Parameters
 
 Update Module Parameters.
 
 Can only be executed through a governance proposal.
 
-##### [MOD-TR-MSG-6-1] Update Module Parameters parameters
+##### [MOD-ES-MSG-6-1] Update Module Parameters parameters
 
 - `params` (KeySet<String, String>): the parameters to update and their values.
 
-##### [MOD-TR-MSG-6-2] Update Module Parameters precondition checks
+##### [MOD-ES-MSG-6-2] Update Module Parameters precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-TR-MSG-6-2-1] Update Module Parameters basic checks
+###### [MOD-ES-MSG-6-2-1] Update Module Parameters basic checks
 
 - `params`: size of `params` MUST be greater than 0. For each `param` <`key`, `value`> `key` MUST exist, else abort.
 
-###### [MOD-TR-MSG-6-2-2] Update Module Parameters fee checks
+###### [MOD-ES-MSG-6-2-2] Update Module Parameters fee checks
 
 provided transaction fees MUST be sufficient for execution
 
-##### [MOD-TR-MSG-6-3] Update Module Parameters execution
+##### [MOD-ES-MSG-6-3] Update Module Parameters execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -2118,25 +2118,25 @@ for each parameter `param` <`key`, `value`> in `parameters`:
 
 - update parameter set value = `value` where key = `key`.
 
-#### [MOD-TR-QRY-1] Get Trust Registry
+#### [MOD-ES-QRY-1] Get Trust Registry
 
 Anyone CAN execute this method.
 
-##### [MOD-TR-QRY-1-1] Get Trust Registry parameters
+##### [MOD-ES-QRY-1-1] Get Trust Registry parameters
 
 - `id` (uint64) (*mandatory*): id of the [[ref: trust registry]].
 - `active_gf_only` (boolean) (*optional*): if true, include only current governance framework data. If false or null, returns everything.
 - `preferred_language` (string) (*optional*): if set, return only one document per version, with language=`preferred_language` when possible, else if no document exist with this language, return language. If not set, return all documents of all languages.
 
-##### [MOD-TR-QRY-1-2] Get Trust Registry checks
+##### [MOD-ES-QRY-1-2] Get Trust Registry checks
 
-##### [MOD-TR-QRY-1-3] Get Trust Registry execution
+##### [MOD-ES-QRY-1-3] Get Trust Registry execution
 
 return found `TrustRegistry` entry (if any), as well as *all its nested* `GovernanceFrameworkVersion` and `GovernanceFrameworkDocument` entries. If `active_gf_only` is true, return only nested `GovernanceFrameworkVersion` and `GovernanceFrameworkDocument` entries for the active version.
 
-#### [MOD-TR-QRY-2] List Trust Registries
+#### [MOD-ES-QRY-2] List Trust Registries
 
-##### [MOD-TR-QRY-2-1] List Trust Registries query parameters
+##### [MOD-ES-QRY-2-1] List Trust Registries query parameters
 
 The following parameters are optional:
 
@@ -2146,29 +2146,29 @@ The following parameters are optional:
 - `preferred_language` (string) (*optional*): if set, return only one document per version, with language=`preferred_language` when possible, else if no document exist with this language, return language. If not set, return all documents of all languages.
 - `response_max_size` (small number) (*optional*): default to 64. Max 1,024.
 
-##### [MOD-TR-QRY-2-2] List Trust Registries query checks
+##### [MOD-ES-QRY-2-2] List Trust Registries query checks
 
 If any of these checks fail, [[ref: query]] MUST fail.
 
 - `response_max_size` must be between 1 and 1,024. Default to 64 if unspecified.
 
-##### [MOD-TR-QRY-2-3] List Trust Registries execution of the query
+##### [MOD-ES-QRY-2-3] List Trust Registries execution of the query
 
 If all precondition checks passed, [[ref: query]] is executed and result (may be empty) returned. If `modified_after` is specified, order by `modified` desc.
 
-#### [MOD-TR-QRY-3] List Module Parameters
+#### [MOD-ES-QRY-3] List Module Parameters
 
 Anyone CAN run this [[ref: query]].
 
-##### [MOD-TR-QRY-3-2] List Module Parameters parameters
+##### [MOD-ES-QRY-3-2] List Module Parameters parameters
 
-##### [MOD-TR-QRY-3-2] List Module Parameters query checks
+##### [MOD-ES-QRY-3-2] List Module Parameters query checks
 
-##### [MOD-TR-QRY-3-3] List Module Parameters execution of the query
+##### [MOD-ES-QRY-3-3] List Module Parameters execution of the query
 
 Return the list of the existing parameters and their values.
 
-##### [MOD-TR-QRY-3-4] List Module Parameters API result example
+##### [MOD-ES-QRY-3-4] List Module Parameters API result example
 
 ```json
 {
@@ -2786,14 +2786,14 @@ At any time, [[ref: applicant]] can cancel the validation process.
 
 Some special unexpected situation may arise and must be mitigated. Examples:
 
-- if selected validator permission is revoked while applicant's validation is in PENDING state: Applicant CAN cancel the validation process [MOD-PERM-MSG-6].
-- if selected validator permission is revoked while applicant is in VALIDATED state: Applicant CAN renew the validation process by choosing a new validator [MOD-PERM-MSG-2].
+- if selected validator permission is revoked while applicant's validation is in PENDING state: Applicant CAN cancel the validation process [MOD-PP-MSG-6].
+- if selected validator permission is revoked while applicant is in VALIDATED state: Applicant CAN renew the validation process by choosing a new validator [MOD-PP-MSG-2].
 
-#### [MOD-PERM-MSG-1] Start Permission VP
+#### [MOD-PP-MSG-1] Start Permission VP
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-PERM-MSG-1-1] Start Permission VP parameters
+##### [MOD-PP-MSG-1-1] Start Permission VP parameters
 
 An Applicant that would like to start a permission validation process MUST execute this method by specifying:
 
@@ -2829,11 +2829,11 @@ Permitted message types to be set in `vs_operator_authz_msg_types` depends on `t
 
 Available compatible perms can be found by using an indexer and presented in a front-end so applicant can choose its validator.
 
-##### [MOD-PERM-MSG-1-2] Start Permission VP precondition checks
+##### [MOD-PP-MSG-1-2] Start Permission VP precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-1-2-1] Start Permission VP basic checks
+###### [MOD-PP-MSG-1-2-1] Start Permission VP basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -2841,18 +2841,18 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `type` (PermissionType) (*mandatory*) MUST be a valid PermissionType: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.
-- `validator_perm_id` (uint64) (*mandatory*): see [MOD-PERM-MSG-1-2-2](#mod-perm-msg-1-2-2-start-permission-vp-permission-checks).
+- `validator_perm_id` (uint64) (*mandatory*): see [MOD-PP-MSG-1-2-2](#mod-pp-msg-1-2-2-start-permission-vp-permission-checks).
 - `validation_fees` (number) (*optional*): Requested validation_fees for this permission (can be modified by validator).
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
 - `verification_fees` (number) (*optional*): Requested verification_fees for this permission (can be modified by validator).
 - `did`, if specified, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PERM-MSG-1-1](#mod-perm-msg-1-1-start-permission-vp-parameters).
+- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-1-1](#mod-pp-msg-1-1-start-permission-vp-parameters).
 
 :::note
 A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It's up to the issuer to decide if running the validation process is REQUIRED or not.
 :::
 
-###### [MOD-PERM-MSG-1-2-2] Start Permission VP permission checks
+###### [MOD-PP-MSG-1-2-2] Start Permission VP permission checks
 
 - Load `Permission` entry `validator_perm` from `validator_perm_id`. It MUST be a [[ref: active permission]] else transaction MUST abort.
 - Load `CredentialSchema` entry `cs` from `validator_perm.schema_id`. It MUST exist.
@@ -2893,7 +2893,7 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 
 At the end, if a [[ ref: active permission]] `validator_perm` is not found, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-1-2-3] Start Permission VP fee checks
+###### [MOD-PP-MSG-1-2-3] Start Permission VP fee checks
 
 - Load `Permission` entry `validator_perm` from `validator_perm_id`.
 - Load `CredentialSchema` entry `cs` from `validator_perm.schema_id`.
@@ -2932,7 +2932,7 @@ else if `(cs.pricing_asset_type, cs.pricing_asset)` is set to an arbitrary coin 
 Trust deposit MUST always be paid in [[ref: native denom]]
 :::
 
-###### [MOD-PERM-MSG-1-2-4] Start Permission VP overlap checks
+###### [MOD-PP-MSG-1-2-4] Start Permission VP overlap checks
 
 We want to make sure that 2 validation processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different VP with differents validators for the same `schema_id`, `type`.
 
@@ -2942,7 +2942,7 @@ if size of `perms[]` > 0, it means there is already an existing validation proce
 
 > note: this check was not present in v3.
 
-##### [MOD-PERM-MSG-1-3] Start Permission VP execution
+##### [MOD-PP-MSG-1-3] Start Permission VP execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -2990,7 +2990,7 @@ If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizatio
   - `record.expiration`: `now`
   - `record.period`: `vs_operator_authz_period`
 
-> Note: the record is created with `expiration = now` so authorization is **not yet active**. [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) will reject any attempt to use it until [[MOD-PERM-MSG-3]](#mod-perm-msg-3-set-permission-vp-to-validated) updates `expiration` to `applicant_perm.effective_until`. No on-chain `FeeGrant` object is created at this stage even if `with_feegrant` is true (the recompute subroutine in [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) requires `expiration > now`).
+> Note: the record is created with `expiration = now` so authorization is **not yet active**. [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) will reject any attempt to use it until [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-permission-vp-to-validated) updates `expiration` to `applicant_perm.effective_until`. No on-chain `FeeGrant` object is created at this stage even if `with_feegrant` is true (the recompute subroutine in [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) requires `expiration > now`).
 
 #### Connecting to the VS of the Validator
 
@@ -3017,7 +3017,7 @@ The [[ref: validator]] may compile a summary file of the validation process, doc
 
 For audit or governance purposes, the [[ref: validator]] should register a digest (e.g., hash or SRI) of this summary in `applicant_perm.vp_summary_digest`.
 
-#### [MOD-PERM-MSG-2] Renew Permission VP
+#### [MOD-PP-MSG-2] Renew Permission VP
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
@@ -3029,17 +3029,17 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 - Renewal does not allow changing the `perm.validation_fees`, `perm.issuance_fees`, `perm.verification_fees`. To change these values, applicant MUST start a new validation process.
 - if permission is revoked, slashed, or repaid, method MUST fail.
 
-##### [MOD-PERM-MSG-2-1] Renew Permission VP parameters
+##### [MOD-PP-MSG-2-1] Renew Permission VP parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission for which applicant would like to renew the validation process;
 
-##### [MOD-PERM-MSG-2-2] Renew Permission VP precondition checks
+##### [MOD-PP-MSG-2-2] Renew Permission VP precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-2-2-1] Renew Permission VP basic checks
+###### [MOD-PP-MSG-2-2-1] Renew Permission VP basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3048,12 +3048,12 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64 and a permission entry with the same id MUST exist.
 
-###### [MOD-PERM-MSG-2-2-2] Renew Permission VP permission checks
+###### [MOD-PP-MSG-2-2-2] Renew Permission VP permission checks
 
 - Load `Permission` entry `applicant_perm`. `corporation` running the operation MUST be `applicant_perm.corporation`, else MUST abort. `applicant_perm` MUST be a [[ref: active permission]].
 - Load `Permission` entry `validator_perm` from `applicant_perm.validator_perm_id`. It MUST exist, and be a [[ref: active permission]], else MUST abort.
 
-###### [MOD-PERM-MSG-2-2-3] Renew Permission VP fee checks
+###### [MOD-PP-MSG-2-2-3] Renew Permission VP fee checks
 
 - Load `Permission` entry `validator_perm` from `applicant_perm.validator_perm_id`.
 - Load `CredentialSchema` entry `cs` from `validator_perm.schema_id`.
@@ -3092,7 +3092,7 @@ else if `(cs.pricing_asset_type, cs.pricing_asset)` is set to an arbitrary coin 
 Trust deposit MUST always be paid in [[ref: native denom]]
 :::
 
-###### [MOD-PERM-MSG-2-3] Renew Permission VP execution
+###### [MOD-PP-MSG-2-3] Renew Permission VP execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -3116,11 +3116,11 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - `applicant_perm.vp_current_deposit` (number): `validation_trust_deposit_in_native_denom`.
   - `applicant_perm.modified`: `now`
 
-#### [MOD-PERM-MSG-3] Set Permission VP to Validated
+#### [MOD-PP-MSG-3] Set Permission VP to Validated
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-PERM-MSG-3-1] Set Permission VP to Validated parameters
+##### [MOD-PP-MSG-3-1] Set Permission VP to Validated parameters
 
 An [[ref: account]] that would like to set a validation entry to VALIDATED MUST execute this method by specifying:
 
@@ -3135,11 +3135,11 @@ An [[ref: account]] that would like to set a validation entry to VALIDATED MUST 
 - `issuance_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_VALIDATION_PROCESS mode) or an ISSUER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 - `verification_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_VALIDATION_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 
-##### [MOD-PERM-MSG-3-2] Set Permission VP to Validated precondition checks
+##### [MOD-PP-MSG-3-2] Set Permission VP to Validated precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-3-2-1] Set Permission VP to Validated basic checks
+###### [MOD-PP-MSG-3-2-1] Set Permission VP to Validated basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3199,19 +3199,19 @@ Now, let's verify `effective_until`:
 - else if `applicant_perm.effective_until` is NULL, `effective_until` MUST be greater than current current timestamp AND, if `vp_exp` is not null, lower or equal to `vp_exp`.
 - else `effective_until` MUST be greater than `applicant_perm.effective_until` AND, if `vp_exp` is not null, lower or equal to `vp_exp`.
 
-###### [MOD-PERM-MSG-3-2-2] Set Permission VP to Validated validator perms
+###### [MOD-PP-MSG-3-2-2] Set Permission VP to Validated validator perms
 
 - load `validator_perm` from `applicant_perm.validator_perm_id`. `validator_perm` MUST be a [[ref: active permission]].
 - `corporation` running the method MUST be `validator_perm.corporation`.
 
 If `validator_perm` is not a [[ ref: active permission]] (expired, revoked, slashed...) then applicant MUST start a new validation process.
 
-###### [MOD-PERM-MSG-3-2-3] Set Permission VP to Validated fee checks
+###### [MOD-PP-MSG-3-2-3] Set Permission VP to Validated fee checks
 
 - Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 - if `applicant_perm.vp_current_fees` is not in [[ref: native denom]], `corporation` account MUST have `applicant_perm.vp_current_deposit` available in [[ref: native denom]] on its account for paying the trust deposit.
 
-###### [MOD-PERM-MSG-3-2-4] Set Permission VP to Validated overlap checks
+###### [MOD-PP-MSG-3-2-4] Set Permission VP to Validated overlap checks
 
 We want to make sure that 2 permissions cannot be active at the same time for the same `validator_perm_id`. That should not occur in this method, but better do the check anyway.
 
@@ -3225,7 +3225,7 @@ for each `Permission` entry `p` from `perms[]`:
 
 > note: this check was not present in v3.
 
-##### [MOD-PERM-MSG-3-3] Set Permission VP to Validated execution
+##### [MOD-PP-MSG-3-3] Set Permission VP to Validated execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -3287,29 +3287,29 @@ Activate VS Operator Authorization, if any. Call [[MOD-DE-MSG-9]](#mod-de-msg-9-
 - `perm_id`: `applicant_perm.id`
 - `new_expiration`: `applicant_perm.effective_until`
 
-This call is a no-op if no record was created at [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp) (i.e., the applicant did not declare `vs_operator_authz_msg_types`). If a record exists, its `expiration` is updated from `now` (disabled) to `applicant_perm.effective_until`, and the on-chain `FeeGrant` for the containing VSOA is granted for the first time (or refreshed) via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance).
+This call is a no-op if no record was created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) (i.e., the applicant did not declare `vs_operator_authz_msg_types`). If a record exists, its `expiration` is updated from `now` (disabled) to `applicant_perm.effective_until`, and the on-chain `FeeGrant` for the containing VSOA is granted for the first time (or refreshed) via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance).
 
-#### [MOD-PERM-MSG-4] Void
+#### [MOD-PP-MSG-4] Void
 
-#### [MOD-PERM-MSG-5] Void
+#### [MOD-PP-MSG-5] Void
 
-#### [MOD-PERM-MSG-6] Cancel Permission VP Last Request
+#### [MOD-PP-MSG-6] Cancel Permission VP Last Request
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 At any time, [[ref: applicant]] of a permission validation process may request cancellation of the process, provided state is PENDING. Upon method execution, the pending validation is cancelled and escrewed [[ref: trust fees]] are refunded. If `vp_exp` is not null, `vp_state` is set back to VALIDATED, else `vp_state` is set to TERMINATED.
 
-##### [MOD-PERM-MSG-6-1] Cancel Permission VP Last Request parameters
+##### [MOD-PP-MSG-6-1] Cancel Permission VP Last Request parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the `Permission` entry;
 
-##### [MOD-PERM-MSG-6-2] Cancel Permission VP Last Request precondition checks
+##### [MOD-PP-MSG-6-2] Cancel Permission VP Last Request precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-6-2-1] Cancel Permission VP Last Request basic checks
+###### [MOD-PP-MSG-6-2-1] Cancel Permission VP Last Request basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3322,11 +3322,11 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `applicant_perm.vp_state` MUST be PENDING.
 - if `applicant_perm.deposit` has been slashed and not repaid, MUST abort
 
-###### [MOD-PERM-MSG-6-2-2] Cancel Permission VP Last Request fee checks
+###### [MOD-PP-MSG-6-2-2] Cancel Permission VP Last Request fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 
-##### [MOD-PERM-MSG-6-3] Cancel Permission VP Last Request execution
+##### [MOD-PP-MSG-6-3] Cancel Permission VP Last Request execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -3346,15 +3346,15 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - call [MOD-TD-MSG-1] to reduce trust deposit of `applicant_perm.corporation` by `applicant_perm.vp_current_deposit`
   - set `applicant_perm.vp_current_deposit` to 0.
 
-If `applicant_perm.vp_state` was set to TERMINATED (i.e. `applicant_perm.vp_exp` was null so validation never completed), call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `perm_id = applicant_perm.id` to remove any disabled authorization record created at [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp). The call is a no-op if no record exists. If `applicant_perm.vp_state` was set back to VALIDATED, no VSOA changes are needed (the existing record's `expiration` remains at the value set by the previous successful validation).
+If `applicant_perm.vp_state` was set to TERMINATED (i.e. `applicant_perm.vp_exp` was null so validation never completed), call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `perm_id = applicant_perm.id` to remove any disabled authorization record created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp). The call is a no-op if no record exists. If `applicant_perm.vp_state` was set back to VALIDATED, no VSOA changes are needed (the existing record's `expiration` remains at the value set by the previous successful validation).
 
-#### [MOD-PERM-MSG-7] Create Root Permission
+#### [MOD-PP-MSG-7] Create Root Permission
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 This method is used by controller authorities of Trust Registries. When they create a Credential Schema, they need to create (a) permission(s) of type ECOSYSTEM so that other participants can run validation processes (if schema mode is ECOSYSTEM) or self create their permissions (schema mode set to OPEN).
 
-##### [MOD-PERM-MSG-7-1] Create Root Permission parameters
+##### [MOD-PP-MSG-7-1] Create Root Permission parameters
 
 An [[ref: account]] that would like to create a `Permission` entry MUST call this method by specifying:
 
@@ -3377,17 +3377,17 @@ The following VS Operator Authorization parameters are **optional** and collecti
 - `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
 - `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
 
-Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`. Since [Create Root Permission](#mod-perm-msg-7-create-root-permission) always creates an ECOSYSTEM permission, only the following is allowed:
+Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`. Since [Create Root Permission](#mod-pp-msg-7-create-root-permission) always creates an ECOSYSTEM permission, only the following is allowed:
 
 |Permission type|Permitted Messages|
 |-|-|
 | ECOSYSTEM | SetPermissionVPtoValidated |
 
-##### [MOD-PERM-MSG-7-2] Create Root Permission precondition checks
+##### [MOD-PP-MSG-7-2] Create Root Permission precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-7-2-1] Create Root Permission basic checks
+###### [MOD-PP-MSG-7-2-1] Create Root Permission basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3401,9 +3401,9 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `validation_fees` (number) (*mandatory*): MUST be >= 0.
 - `issuance_fees` (number) (*mandatory*): MUST be >= 0.
 - `verification_fees` (number) (*mandatory*): MUST be >= 0.
-- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PERM-MSG-7-1](#mod-perm-msg-7-1-create-root-permission-parameters).
+- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-7-1](#mod-pp-msg-7-1-create-root-permission-parameters).
 
-###### [MOD-PERM-MSG-7-2-2] Create Root Permission permission checks
+###### [MOD-PP-MSG-7-2-2] Create Root Permission permission checks
 
 To execute this method, [[ref: account]] MUST match at least one these rules, else [[ref: transaction]] MUST abort.
 
@@ -3412,13 +3412,13 @@ To execute this method, [[ref: account]] MUST match at least one these rules, el
 - `corporation` executing the method MUST be `tr.corporation`.
 - else MUST abort.
 
-###### [MOD-PERM-MSG-7-2-3] Create Root Permission fee checks
+###### [MOD-PP-MSG-7-2-3] Create Root Permission fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
-###### [MOD-PERM-MSG-7-2-4] Create Root Permission overlap checks
+###### [MOD-PP-MSG-7-2-4] Create Root Permission overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-perm-msg-8-adjust-permission) to set or adjust the `effective_until` value.
+We want to make sure that 2 permissions cannot be active at the same time. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-permission) to set or adjust the `effective_until` value.
 
 Find all [[ref: active permissions]] `perms[]` (not revoked, not slashed, not repaid) for `schema_id`, ECOSYSTEM,  `corporation`.
 
@@ -3432,7 +3432,7 @@ for each `Permission` entry `p` from `perms[]`:
 
 > note: this check was not present in v3.
 
-##### [MOD-PERM-MSG-7-3] Create Root Permission execution
+##### [MOD-PP-MSG-7-3] Create Root Permission execution
 
 If all precondition checks passed, method is executed.
 
@@ -3470,9 +3470,9 @@ If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizatio
   - `record.expiration`: `perm.effective_until`
   - `record.period`: `vs_operator_authz_period`
 
-> Note: like [[MOD-PERM-MSG-14]](#mod-perm-msg-14-self-create-permission), the record is created with `expiration = perm.effective_until` and is therefore immediately active. If `with_feegrant` is true and `perm.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
+> Note: like [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission), the record is created with `expiration = perm.effective_until` and is therefore immediately active. If `with_feegrant` is true and `perm.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
 
-#### [MOD-PERM-MSG-8] Adjust Permission
+#### [MOD-PP-MSG-8] Adjust Permission
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
@@ -3482,18 +3482,18 @@ This method can be called:
 - by `perm.corporation`, if it is a self-created permission (schema configuration is open)
 - by a `corporation` of a validator permission (if permission is managed by a VP).
 
-##### [MOD-PERM-MSG-8-1] Adjust Permission parameters
+##### [MOD-PP-MSG-8-1] Adjust Permission parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
 - `effective_until` (timestamp) (*mandatory*): timestamp until when (exclusive) this `Permission` will be effective.
 
-##### [MOD-PERM-MSG-8-2] Adjust Permission precondition checks
+##### [MOD-PP-MSG-8-2] Adjust Permission precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-8-2-1] Adjust Permission basic checks
+###### [MOD-PP-MSG-8-2-1] Adjust Permission basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3508,7 +3508,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 > Note: This method can be used to both Extend or Reduce the `effective_until`, or set an `effective_until` if it was null,  which was not the case in spec v3.
 
-###### [MOD-PERM-MSG-8-2-2] Adjust Permission advanced checks
+###### [MOD-PP-MSG-8-2-2] Adjust Permission advanced checks
 
 1. ECOSYSTEM permissions
 
@@ -3523,13 +3523,13 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `effective_until` MUST be lower or equal to `applicant_perm.vp_exp` else MUST abort.
 - load `validator_perm` from `applicant_perm.validator_perm_id`. `validator_perm` MUST be a [[ref: active permission]]. `corporation` running the method MUST be `validator_perm.corporation`.
 
-###### [MOD-PERM-MSG-8-2-3] Adjust Permission fee checks
+###### [MOD-PP-MSG-8-2-3] Adjust Permission fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-8-2-4] Adjust Permission overlap checks
+###### [MOD-PP-MSG-8-2-4] Adjust Permission overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time for the same `validator_perm_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-perm-msg-8-adjust-permission) to set or adjust the `effective_until` value.
+We want to make sure that 2 permissions cannot be active at the same time for the same `validator_perm_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-permission) to set or adjust the `effective_until` value.
 
 Find all [[ref: active permissions]] `perms[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_perm_id`, `corporation`.
 
@@ -3541,7 +3541,7 @@ for each `Permission` entry `p` from `perms[]`:
 
 > note: this check was not present in v3.
 
-##### [MOD-PERM-MSG-8-3] Adjust Permission execution
+##### [MOD-PP-MSG-8-3] Adjust Permission execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -3560,9 +3560,9 @@ Synchronise VS Operator Authorization expiration, if any. Call [[MOD-DE-MSG-9]](
 - `perm_id`: `applicant_perm.id`
 - `new_expiration`: `applicant_perm.effective_until`
 
-This call is a no-op if no record exists for `applicant_perm.id`. If a record exists, its `expiration` is updated and the on-chain `FeeGrant` for the containing VSOA is refreshed via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance). Adjust Permission does **not** accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp) and [[MOD-PERM-MSG-14]](#mod-perm-msg-14-self-create-permission)). Adjust also cannot create a record that does not already exist.
+This call is a no-op if no record exists for `applicant_perm.id`. If a record exists, its `expiration` is updated and the on-chain `FeeGrant` for the containing VSOA is refreshed via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance). Adjust Permission does **not** accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission)). Adjust also cannot create a record that does not already exist.
 
-#### [MOD-PERM-MSG-9] Revoke Permission
+#### [MOD-PP-MSG-9] Revoke Permission
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
@@ -3572,17 +3572,17 @@ This method can only be called:
 - by the grantee `corporation` (OPEN, GRANTOR, ECOSYSTEM schema mode).
 - by the `TrustRegistry` `corporation` (owner of the credential schema).
 
-##### [MOD-PERM-MSG-9-1] Revoke Permission parameters
+##### [MOD-PP-MSG-9-1] Revoke Permission parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
 
-##### [MOD-PERM-MSG-9-2] Revoke Permission precondition checks
+##### [MOD-PP-MSG-9-2] Revoke Permission precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-9-2-1] Revoke Permission basic checks
+###### [MOD-PP-MSG-9-2-1] Revoke Permission basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3593,7 +3593,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - Load `Permission` entry `applicant_perm` from `id`. If no entry found, abort.
 - `applicant_perm` MUST be a [[ref: active permission]]
 
-###### [MOD-PERM-MSG-9-2-2] Revoke Permission advanced checks
+###### [MOD-PP-MSG-9-2-2] Revoke Permission advanced checks
 
 Either Option #1, #2 or #3 MUST return true, else abort.
 
@@ -3673,11 +3673,11 @@ issuer --> holder: granted schema permission
 
 ```
 
-###### [MOD-PERM-MSG-9-2-3] Revoke Permission fee checks
+###### [MOD-PP-MSG-9-2-3] Revoke Permission fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 
-##### [MOD-PERM-MSG-9-3] Revoke Permission execution
+##### [MOD-PP-MSG-9-3] Revoke Permission execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -3691,7 +3691,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `perm_id = applicant_perm.id` to remove any authorization record for this permission. The call is a no-op if no record exists.
 
-#### [MOD-PERM-MSG-10] Create or Update Permission Session
+#### [MOD-PP-MSG-10] Create or Update Permission Session
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
@@ -3734,7 +3734,7 @@ Issued <-- Issued: Store credential in wallet agent
 
 See [[ref: VT spec]].
 
-##### [MOD-PERM-MSG-10-1] Create or Update Permission Session parameters
+##### [MOD-PP-MSG-10-1] Create or Update Permission Session parameters
 
 An [[ref: account]] that would like to create or update a `PermissionSession` entry MUST send a Msg by specifying:
 
@@ -3747,7 +3747,7 @@ An [[ref: account]] that would like to create or update a `PermissionSession` en
 - `wallet_agent_perm_id` (uint64) (*optional*): the wallet credential issuer permission id of the VUA where the credential will be or is stored. Can be the same perm than `agent_perm_id` if agent and wallet_agent are the same agent. Only set by VUAs, MUST NOT be specified when peer is a VS.
 - `digest` (string) (*optional*): digest derived from an issued or verified credential.
 
-##### [MOD-PERM-MSG-10-2] Create or Update Permission Session precondition checks
+##### [MOD-PP-MSG-10-2] Create or Update Permission Session precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
@@ -3799,7 +3799,7 @@ wallet_agent:
 we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a permission that is not controlled by its owner.
 :::
 
-###### [MOD-PERM-MSG-10-3] Create or Update Permission Session fee checks
+###### [MOD-PP-MSG-10-3] Create or Update Permission Session fee checks
 
 - Load `CredentialSchema` entry `cs` from `issuer_perm.schema_id` if `issuer_perm` is not null, else from `verifier_perm.schema_id`.
 - Fee payer MUST have sufficient available balance for the required [[ref: estimated transaction fees]].
@@ -3960,7 +3960,7 @@ Required balance check:
 - When paying with COIN ≠ [[ref: native denom]] or with FIAT, payer pays trust deposits on behalf of payees (since payees receive non-native assets that cannot be directly staked).
 :::
 
-##### [MOD-PERM-MSG-10-4] Create or Update Permission Session execution
+##### [MOD-PP-MSG-10-4] Create or Update Permission Session execution
 
 If all precondition checks passed, method is executed.
 
@@ -4124,29 +4124,29 @@ if current transaction if for issuance of a credential, persist the digest SRI b
 `session.authz[]` can contain null `issuer_perm_id` OR `verifier_perm_id`
 :::
 
-#### [MOD-PERM-MSG-11] Update Permission Module Parameters
+#### [MOD-PP-MSG-11] Update Permission Module Parameters
 
 Update Permission Module Parameters.
 
 Can only be executed through a governance proposal.
 
-##### [MOD-PERM-MSG-11-1] Update Permission Module Parameters parameters
+##### [MOD-PP-MSG-11-1] Update Permission Module Parameters parameters
 
 - `params` (KeySet<String, String>): the parameters to update and their values.
 
-##### [MOD-PERM-MSG-11-2] Update Permission Module Parameters precondition checks
+##### [MOD-PP-MSG-11-2] Update Permission Module Parameters precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-11-2-1] Update Permission Module Parameters basic checks
+###### [MOD-PP-MSG-11-2-1] Update Permission Module Parameters basic checks
 
 - `params`: size of `params` MUST be greater than 0. For each `param` <`key`, `value`> `key` MUST exist, else abort.
 
-###### [MOD-PERM-MSG-11-2-2] Update Permission Module Parameters fee checks
+###### [MOD-PP-MSG-11-2-2] Update Permission Module Parameters fee checks
 
 provided transaction fees MUST be sufficient for execution
 
-##### [MOD-PERM-MSG-11-3] Update Permission Module Parameters execution
+##### [MOD-PP-MSG-11-3] Update Permission Module Parameters execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -4156,25 +4156,25 @@ for each parameter `param` <`key`, `value`> in `parameters`:
 
 - update parameter set value = `value` where key = `key`.
 
-#### [MOD-PERM-MSG-12] Slash Permission Trust Deposit
+#### [MOD-PP-MSG-12] Slash Permission Trust Deposit
 
 This method can only be called by either:
 
 - a `corporation` ancestor validator of this permission;
 - the `corporation` controller of the `TrustRegistry` object, owner of the corresponding credential schema.
 
-##### [MOD-PERM-MSG-12-1] Slash Permission Trust Deposit parameters
+##### [MOD-PP-MSG-12-1] Slash Permission Trust Deposit parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
 - `amount` (number) (*mandatory*): the amount to slash
 
-##### [MOD-PERM-MSG-12-2] Slash Permission Trust Deposit precondition checks
+##### [MOD-PP-MSG-12-2] Slash Permission Trust Deposit precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-12-2-1] Slash Permission Trust Deposit basic checks
+###### [MOD-PP-MSG-12-2-1] Slash Permission Trust Deposit basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -4189,7 +4189,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 Even if the permission has expired or is revoked, it is still possible to slash it.
 :::
 
-###### [MOD-PERM-MSG-12-2-2] Slash Permission Trust Deposit validator perms
+###### [MOD-PP-MSG-12-2-2] Slash Permission Trust Deposit validator perms
 
 Either Option #1, or #2 MUST return true, else abort.
 
@@ -4211,11 +4211,11 @@ if `applicant_perm.validator_perm_id` is defined:
 - if `corporation` running the method is `tr.corporation`, return true.
 - else return false.
 
-###### [MOD-PERM-MSG-12-2-3] Slash Permission Trust Deposit fee checks
+###### [MOD-PP-MSG-12-2-3] Slash Permission Trust Deposit fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 
-##### [MOD-PERM-MSG-12-3] Slash Permission Trust Deposit execution
+##### [MOD-PP-MSG-12-3] Slash Permission Trust Deposit execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -4233,23 +4233,23 @@ use [MOD-TD-MSG-7](#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit) to burn t
 
 Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `perm_id = applicant_perm.id` to remove any authorization record for this permission. The call is a no-op if no record exists.
 
-#### [MOD-PERM-MSG-13] Repay Permission Slashed Trust Deposit
+#### [MOD-PP-MSG-13] Repay Permission Slashed Trust Deposit
 
 This method can only be called by the `corporation` that want to repay the deposit of a slashed perm they own. This won't make the perm re-usable: it will be needed for the `corporation` associated to this permission to request a new permission, as slashed permissions cannot be revived (same happen for revoked, etc...).
 
 Nevertheless, to get a new permission for a given ecosystem, it is needed, using this method, to repay the deposit of a slashed permission first.
 
-##### [MOD-PERM-MSG-13-1] Repay Permission Slashed Trust Deposit parameters
+##### [MOD-PP-MSG-13-1] Repay Permission Slashed Trust Deposit parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission
 
-##### [MOD-PERM-MSG-13-2] Repay Permission Slashed Trust Deposit precondition checks
+##### [MOD-PP-MSG-13-2] Repay Permission Slashed Trust Deposit precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-13-2-1] Repay Permission Slashed Trust Deposit basic checks
+###### [MOD-PP-MSG-13-2-1] Repay Permission Slashed Trust Deposit basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -4260,12 +4260,12 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - Load `Permission` entry `applicant_perm` from `id`. If no entry found, abort.
 - if `applicant_perm.corporation` is not equal to `corporation`, abort.
 
-###### [MOD-PERM-MSG-13-2-2] Repay Permission Slashed Trust Deposit fee checks
+###### [MOD-PP-MSG-13-2-2] Repay Permission Slashed Trust Deposit fee checks
 
 - Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]];
 - `corporation` MUST have at least `applicant_perm.slashed_deposit` in its account balance, else [[ref: transaction]] MUST abort.
 
-##### [MOD-PERM-MSG-13-3] Repay Permission Slashed Trust Deposit execution
+##### [MOD-PP-MSG-13-3] Repay Permission Slashed Trust Deposit execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -4280,7 +4280,7 @@ use [Adjust Trust Deposit](#mod-td-msg-1-adjust-trust-deposit) to transfer `appl
 - set `applicant_perm.modified` to `now`
 - set `applicant_perm.repaid_deposit` to `applicant_perm.slashed_deposit`.
 
-#### [MOD-PERM-MSG-14] Self Create Permission
+#### [MOD-PP-MSG-14] Self Create Permission
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
@@ -4290,7 +4290,7 @@ This simple permission creation method can be used to self-create an ISSUER (res
 Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their permission may be revoked by ecosystem governance authority and their deposit slashed.
 :::
 
-##### [MOD-PERM-MSG-14-1] Self Create Permission parameters
+##### [MOD-PP-MSG-14-1] Self Create Permission parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
@@ -4319,11 +4319,11 @@ Permitted message types to be set in `vs_operator_authz_msg_types` depends on `t
 | ISSUER | CreateOrUpdatePermissionSession, SetPermissionVPtoValidated |
 | VERIFIER | CreateOrUpdatePermissionSession |
  
-##### [MOD-PERM-MSG-14-2] Self Create Permission precondition checks
+##### [MOD-PP-MSG-14-2] Self Create Permission precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-14-2-1] Self Create Permission basic checks
+###### [MOD-PP-MSG-14-2-1] Self Create Permission basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -4344,9 +4344,9 @@ Load `Permission` `validator_perm` from `validator_perm_id`.
   - else if not null, must be greater than `effective_from` AND if `validator_perm.effective_until` is not null, MUST be lower or equal to `validator_perm.effective_until`
 - `verification_fees` (number) (*optional*): If specified, MUST be >= 0 and MUST be a ISSUER permission.
 - `validation_fees` (number) (*optional*): If specified, MUST be >= 0 and MUST be a ISSUER permission.
-- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PERM-MSG-14-1](#mod-perm-msg-14-1-self-create-permission-parameters).
+- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-14-1](#mod-pp-msg-14-1-self-create-permission-parameters).
 
-###### [MOD-PERM-MSG-14-2-2] Self Create Permission permission checks
+###### [MOD-PP-MSG-14-2-2] Self Create Permission permission checks
 
 To execute this method, [[ref: account]] MUST match at least one these rules, else [[ref: transaction]] MUST abort.
 
@@ -4356,13 +4356,13 @@ To execute this method, [[ref: account]] MUST match at least one these rules, el
 - if `type` is equal to VERIFIER and `validation_fees` is specified and different than 0, MUST abort.
 - if `type` is equal to VERIFIER and `verification_fees` is specified and different than 0, MUST abort.
 
-###### [MOD-PERM-MSG-14-2-3] Self Create Permission fee checks
+###### [MOD-PP-MSG-14-2-3] Self Create Permission fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
-###### [MOD-PERM-MSG-14-2-4] Self Create Permission overlap checks
+###### [MOD-PP-MSG-14-2-4] Self Create Permission overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time for the same `validator_perm_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-perm-msg-8-adjust-permission) to set or adjust the `effective_until` value.
+We want to make sure that 2 permissions cannot be active at the same time for the same `validator_perm_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-permission) to set or adjust the `effective_until` value.
 
 Find all [[ref: active permissions]] `perms[]` (not revoked, not slashed, not repaid) for `cs.id`, `type`, `validator_perm_id`, `corporation`.
 
@@ -4374,7 +4374,7 @@ for each `Permission` entry `p` from `perms[]`:
 
 > note: this check was not present in v3.
 
-##### [MOD-PERM-MSG-14-3] Self Create Permission execution
+##### [MOD-PP-MSG-14-3] Self Create Permission execution
 
 If all precondition checks passed, method is executed.
 
@@ -4414,9 +4414,9 @@ If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizatio
   - `record.expiration`: `perm.effective_until`
   - `record.period`: `vs_operator_authz_period`
 
-> Note: unlike [[MOD-PERM-MSG-1]](#mod-perm-msg-1-start-permission-vp), the record is created with `expiration = perm.effective_until` and is therefore immediately active. If `with_feegrant` is true and `perm.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
+> Note: unlike [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp), the record is created with `expiration = perm.effective_until` and is therefore immediately active. If `with_feegrant` is true and `perm.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
 
-#### [MOD-PERM-MSG-15] Trigger Resolver
+#### [MOD-PP-MSG-15] Trigger Resolver
 
 This method CAN be executed by:
 
@@ -4431,17 +4431,17 @@ This method is intended to be used by external services (such as the Verana inde
 
 The method does not modify the [[ref: VPR]] state; it only emits an event that off-chain components MAY consume.
 
-##### [MOD-PERM-MSG-15-1] Trigger Resolver parameters
+##### [MOD-PP-MSG-15-1] Trigger Resolver parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission for which a trust resolution must be triggered.
 
-##### [MOD-PERM-MSG-15-2] Trigger Resolver precondition checks
+##### [MOD-PP-MSG-15-2] Trigger Resolver precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PERM-MSG-15-2-1] Trigger Resolver basic checks
+###### [MOD-PP-MSG-15-2-1] Trigger Resolver basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -4452,7 +4452,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `perm` MUST be an [[ref: active permission]], else abort.
 - `perm.did` MUST NOT be null, else abort.
 
-###### [MOD-PERM-MSG-15-2-2] Trigger Resolver authorization checks
+###### [MOD-PP-MSG-15-2-2] Trigger Resolver authorization checks
 
 At least one of the two authorization paths below MUST pass, else [[ref: transaction]] MUST abort.
 
@@ -4476,11 +4476,11 @@ The target `perm` itself is excluded from this walk; only its ancestors (from th
 
 If the walk terminates without a match, Path 2 fails.
 
-###### [MOD-PERM-MSG-15-2-3] Trigger Resolver fee checks
+###### [MOD-PP-MSG-15-2-3] Trigger Resolver fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 
-##### [MOD-PERM-MSG-15-3] Trigger Resolver execution
+##### [MOD-PP-MSG-15-3] Trigger Resolver execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -4490,7 +4490,7 @@ This method does not modify the state of the [[ref: VPR]]. It MUST emit an event
 
 > Note: the identity of the signers (`corporation`, `operator`), the fee payer, the block height and timestamp, and the full Msg payload are already observable from the transaction itself. Indexers MAY use the `Permission` entry queried by `perm_id` to resolve `did`, `corporation`, `vs_operator`, and ancestor chain without duplicating them in the event payload.
 
-#### [MOD-PERM-QRY-1] List Permissions
+#### [MOD-PP-QRY-1] List Permissions
 
 Anyone CAN execute this method.
 
@@ -4503,7 +4503,7 @@ Generic query used for (at least):
 - find all ISSUER_GRANTOR active permission, so that I can apply to an ISSUER permission;
 ...
 
-##### [MOD-PERM-QRY-1-1] List Permissions parameters
+##### [MOD-PP-QRY-1-1] List Permissions parameters
 
 - `schema_id` (number) (*optional*): the schema id.
 - `grantee` (account) (*optional*): the grantee account.
@@ -4518,7 +4518,7 @@ Generic query used for (at least):
 - `response_max_size` (small number) (*optional*): limit to `response_max_size` results. Must be min 1, max 1,024. Default to 64.
 - `when` (timestamp) (*optional*): if set, query *at* `when`, else query *at* now(). Used to query the VPR state at a previous datetime.
 
-##### [MOD-PERM-QRY-1-2] List Permissions checks
+##### [MOD-PP-QRY-1-2] List Permissions checks
 
 Basic type check arg SHOULD be applied.
 
@@ -4526,31 +4526,31 @@ If any of these checks fail, [[ref: query]] MUST fail.
 
 - `response_max_size` must be between 1 and 1,024. Default to 64 if unspecified.
 
-##### [MOD-PERM-QRY-1-3] List Permissions execution
+##### [MOD-PP-QRY-1-3] List Permissions execution
 
 return a list of found entries, or an empty list if nothing found. Ordered by `modified` asc.
 
-#### [MOD-PERM-QRY-2] Get Permission
+#### [MOD-PP-QRY-2] Get Permission
 
 Anyone CAN execute this method.
 
-##### [MOD-PERM-QRY-2-1] Get Permission parameters
+##### [MOD-PP-QRY-2-1] Get Permission parameters
 
 - `id` of the [[ref: credential schema permission]] (*mandatory*);
 
-##### [MOD-PERM-QRY-2-2] Get Permission checks
+##### [MOD-PP-QRY-2-2] Get Permission checks
 
 - `id` must be a uint64.
 
-##### [MOD-PERM-QRY-2-3] Get Permission execution
+##### [MOD-PP-QRY-2-3] Get Permission execution
 
 return found entry (if any).
 
-#### [MOD-PERM-QRY-3] Void
+#### [MOD-PP-QRY-3] Void
 
-Obsoleted by [MOD-PERM-QRY-1].
+Obsoleted by [MOD-PP-QRY-1].
 
-#### [MOD-PERM-QRY-4] Find Beneficiaries
+#### [MOD-PP-QRY-4] Find Beneficiaries
 
 Anyone can execute this method.
 
@@ -4629,18 +4629,18 @@ v --> vg
 
 ```
 
-##### [MOD-PERM-QRY-4-1] Find Beneficiaries parameters
+##### [MOD-PP-QRY-4-1] Find Beneficiaries parameters
 
 - `issuer_perm_id` (uint64) (*optional*): id of issuer permission.
 - `verifier_perm_id` (uint64) (*optional*): id of verifier permission.
 
-##### [MOD-PERM-QRY-4-2] Find Beneficiaries checks
+##### [MOD-PP-QRY-4-2] Find Beneficiaries checks
 
 - if `issuer_perm_id` and `verifier_perm_id` are unset then MUST abort.
 - if `issuer_perm_id` is specified, load `issuer_perm` from `issuer_perm_id`, Permission MUST exist and MUST be a [[ref: active permission]].
 - if `verifier_perm_id` is specified, load `verifier_perm` from `verifier_perm_id`, Permission MUST exist and MUST be a [[ref: active permission]].
 
-##### [MOD-PERM-QRY-4-3] Find Beneficiaries execution
+##### [MOD-PP-QRY-4-3] Find Beneficiaries execution
 
 Example: Let's build the set. Revoked and slashed permissions will not be added to the set. Expired permissions, if not revoked/slashed, will be considered.
 
@@ -4671,29 +4671,29 @@ return `found_perms`.
 This works even is schema is open to any issuer or open to any verifier.
 :::
 
-#### [MOD-PERM-QRY-5] Get PermissionSession
+#### [MOD-PP-QRY-5] Get PermissionSession
 
-##### [MOD-PERM-QRY-5-1] Get PermissionSession parameters
+##### [MOD-PP-QRY-5-1] Get PermissionSession parameters
 
 - `id` (uuid) (*mandatory*): the id of the `PermissionSession`.
 
-##### [MOD-PERM-QRY-5-2] Get PermissionSession checks
+##### [MOD-PP-QRY-5-2] Get PermissionSession checks
 
-##### [MOD-PERM-QRY-5-3] Get PermissionSession execution
+##### [MOD-PP-QRY-5-3] Get PermissionSession execution
 
 return `PermissionSession` entry if found, else return not found.
 
-##### [MOD-PERM-QRY-6] List Permission Module Parameters
+##### [MOD-PP-QRY-6] List Permission Module Parameters
 
-##### [MOD-PERM-QRY-6-2] List Permission Module Parameters parameters
+##### [MOD-PP-QRY-6-2] List Permission Module Parameters parameters
 
-##### [MOD-PERM-QRY-6-2] List Permission Module Parameters query checks
+##### [MOD-PP-QRY-6-2] List Permission Module Parameters query checks
 
-##### [MOD-PERM-QRY-6-3] List Permission Module Parameters execution of the query
+##### [MOD-PP-QRY-6-3] List Permission Module Parameters execution of the query
 
 Return the list of the existing parameters and their values.
 
-##### [MOD-PERM-QRY-6-4] List Permission Module Parameters API result example
+##### [MOD-PP-QRY-6-4] List Permission Module Parameters API result example
 
 ```json
 {
@@ -5036,7 +5036,7 @@ This method is used by the network governance authority to **globally slash** a 
 
 This method can only be called by a governance proposal. A globally slashed account MUST repay the slashed deposit in order to continue to use the services provided by the VPR. When and account is slashed, and while slashed deposit has not been repaid, all account linked permissions MUST be considered non trustable.
 
-This method is for network governance authority slash. For ecosystem slash, see [Slash Permission Trust Deposit](#mod-perm-msg-12-slash-permission-trust-deposit).
+This method is for network governance authority slash. For ecosystem slash, see [Slash Permission Trust Deposit](#mod-pp-msg-12-slash-permission-trust-deposit).
 
 ##### [MOD-TD-MSG-5-1] Slash Trust Deposit method parameters
 
@@ -5374,8 +5374,8 @@ MUST abort if one of these conditions fails:
 
 This method can only be called directly by the following Permission module methods, with no signer check:
 
-- [Start Permission VP](#mod-perm-msg-1-start-permission-vp)
-- [Self Create Permission](#mod-perm-msg-14-self-create-permission)
+- [Start Permission VP](#mod-pp-msg-1-start-permission-vp)
+- [Self Create Permission](#mod-pp-msg-14-self-create-permission)
 
 It creates a new [PermissionAuthorizationRecord](#permissionauthorizationrecord) inside `VSOperatorAuthorization[corporation, vs_operator]` and, if the record enables a fee grant and its `expiration` is in the future, synchronises the on-chain `FeeGrant` for the containing VSOA.
 
@@ -5435,9 +5435,9 @@ This is a shared subroutine invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-o
 
 This method can only be called directly by the following Permission module methods, with no signer check:
 
-- [Cancel Permission VP Last Request](#mod-perm-msg-6-cancel-permission-vp-last-request) (only when the cancellation terminates the permission)
-- [Revoke Permission](#mod-perm-msg-9-revoke-permission)
-- [Slash Permission Trust Deposit](#mod-perm-msg-12-slash-permission-trust-deposit)
+- [Cancel Permission VP Last Request](#mod-pp-msg-6-cancel-permission-vp-last-request) (only when the cancellation terminates the permission)
+- [Revoke Permission](#mod-pp-msg-9-revoke-permission)
+- [Slash Permission Trust Deposit](#mod-pp-msg-12-slash-permission-trust-deposit)
 
 It removes the unique [PermissionAuthorizationRecord](#permissionauthorizationrecord) identified by `perm_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no such record exists.
 
@@ -5469,8 +5469,8 @@ This method does NOT read `Permission` state.
 
 This method can only be called directly by the following Permission module methods, with no signer check:
 
-- [Set Permission VP to Validated](#mod-perm-msg-3-set-permission-vp-to-validated)
-- [Adjust Permission](#mod-perm-msg-8-adjust-permission)
+- [Set Permission VP to Validated](#mod-pp-msg-3-set-permission-vp-to-validated)
+- [Adjust Permission](#mod-pp-msg-8-adjust-permission)
 
 It updates the `expiration` of the unique record identified by `perm_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no record exists for `perm_id`.
 
@@ -5545,7 +5545,7 @@ Return a list of `VSOperatorAuthorization` entries matching the filter criteria,
 #### [MOD-DI-MSG-1] Store Digest
 
 - Any authorized `operator` CAN execute this method on behalf of a `corporation`.
-- This method can be called directly by [Create or Update Permission Session](#mod-perm-msg-10-create-or-update-permission-session) module with no checks.
+- This method can be called directly by [Create or Update Permission Session](#mod-pp-msg-10-create-or-update-permission-session) module with no checks.
 
 ##### [MOD-DI-MSG-1-1] Store Digest method parameters
 

--- a/spec.md
+++ b/spec.md
@@ -1354,7 +1354,7 @@ A `Corporation` is the VPR-level entity that extends a Cosmos SDK [[ref: group]]
 
 `Corporation`:
 
-- `did` (string) (*mandatory*): the DID of the Corporation.
+- `did` (string) (*mandatory*): the DID of the Corporation. MUST be **globally unique** across all `Corporation` entries (per-Corporation `did` uniqueness invariant): at any block height, no two `Corporation` entries MAY share the same `did` value. Enforced at create time by [[MOD-CO-MSG-1-2-1]](#mod-co-msg-1-2-1-create-new-corporation-basic-checks) and at rotation time by [[MOD-CO-MSG-2-2-1]](#mod-co-msg-2-2-1-update-corporation-basic-checks).
 - `created` (timestamp) (*mandatory*): timestamp this Corporation has been created.
 - `modified` (timestamp) (*mandatory*): timestamp this Corporation has been modified.
 - `archived` (timestamp) (*optional*): timestamp this Corporation has been archived.
@@ -1368,8 +1368,8 @@ A `Corporation` is the VPR-level entity that extends a Cosmos SDK [[ref: group]]
 `Ecosystem`:
 
 - `id` (uint64) (*mandatory*): the id of the ecosystem.
-- `did` (string) (*mandatory*): the did of the ecosystem.
-- `corporation` (group) (*mandatory*): [[ref: corporation]] that controls this entry.
+- `did` (string) (*mandatory*): the did of the ecosystem. MAY be shared with other `Ecosystem` entries (a single DID MAY be the `did` of several ecosystems); per-Ecosystem DID uniqueness is NOT enforced because the `Ecosystem` identity is its `id`. However, per-Ecosystem `(did, corporation)` consistency IS enforced: at any block height, all `Ecosystem` entries with equal `did` MUST share the same `corporation`. Enforced at create time by [[MOD-ES-MSG-1-2-1]](#mod-es-msg-1-2-1-create-new-ecosystem-basic-checks) and at rotation time by [[MOD-ES-MSG-2-2-1]](#mod-es-msg-2-2-1-update-ecosystem-basic-checks).
+- `corporation` (group) (*mandatory*): [[ref: corporation]] that controls this entry. Constrained by the per-Ecosystem `(did, corporation)` consistency invariant above.
 - `created` (timestamp) (*mandatory*): timestamp this Ecosystem has been created.
 - `modified` (timestamp) (*mandatory*): timestamp this Ecosystem has been modified.
 - `archived` (timestamp) (*mandatory*): timestamp this Ecosystem has been archived.
@@ -1447,8 +1447,8 @@ A `GovernanceFrameworkVersion` represents a single version of either an [[ref: E
 - `id` (uint64) (*mandatory*): the id of the participant.
 - `schema_id` (uint64) (*mandatory*): the id of the related `CredentialSchema` entry.
 - `role` (ParticipantRole): ISSUER, VERIFIER, ISSUER_GRANTOR, VERIFIER_GRANTOR, ECOSYSTEM, HOLDER
-- `did` (string) (*optional*): [[ref: DID]] this permission refers to. MUST conform to [[spec-norm:RFC3986]].
-- `corporation` (group) (*mandatory*): [[ref: corporation]] that owns this permission.
+- `did` (string) (*optional*): [[ref: DID]] this permission refers to. MUST conform to [[spec-norm:RFC3986]]. MAY be shared with other `Participant` entries (a single DID MAY be the `did` of several participants); per-Participant DID uniqueness is NOT enforced because the `Participant` identity is its `id`. However, per-Participant `(did, corporation)` consistency IS enforced: at any block height, all `Participant` entries with non-null equal `did` MUST share the same `corporation`. Enforced by the create-time basic checks of [[MOD-PP-MSG-1-2-1]](#mod-pp-msg-1-2-1-start-participant-op-basic-checks), [[MOD-PP-MSG-7-2-1]](#mod-pp-msg-7-2-1-create-root-participant-basic-checks), and [[MOD-PP-MSG-14-2-1]](#mod-pp-msg-14-2-1-self-create-participant-basic-checks). `Participant.did` is set at create time and is not rotated thereafter.
+- `corporation` (group) (*mandatory*): [[ref: corporation]] that owns this permission. Constrained by the per-Participant `(did, corporation)` consistency invariant above (when `did` is non-null).
 - `vs_operator` (account) (*mandatory*): verifiable service agent account. This is the account that will have the right to create or update permission sessions.
 - `created` (timestamp) (*mandatory*): timestamp this `Participant` has been created.
 - `adjusted` (timestamp) (*mandatory*): timestamp this `Participant` has been adjusted.
@@ -2006,6 +2006,7 @@ If any of these precondition checks fail, method MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - A `Corporation` entry for the signing [[ref: group]] MUST NOT exist; if one exists, method MUST abort (a group MAY register itself as a `Corporation` at most once).
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
+- `did` MUST NOT already be the `did` of any existing `Corporation` entry; if some `Corporation` entry already holds this `did`, method MUST abort (per-Corporation `did` uniqueness invariant: a DID is the `did` of at most one `Corporation`).
 - `language` (string(17)) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 - `doc_url` (string) (*mandatory*): MUST be a valid URL.
 - `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
@@ -2074,6 +2075,7 @@ If any of these precondition checks fail, method MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - A `Corporation` entry `co` for the signing `corporation` MUST exist; if none exists, method MUST abort.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
+- `did` MUST NOT already be the `did` of any **other** `Corporation` entry (i.e., any `Corporation` entry whose underlying group differs from the signing `corporation`); if some other `Corporation` entry already holds this `did`, method MUST abort (per-Corporation `did` uniqueness invariant). Rotating to the same value `co.did` already holds is a no-op and MUST be allowed.
 
 ###### [MOD-CO-MSG-2-2-2] Update Corporation fee checks
 
@@ -2254,12 +2256,13 @@ If any of these precondition checks fail, method MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
+- if any existing `Ecosystem` entry has `did` equal to the provided `did`, its `corporation` MUST equal the signing `corporation`; else method MUST abort (per-Ecosystem `(did, corporation)` consistency invariant: at any block height, all `Ecosystem` entries sharing a `did` are controlled by the same `Corporation`).
 - `language` (string(17)) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 - `doc_url` (string) (*mandatory*): MUST be a valid URL .
 - `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
 
 :::note
-It is not a problem if several ecosystems are created with the same ecosystem DID. Identifier of a `Ecosystem` is its id, and the Verifiable Trust Spec includes the id of the `Ecosystem` in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.
+Several `Ecosystem` entries MAY share the same ecosystem DID. The identifier of an `Ecosystem` is its `id`, and the Verifiable Trust Spec includes the `id` of the `Ecosystem` in the DID Document. Per-Ecosystem DID uniqueness is therefore NOT required: proof of control of the DID is verified by resolving the DID outside of the context of the VPR. However, **all `Ecosystem` entries sharing the same `did` MUST be controlled by the same `corporation`** — see the basic-check bullet above. Proof of control of the shared DID is, by construction, held by that single controlling `Corporation`, and the corresponding `Corporation` entry (if any whose own `did` equals this value) is unique by the per-Corporation `did` uniqueness invariant (although the Corporation that *owns* the DID per Corp.did and the Corporation that *controls* the Ecosystems claiming it need not coincide).
 :::
 
 ###### [MOD-ES-MSG-1-2-2] Create New Ecosystem fee checks
@@ -2326,6 +2329,7 @@ If any of these precondition checks fail, method MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` (uint64) (*mandatory*): a `Ecosystem` entry `ecosystem` with id `id` MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry `ecosystem`.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
+- if any **other** `Ecosystem` entry (i.e., any `Ecosystem` entry whose `id` differs from the supplied `id`) has `did` equal to the provided `did`, its `corporation` MUST equal the signing `corporation`; else method MUST abort (per-Ecosystem `(did, corporation)` consistency invariant). Rotating `ecosystem.did` to a value already held by another `Ecosystem` controlled by a different `corporation` is forbidden.
 
 ###### [MOD-ES-MSG-2-2-2] Update Ecosystem fee checks
 
@@ -3306,6 +3310,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this `Participant` entry (can be modified by validator).
 - `verification_fees` (number) (*optional*): Requested verification_fees for this `Participant` entry (can be modified by validator).
 - `did`, if specified, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
+- if `did` is specified and any existing `Participant` entry has non-null `did` equal to the provided `did`, its `corporation` MUST equal the signing `corporation`; else method MUST abort (per-Participant `(did, corporation)` consistency invariant: at any block height, all `Participant` entries sharing a non-null `did` are owned by the same `Corporation`).
 - VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-1-1](#mod-pp-msg-1-1-start-participant-op-parameters).
 
 :::note
@@ -3856,6 +3861,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `schema_id` MUST be a valid uint64 and a [[ref: credential schema]] entry with this id MUST exist.
 - `did`, if specified, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
+- if `did` is specified and any existing `Participant` entry has non-null `did` equal to the provided `did`, its `corporation` MUST equal the signing `corporation`; else method MUST abort (per-Participant `(did, corporation)` consistency invariant).
 - `effective_from` must be in the future.
 - `effective_until`, if not null, must be greater than `effective_from`
 - `validation_fees` (number) (*mandatory*): MUST be >= 0.
@@ -4796,6 +4802,7 @@ Load `Participant` `validator_participant` from `validator_participant_id`.
 - `validator_participant_id` (uint64) (*mandatory*): `validator_participant` MUST be an ECOSYSTEM [[ref: active participant]] or [[ref: future participant]].
 - `vs_operator` (account) (*optional*): no check required.
 - `did`, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
+- if any existing `Participant` entry has non-null `did` equal to the provided `did`, its `corporation` MUST equal the signing `corporation`; else method MUST abort (per-Participant `(did, corporation)` consistency invariant: at any block height, all `Participant` entries sharing a non-null `did` are owned by the same `Corporation`).
 - `effective_from` MUST be in the future AND
   - MUST be greater or equal to `validator_participant.effective_from` AND
   - if `validator_participant.effective_until` is not null, MUST be lower than `validator_participant.effective_until`

--- a/spec.md
+++ b/spec.md
@@ -1107,7 +1107,7 @@ entity "Participant" as csp {
 }
 
 
-enum "ValidationState" as valstate {
+enum "OnboardingState" as valstate {
   PENDING
   VALIDATED
   TERMINATED
@@ -2821,11 +2821,11 @@ Permitted message types to be set in `vs_operator_authz_msg_types` depends on `t
 |Participant role|Permitted Messages|
 |-|-|
 | HOLDER | TriggerResolver |
-| ISSUER | CreateOrUpdateParticipantSession, SetPermissionVPtoValidated |
+| ISSUER | CreateOrUpdateParticipantSession, SetParticipantOPtoValidated |
 | VERIFIER | CreateOrUpdateParticipantSession |
-| ISSUER_GRANTOR | SetPermissionVPtoValidated |
-| VERIFIER_GRANTOR | SetPermissionVPtoValidated |
-| ECOSYSTEM | SetPermissionVPtoValidated |
+| ISSUER_GRANTOR | SetParticipantOPtoValidated |
+| VERIFIER_GRANTOR | SetParticipantOPtoValidated |
+| ECOSYSTEM | SetParticipantOPtoValidated |
  
 
 Available compatible perms can be found by using an indexer and presented in a front-end so applicant can choose its validator.
@@ -3152,8 +3152,8 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - Authorization:
 
 either (executed by any operator of corporation):
-[[AUTHZ-CHECK-1]](#authz-check-1-operator-authorization-checks) MUST pass for this (`corporation`, `operator`) tuple and `SetPermissionVPtoValidated` message.
-[[AUTHZ-CHECK-2]](#authz-check-2-fee-grant-checks) MUST pass for this (`corporation`, `operator`) tuple and `SetPermissionVPtoValidated` message.
+[[AUTHZ-CHECK-1]](#authz-check-1-operator-authorization-checks) MUST pass for this (`corporation`, `operator`) tuple and `SetParticipantOPtoValidated` message.
+[[AUTHZ-CHECK-2]](#authz-check-2-fee-grant-checks) MUST pass for this (`corporation`, `operator`) tuple and `SetParticipantOPtoValidated` message.
 OR (executed by vs-agent account defined in validator permission):
 [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) MUST pass for this (`corporation`, `operator`, `validator_participant`) tuple.
 [[AUTHZ-CHECK-4]](#authz-check-4-vs-operator-fee-grant-checks) MUST pass for this (`corporation`, `operator`, `validator_participant`) tuple.
@@ -3382,7 +3382,7 @@ Permitted message types to be set in `vs_operator_authz_msg_types` depends on `t
 
 |Participant role|Permitted Messages|
 |-|-|
-| ECOSYSTEM | SetPermissionVPtoValidated |
+| ECOSYSTEM | SetParticipantOPtoValidated |
 
 ##### [MOD-PP-MSG-7-2] Create Root Participant precondition checks
 
@@ -4317,7 +4317,7 @@ Permitted message types to be set in `vs_operator_authz_msg_types` depends on `t
 |Participant role|Permitted Messages|
 |-|-|
 | HOLDER | TriggerResolver |
-| ISSUER | CreateOrUpdateParticipantSession, SetPermissionVPtoValidated |
+| ISSUER | CreateOrUpdateParticipantSession, SetParticipantOPtoValidated |
 | VERIFIER | CreateOrUpdateParticipantSession |
  
 ##### [MOD-PP-MSG-14-2] Self Create Participant precondition checks
@@ -4515,7 +4515,7 @@ Generic query used for (at least):
 - `only_slashed` (boolean) (*optional*): if set to true, only return slashed permissions.
 - `only_repaid` (boolean) (*optional*): if set to true, only return repaid slashed permissions.
 - `modified_after` (timestamp) (*optional*): limit to permissions modified after (or equal to) `modified_after`.
-- `op_state` (ValidationState) (*optional*): limit to permissions with a `op_state` not null and equal to `op_state`.
+- `op_state` (OnboardingState) (*optional*): limit to permissions with a `op_state` not null and equal to `op_state`.
 - `response_max_size` (small number) (*optional*): limit to `response_max_size` results. Must be min 1, max 1,024. Default to 64.
 - `when` (timestamp) (*optional*): if set, query *at* `when`, else query *at* now(). Used to query the VPR state at a previous datetime.
 

--- a/spec.md
+++ b/spec.md
@@ -965,16 +965,22 @@ verifiera --> verifiertd:  \t+11.4 TUs
 
 *This section is non-normative.*
 
-A [[ref: governance framework]] must define the governance rules that apply to a [[ref: VPR]].
+The governance of a [[ref: VPR]] is **layered**. Three independent [[ref: governance framework]] tiers cohabit on the registry:
 
-A designated [[ref: governance authority]] is responsible for **enforcing these rules** and, when necessary, **applying financial sanctions** to participants who violate the rules.
+- the **VPR-level governance framework**, which defines the global rules for operating the registry itself;
+- one or more **[[ref: corporation governance framework]]s** (CGFs) — one per [[ref: corporation]] registered in the VPR;
+- one or more **[[ref: ecosystem governance framework]]s** (EGFs) — one per [[ref: ecosystem]] hosted on the VPR.
+
+Each tier has its own designated [[ref: governance authority]], responsible for **enforcing its rules** and, when necessary, **applying financial sanctions** (such as [[ref: trust deposit]] slashing) to participants who violate them.
 
 :::note
-**Ecosystem Governance Frameworks (EGFs)** operate **independently** from the [[ref: VPR]] [[ref: governance framework]].
+**Corporation Governance Frameworks (CGFs)** and **Ecosystem Governance Frameworks (EGFs)** operate **independently** from the [[ref: VPR]] [[ref: governance framework]].
 
-While the **VPR governance framework** defines the global rules for operating the Verifiable Public Registry (e.g., trust deposits, fee distribution, slashing conditions), each **ecosystem** must define its own **EGF** to govern roles, permissions, credential policies, and compliance within its specific domain.
+- The **VPR governance framework** defines the global rules for operating the [[ref: VPR]] itself (e.g., trust deposits, fee distribution, slashing conditions, [[ref: corporation]] registration).
+- Each **[[ref: corporation]]** publishes its own **[[ref: corporation governance framework]]** (CGF) to govern the corporation as a VPR-level entity: its lifecycle, the scope of authority delegated to its `operator` accounts (via `OperatorAuthorization`), its membership and voting rules (managed by the underlying Cosmos SDK [[ref: group]]), and its obligations toward the VPR.
+- Each **[[ref: ecosystem]]** publishes its own **[[ref: ecosystem governance framework]]** (EGF) to govern roles, `Participant` lifecycle, credential schemas, onboarding policies, and compliance within that ecosystem.
 
-This separation ensures that ecosystems remain autonomous and can tailor governance to their unique needs, without being constrained by the global rules of the VPR.
+This **three-tier separation** ensures that corporations and ecosystems remain autonomous and can tailor governance to their respective needs, without being constrained by the global rules of the VPR.
 :::
 
 ## Data model

--- a/spec.md
+++ b/spec.md
@@ -278,7 +278,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 
 *This section is non-normative.*
 
-In an [[ref: VPR]], any [[ref: corporation]] can create a `Ecosystem` entry that represents a [[ref: ecosystem]] of an ecosystem. Each `Ecosystem` entry must provide, at a minimum:
+In an [[ref: VPR]], any [[ref: corporation]] can create an `Ecosystem` entry to represent an [[ref: ecosystem]] it controls. Each `Ecosystem` entry MUST provide, at a minimum:
 
 - an ecosystem controlled resolvable [[ref: DID]];
 - one or more [[ref: ecosystem governance framework]] document(s);
@@ -301,25 +301,25 @@ object "Ecosystem" as tra #3fbdb6 {
 
 ```
 
-### Credential Schemas and Permissions
+### Credential Schemas and Participants
 
 *This section is non-normative.*
 
-[[ref: Credential schemas]] are created and managed by ecosystem corporation ([[ref: ecosystems]]). Each [[ref: Credential schema]] includes, at a minimum:
+[[ref: Credential schemas]] are created and managed by [[ref: ecosystems]] (i.e., by the [[ref: corporation]] controlling each [[ref: ecosystem]]). Each [[ref: Credential schema]] includes, at a minimum:
 
-- A **Json Schema** that defines the structure of the corresponding [[ref: verifiable credential]]
-- A **IssuerOnboardingMode** for **issuance policy**, which determines how `ISSUER` permissions are granted. Modes include:
-  - `OPEN`: `ISSUER` permissions can be self-created by anyone.
-  - `ECOSYSTEM_ONBOARDING_PROCESS`: `ISSUER` permissions are granted directly by the [[ref: ecosystem]], the ecosystem corporation through the execution of an Onboarding Process.
-  - `GRANTOR_ONBOARDING_PROCESS`: `ISSUER` permissions are granted by one or several [[ref: issuer grantor]](s) (ecosystem operator(s) responsible for selecting issuers for the credential schema of this [[ref: ecosystem]]), selected by the [[ref: ecosystem]] through the execution of an Onboarding Process.
-- A **VerifierOnboardingMode** for **verification policy**, which determines how `VERIFIER` permissions are granted. Modes include:
-  - `OPEN`: `VERIFIER` permissions can be created by anyone.
-  - `ECOSYSTEM_ONBOARDING_PROCESS`: `VERIFIER` permissions are granted directly by the [[ref: ecosystem]], the Ecosystem corporation through the execution of an Onboarding Process.
-  - `GRANTOR_ONBOARDING_PROCESS`: `VERIFIER` permissions are granted by one or several [[ref: verifier grantor]](s) (ecosystem operator(s) responsible for selecting verifiers for the credential schema of this [[ref: ecosystem]]), selected by the [[ref: ecosystem]], through the execution of an Onboarding Process.
-- An **HolderOnboardingMode** for **holder policy**, which determines how `HOLDER` permissions are granted. Modes include:
-  - `ISSUER_ONBOARDING_PROCESS`: `HOLDER` permissions are granted directly by issuers to holder through the execution of an Onboarding Process.
-  - `PERMISSIONLESS`: holder that want to obtain credentials from an issuer do not require a permission in the VPR.
-- A **Participant tree** that defines the roles and relationships involved in managing the schema’s lifecycle. Each created permission in the tree can define business rules, see below [Business Models](#business-models).
+- A **Json Schema** that defines the structure of the corresponding [[ref: verifiable credential]].
+- An **IssuerOnboardingMode** for **issuance policy**, which determines how `ISSUER` `Participant` entries are created. Modes include:
+  - `OPEN`: `ISSUER` Participants can be self-created by any [[ref: corporation]].
+  - `ECOSYSTEM_ONBOARDING_PROCESS`: `ISSUER` Participants are created directly by the controlling [[ref: ecosystem]] through an [[ref: onboarding process]].
+  - `GRANTOR_ONBOARDING_PROCESS`: `ISSUER` Participants are created by one or several [[ref: issuer grantor]](s) — ecosystem operators responsible for onboarding issuers for the credential schema of this [[ref: ecosystem]] — selected by the [[ref: ecosystem]] through an [[ref: onboarding process]].
+- A **VerifierOnboardingMode** for **verification policy**, which determines how `VERIFIER` `Participant` entries are created. Modes include:
+  - `OPEN`: `VERIFIER` Participants can be self-created by any [[ref: corporation]].
+  - `ECOSYSTEM_ONBOARDING_PROCESS`: `VERIFIER` Participants are created directly by the controlling [[ref: ecosystem]] through an [[ref: onboarding process]].
+  - `GRANTOR_ONBOARDING_PROCESS`: `VERIFIER` Participants are created by one or several [[ref: verifier grantor]](s) — ecosystem operators responsible for onboarding verifiers for the credential schema of this [[ref: ecosystem]] — selected by the [[ref: ecosystem]] through an [[ref: onboarding process]].
+- A **HolderOnboardingMode** for **holder policy**, which determines how `HOLDER` `Participant` entries are created. Modes include:
+  - `ISSUER_ONBOARDING_PROCESS`: `HOLDER` Participants are created directly by [[ref: issuers]] for holders, through an [[ref: onboarding process]].
+  - `PERMISSIONLESS`: a holder that wants to obtain credentials from an [[ref: issuer]] does not require a `Participant` entry in the VPR.
+- A **Participant tree** that defines the roles and relationships involved in managing the schema’s lifecycle. Each `Participant` entry in the tree can define business rules; see [Business Models](#business-models) below.
 
 ```plantuml
 
@@ -329,40 +329,40 @@ scale max 800 width
 package "Example Credential Schema Participant Tree" as cs {
 
     object "Ecosystem A" as tr #3fbdb6 {
-        permissionType: ECOSYSTEM (Root)
+        type: ECOSYSTEM (Root)
         did:example:ecosystemA
     }
     object "Issuer Grantor B" as ig {
-        permissionType: ISSUER_GRANTOR
+        type: ISSUER_GRANTOR
         did:example:igB
     }
     object "Issuer C" as issuer #7677ed  {
-        permissionType: ISSUER
+        type: ISSUER
         did:example:iC
     }
     object "Verifier Grantor D" as vg {
-        permissionType: VERIFIER_GRANTOR
+        type: VERIFIER_GRANTOR
         did:example:vgD
     }
     object "Verifier E" as verifier #00b0f0 {
-        permissionType: VERIFIER
+        type: VERIFIER
         did:example:vE
     }
 
     object "Holder Z " as holder #FFB073 {
-        permissionType: HOLDER
+        type: HOLDER
     }
 }
 
 
 
-tr --> ig : granted schema permission
-ig --> issuer : granted schema permission
+tr --> ig : creates schema participant
+ig --> issuer : creates schema participant
 
-tr --> vg : granted schema permission
-vg --> verifier : granted schema permission
+tr --> vg : creates schema participant
+vg --> verifier : creates schema participant
 
-issuer --> holder: granted schema permission
+issuer --> holder: creates schema participant
 
 @enduml
 
@@ -372,12 +372,12 @@ Participant roles are defined in the table below:
 
 | **Participant Role**   | **Description**                                                  |
 |-----------------------|------------------------------------------------------------------|
-| **Ecosystem**    | Create and control ecosystems and credential Schemas. Recognize other participants by granting permission(s) to them.        |
-| **Issuer Grantor**    | Ecosystem operator that grants Issuer permissions to candidate issuers.                   |
-| **Verifier Grantor**  | Ecosystem operator that grants Verifier permissions to candidate verifiers.               |
+| **Ecosystem**    | Create and control [[ref: ecosystems]] and credential schemas. Recognize other participants by validating them onto the schema (creating their `Participant` entries).        |
+| **Issuer Grantor**    | Ecosystem operator that creates `ISSUER` `Participant` entries for candidate issuers.                   |
+| **Verifier Grantor**  | Ecosystem operator that creates `VERIFIER` `Participant` entries for candidate verifiers.               |
 | **Issuer**            | Can issue credentials of this schema.                            |
 | **Verifier**          | Can request presentation of credentials of this schema.          |
-| **Holder**            | Holds a credential. Holder permission provide credential status (active, revoked...)  |
+| **Holder**            | Holds a credential. `HOLDER` `Participant` entries carry credential status (active, revoked, ...). |
 
 Example of a Json Schema credential schema:
 
@@ -430,16 +430,16 @@ Example of a Json Schema credential schema:
 
 To participate in an [[ref: ecosystem]] and assume a role associated with a specific [[ref: credential schema]]:
 
-- if schema is `OPEN` for issuance and/or verification: an entity must have an [[ref: account]] in the [[ref: VPR]] and self-create its permission.
+- if the schema is `OPEN` for issuance and/or verification: a [[ref: corporation]] MUST have a registered `Corporation` entry in the [[ref: VPR]] and self-create its `Participant` entry.
 
-- if schema is not `OPEN` for issuance and/or verification: an entity must have an [[ref: account]] in the [[ref: VPR]] and complete a [[ref: onboarding process]] to obtain the required permission.
+- if the schema is not `OPEN` for issuance and/or verification: a [[ref: corporation]] MUST have a registered `Corporation` entry in the [[ref: VPR]] and complete an [[ref: onboarding process]] to obtain its `Participant` entry.
 
 The [[ref: onboarding process]] involves two parties:
 
-- The [[ref: applicant]] — the entity requesting permission for a credential schema within the ecosystem.  
-- The [[ref: validator]] — an entity that already holds permission for the same credential schema and has been delegated authority to validate applicants and issue permissions.
+- The [[ref: applicant]] — the [[ref: corporation]] requesting a `Participant` entry for a credential schema within the ecosystem.
+- The [[ref: validator]] — a corporation that already holds a `Participant` entry for the same credential schema and has been delegated authority to validate applicants and create new `Participant` entries.
 
-Running an onboarding process **typically involves the payment of [[ref: trust fees]]**. [[ref: Trust fee]] amount to be paid by the [[ref: applicant]] is defined in the permission of the [[ref: validator]] involved in the [[ref: onboarding process]]:
+Running an [[ref: onboarding process]] **typically involves the payment of [[ref: trust fees]]**. The [[ref: trust fee]] amount to be paid by the [[ref: applicant]] is defined in the [[ref: validator]]'s `Participant` entry:
 
 ```plantuml
 
@@ -469,27 +469,87 @@ package "Pay per validation Fee Structure" as cs {
     }
 
     object "Holder Z - Credential Schema Participant" as holder #FFB073 {
-        permissionType: HOLDER
+        type: HOLDER
     }
 }
 
-tr --> ig : granted schema permission
-ig --> issuer : granted schema permission
-issuer --> holder: granted schema permission
-tr --> vg : granted schema permission
-vg --> verifier : granted schema permission
+tr --> ig : creates schema participant
+ig --> issuer : creates schema participant
+issuer --> holder: creates schema participant
+tr --> vg : creates schema participant
+vg --> verifier : creates schema participant
 
 @enduml
 
 ```
 
+### Corporation
+
+*This section is non-normative.*
+
+A [[ref: corporation]] is the VPR-level entity that represents an organisation acting in the registry. It extends a Cosmos SDK [[ref: group]] (whose members and policies are managed by the group module) with VPR-specific attributes: a [[ref: DID]], a [[ref: corporation governance framework]] (CGF), and lifecycle metadata. A `Corporation` entry has no `id` of its own — it is keyed by its underlying [[ref: group]] (1:1).
+
+A corporation interacts with the VPR in two complementary ways:
+
+- as the **controller** of zero or more [[ref: ecosystems]] — i.e., the corporation owns the corresponding `Ecosystem` entries. The controlling corporation manages each ecosystem's [[ref: EGF]], its [[ref: credential schemas]], and the root `ECOSYSTEM` `Participant` entries of those schemas.
+- as the **owner of zero or more `Participant` entries** in zero or more [[ref: ecosystems]] — i.e., the corporation acts as `ISSUER`, `VERIFIER`, `ISSUER_GRANTOR`, `VERIFIER_GRANTOR`, `HOLDER`, or root `ECOSYSTEM` for [[ref: credential schemas]] of those ecosystems.
+
+The two roles are **independent**: a corporation MAY control no ecosystem at all and only hold `Participant` entries in third-party ecosystems; or it MAY control several ecosystems and additionally hold `Participant` entries in others; or any combination of the two.
+
+```plantuml
+
+@startuml
+scale max 800 width
+
+object "Corporation X" as corpX #FFD580 {
+  did:example:corpX
+}
+
+' Ecosystems controlled by Corporation X
+object "Ecosystem A" as eA #3fbdb6 {
+  did:example:eA
+}
+object "Ecosystem B" as eB #3fbdb6 {
+  did:example:eB
+}
+
+' Ecosystems where Corporation X is just a participant
+object "Ecosystem C" as eC #3fbdb6 {
+  did:example:eC
+}
+object "Ecosystem D" as eD #3fbdb6 {
+  did:example:eD
+}
+
+' Corporation X's Participant entries
+object "ISSUER Participant\n(Ecosystem C, Schema #1)" as pC #7677ed
+object "VERIFIER Participant\n(Ecosystem D, Schema #1)" as pD #00b0f0
+object "HOLDER Participant\n(Ecosystem A, Schema #2)" as pA #FFB073
+
+corpX --> eA : controls
+corpX --> eB : controls
+
+corpX --> pC : owns
+corpX --> pD : owns
+corpX --> pA : owns
+
+pC ..> eC : in
+pD ..> eD : in
+pA ..> eA : in
+
+@enduml
+
+```
+
+The same `Corporation` entry is the single entry point for the corporation's governance (the CGF), authorization delegation (via `OperatorAuthorization` to one or more `operator` accounts), and trust-deposit accounting (`TrustDeposit`). See the [Corporation Module](#corporation-module) for the methods that manage `Corporation` entries.
+
 ### DID Indexing
 
 *This section is non-normative.*
 
-The Participant registry is a can be used by crawlers to index the metadata associated with [[ref: verifiable services]].
+The `Participant` registry CAN be used by crawlers to index the metadata associated with [[ref: verifiable services]].
 
-Search engines can iterate over the permissions, and index [[ref: VSs]] by resolving the service identifier (at the moment a [[ref: DID]], that could be extended in the future), verify if service is a [[ref: verifiable service]], and in such a case extracting their verifiable metadata, such as [[ref: linked-vp]] presented credentials.
+Search engines can iterate over `Participant` entries and index [[ref: VSs]] by resolving the service identifier (currently a [[ref: DID]], extensible in the future), verify whether the service is a [[ref: verifiable service]], and in that case extract its verifiable metadata, such as [[ref: linked-vp]] presented credentials.
 
 The index is particularly important for [[ref: verifiable user agents]], such as social browsers, CDN enabled browsers... However, it can also be leveraged by **traditional, form-based search engines**, which may return simple links for accessing [[ref: VSs]].
 
@@ -721,11 +781,11 @@ package "Ecosystem #A - Credential Schema #1" as cs {
 
 
 
-tr --> ig : granted schema permission
-ig --> issuer : granted schema permission
+tr --> ig : creates schema participant
+ig --> issuer : creates schema participant
 
-tr --> vg : granted schema permission
-vg --> verifier : granted schema permission
+tr --> vg : creates schema participant
+vg --> verifier : creates schema participant
 
 @enduml
 
@@ -3082,39 +3142,39 @@ scale max 800 width
 package "Example Credential Schema Participant Tree" as cs {
 
     object "Ecosystem A" as tr #3fbdb6 {
-        permissionType: ECOSYSTEM (Root)
+        type: ECOSYSTEM (Root)
         did:example:trA
     }
     object "Issuer Grantor B" as ig {
-        permissionType: ISSUER_GRANTOR
+        type: ISSUER_GRANTOR
         did:example:igB
     }
     object "Issuer C" as issuer #7677ed  {
-        permissionType: ISSUER
+        type: ISSUER
         did:example:iC
     }
     object "Verifier Grantor D" as vg {
-        permissionType: VERIFIER_GRANTOR
+        type: VERIFIER_GRANTOR
         did:example:vgD
     }
     object "Verifier E" as verifier #00b0f0 {
-        permissionType: VERIFIER
+        type: VERIFIER
         did:example:vE
     }
     object "Holder Z " as holder #FFB073 {
-        permissionType: HOLDER
+        type: HOLDER
     }
 }
 
 
 
-tr --> ig : granted schema permission
-ig --> issuer : granted schema permission
+tr --> ig : creates schema participant
+ig --> issuer : creates schema participant
 
-tr --> vg : granted schema permission
-vg --> verifier : granted schema permission
+tr --> vg : creates schema participant
+vg --> verifier : creates schema participant
 
-issuer --> holder: granted schema permission
+issuer --> holder: creates schema participant
 
 @enduml
 
@@ -4002,40 +4062,40 @@ scale max 800 width
 package "Example Credential Schema Participant Tree" as cs {
 
     object "Ecosystem A" as tr #3fbdb6 {
-        permissionType: ECOSYSTEM (Root)
+        type: ECOSYSTEM (Root)
         did:example:ecosystemA
     }
     object "Issuer Grantor B" as ig {
-        permissionType: ISSUER_GRANTOR
+        type: ISSUER_GRANTOR
         did:example:igB
     }
     object "Issuer C" as issuer #7677ed  {
-        permissionType: ISSUER
+        type: ISSUER
         did:example:iC
     }
     object "Verifier Grantor D" as vg {
-        permissionType: VERIFIER_GRANTOR
+        type: VERIFIER_GRANTOR
         did:example:vgD
     }
     object "Verifier E" as verifier #00b0f0 {
-        permissionType: VERIFIER
+        type: VERIFIER
         did:example:vE
     }
 
     object "Holder Z " as holder #FFB073 {
-        permissionType: HOLDER
+        type: HOLDER
     }
 }
 
 
 
-tr --> ig : granted schema permission
-ig --> issuer : granted schema permission
+tr --> ig : creates schema participant
+ig --> issuer : creates schema participant
 
-tr --> vg : granted schema permission
-vg --> verifier : granted schema permission
+tr --> vg : creates schema participant
+vg --> verifier : creates schema participant
 
-issuer --> holder: granted schema permission
+issuer --> holder: creates schema participant
 
 @enduml
 

--- a/spec.md
+++ b/spec.md
@@ -483,11 +483,11 @@ vg --> verifier : creates schema participant
 
 ```
 
-### Corporation
+### Corporation Management
 
 *This section is non-normative.*
 
-A [[ref: corporation]] is the VPR-level entity that represents an organisation acting in the registry. It extends a Cosmos SDK [[ref: group]] (whose members and policies are managed by the group module) with VPR-specific attributes: a [[ref: DID]], a [[ref: corporation governance framework]] (CGF), and lifecycle metadata. A `Corporation` entry has no `id` of its own — it is keyed by its underlying [[ref: group]] (1:1).
+A [[ref: corporation]] is the VPR-level entity that represents an authority acting in the registry. It extends a Cosmos SDK [[ref: group]] (whose members and policies are managed by the group module) with VPR-specific attributes: a [[ref: DID]], a [[ref: corporation governance framework]] (CGF), and lifecycle metadata. A `Corporation` entry has no `id` of its own — it is keyed by its underlying [[ref: group]] (1:1).
 
 A corporation interacts with the VPR in two complementary ways:
 
@@ -581,7 +581,7 @@ user <|-- browser : show result
 
 *This section is non-normative.*
 
-In a [[ref: VPR]], each [[ref: account]] is associated with a [[ref: trust deposit]].
+In a [[ref: VPR]], each [[ref: corporation]] is associated with a [[ref: trust deposit]].
 
 This [[ref: trust deposit]] is automatically funded through transactions involving **trust operations**, such as:
 
@@ -589,7 +589,7 @@ This [[ref: trust deposit]] is automatically funded through transactions involvi
 
 The trust deposit is fundamental to the **"Proof-of-Trust" (PoT)** mechanism of the [[ref: Verifiable Trust Specification]], and it operates as follows:
 
-- The more you use the [[ref: VPR]], the more your [[ref: trust deposit]] grows.
+- The more a [[ref: corporation]] uses the [[ref: VPR]], the more its [[ref: trust deposit]] grows.
 - Trust deposits **generate yield**: block execution fees are distributed not only to network validators, but also to **trust deposit holders**.
 - **network-level penalties**: If a participant violates the [[ref: governance framework]] of the [[ref: VPR]] or engages in **fraudulent activity**, their **trust deposit may be partially or fully slashed** by the [[ref: VPR]]'s governance authority.
 - **ecosystem-level penalties**: If a participant operates within an ecosystem (e.g., as a [[ref: grantor]], [[ref: issuer]], [[ref: verifier]], or [[ref: holder]],...) and **fails to comply** with that ecosystem’s governance framework (EGF), their **ecosystem-specific trust deposit can be slashed** by the corresponding ecosystem governance authority.
@@ -600,26 +600,11 @@ The trust deposit is fundamental to the **"Proof-of-Trust" (PoT)** mechanism of 
 
 This system ensures that participation in the trust ecosystem is backed by economic accountability, reinforcing the integrity, governability and verifiability of the [[ref: VPR]].
 
-#### Object creation
+#### Onboarding Process Trust Fees
 
 *This section is non-normative.*
 
-The following operations **only require payment of network fees** (no trust deposit is involved):
-
-- **Ecosystems**: requires paying only [[ref: network fees]]  
-- **Credential Schemas**: requires paying only [[ref: network fees]]  
-
-
-- Updating the **governance framework documents** of an ecosystem ecosystem  
-- Updating a Credential Schema
-- Updating an Ecosystem
-- ...
-
-#### Onboarding process trust fees
-
-*This section is non-normative.*
-
-We've explained in the [Credential Schemas and Permissions](#credential-schemas-and-permissions) section above what is an onboarding process.
+We've explained in the [Credential Schemas and Participants](#credential-schemas-and-participants) section above what is an onboarding process.
 
 The table below summarizes the possible combinations of applicants and validators:
 
@@ -637,10 +622,9 @@ The table below summarizes the possible combinations of applicants and validator
 - (4): if *verifier onboarding mode* is set to ECOSYSTEM_ONBOARDING_PROCESS.
 - (5): if *holder onboarding mode* is set to ISSUER_ONBOARDING_PROCESS.
 
-
 Onboarding process is started by the applicant.
 
-*Example of a candidate [[ref: issuer]] ([[ref: applicant]]) that would like to be granted an ISSUER permission for a credential schema of an ecosystem, by a [[ref: validator]] that has a ISSUER_GRANTOR permission:*
+*Example of a candidate [[ref: issuer]] ([[ref: applicant]]) that would like to obtain an `ISSUER` `Participant` entry for a credential schema of an ecosystem, validated by a [[ref: validator]] that holds an `ISSUER_GRANTOR` `Participant` entry:*
 
 ```plantuml
 scale max 800 width
@@ -652,36 +636,36 @@ actor "Validator\n(issuer grantor)\nAccount" as ValidatorAccount
 
 participant "Verifiable Public Registry" as VPR #3fbdb6
 
-ApplicantAccount --> VPR: create new validation with Validator 
-VPR <-- VPR: create validation entry.
-ApplicantAccount <-- VPR: validation entry created
-ApplicantBrowser --> ValidatorVS: connect to validator VS DID found in validation.perm\nby creating a DIDComm connection
+ApplicantAccount --> VPR: start onboarding process with Validator
+VPR <-- VPR: create applicant Participant entry\n(op_state = PENDING)
+ApplicantAccount <-- VPR: applicant Participant entry created
+ApplicantBrowser --> ValidatorVS: connect to validator VS DID found in\napplicant_participant.validator_participant\nby creating a DIDComm connection
 ApplicantBrowser <-- ValidatorVS: DIDComm connection established.
-ApplicantBrowser --> ValidatorVS: I want to proceed with validation.id=...
-ValidatorVS --> ValidatorVS: load validation with id=...\nand verify the associated validation.perm is referring to me
-ApplicantBrowser <-- ValidatorVS: request proof of control\nof validation.applicant account (blind sign)
+ApplicantBrowser --> ValidatorVS: I want to proceed with applicant_participant.id=...
+ValidatorVS --> ValidatorVS: load applicant Participant with this id\nand verify validator_participant_id refers to me
+ApplicantBrowser <-- ValidatorVS: request proof of control\nof applicant_participant.corporation account (blind sign)
 ApplicantBrowser --> ValidatorVS: send blind sign proof of operator account
-ApplicantBrowser <-- ValidatorVS: proof accepted, you are the operator\nof validation entry, I trust you.
+ApplicantBrowser <-- ValidatorVS: proof accepted, you are an operator\nof the applicant Participant, I trust you.
 ApplicantBrowser <-- ValidatorVS: which DID do you want to register as an issuer?
 ApplicantBrowser --> ValidatorVS: send DID
 ValidatorVS --> ValidatorVS: resolve DID and get pub keys
-ApplicantBrowser <-- ValidatorVS: request proof of ownership\nof the DID to be registered in the ISSUER permission (blind sign)
+ApplicantBrowser <-- ValidatorVS: request proof of ownership\nof the DID to be registered on your `ISSUER` `Participant` entry (blind sign)
 ApplicantBrowser --> ValidatorVS: send blind sign proofs
 ApplicantBrowser <-- ValidatorVS: proof accepted, you are the controller of this DID, I trust you.
 note over ApplicantBrowser, ValidatorVS #EEEEEE: (*optional*) repeat the following until tasks completed
 ApplicantBrowser <-- ValidatorVS: Are you a legitimate issuer?\nProve it, by filling forms, sending documents...
 ApplicantBrowser --> ValidatorVS: perform requested tasks...
 note over ApplicantBrowser, ValidatorVS #EEEEEE: tasks completed
-ApplicantBrowser <-- ValidatorVS: Your are a legitimate candidate. I'll now create an ISSUER permission for your account and DID.
-ValidatorAccount --> VPR #3fbdb6: set validation.state to VALIDATED\ncreate permission(s) for applicant.
+ApplicantBrowser <-- ValidatorVS: You are a legitimate candidate. I'll now finalize your `ISSUER` `Participant` entry.
+ValidatorAccount --> VPR #3fbdb6: set applicant_participant.op_state to VALIDATED\n(finalize the `ISSUER` `Participant` entry)
 VPR --> ValidatorAccount: Receive trust fees.
-ApplicantBrowser <-- ValidatorVS: notify ISSUER permission created for your account and DID.\nDID can now issue credentials of this schema.
+ApplicantBrowser <-- ValidatorVS: notify `ISSUER` `Participant` entry validated for your corporation and DID.\nDID can now issue credentials of this schema.
 ```
 
-The **total fees** paid by the applicant consists of:
+The **total fees** paid by the applicant consist of:
 
-- The validation [[ref: trust fees]] defined in the permission of the validator participating in the onboarding process, **plus**
-- An additional amount equal to the `trust_deposit_rate` of that validation [[ref: trust fees]], which is **allocated to the applicant’s trust deposit** when the onboarding process begins.
+- The validation [[ref: trust fees]] defined in the validator's `Participant` entry (the one acting as the validator in the onboarding process), **plus**
+- an additional amount equal to the `trust_deposit_rate` of that validation [[ref: trust fees]], which is **allocated to the applicant's [[ref: trust deposit]]** when the onboarding process begins, **plus**
 - [[ref: network fees]] (not part of the escrowed amount).
 
 Example, using 20% for `trust_deposit_rate`:

--- a/spec.md
+++ b/spec.md
@@ -1,6 +1,6 @@
 # Verifiable Public Registry v4 Specification
 
-**Latest draft:** [spec v4-draft20](https://verana-labs.github.io/verifiable-trust-vpr-spec/)
+**Latest draft:** [spec v4-draft21](https://verana-labs.github.io/verifiable-trust-vpr-spec/)
 
 **Latest stable:** [spec v3](https://verana-labs.github.io/verifiable-trust-vpr-spec/index-v3.html)
 

--- a/spec.md
+++ b/spec.md
@@ -956,7 +956,6 @@ entity "Ecosystem" as tr {
 }
 
 entity "Corporation" as corp {
-  *id: uint64
   +did: string
   +created: timestamp
   +modified: timestamp
@@ -1259,7 +1258,6 @@ A `Corporation` is the VPR-level entity that extends a Cosmos SDK [[ref: group]]
 
 `Corporation`:
 
-- `id` (uint64) (*mandatory*): the id of the Corporation. MUST be equal to the id of the underlying Cosmos SDK [[ref: group]] that this Corporation extends (1:1).
 - `did` (string) (*mandatory*): the DID of the Corporation.
 - `created` (timestamp) (*mandatory*): timestamp this Corporation has been created.
 - `modified` (timestamp) (*mandatory*): timestamp this Corporation has been modified.
@@ -1267,7 +1265,7 @@ A `Corporation` is the VPR-level entity that extends a Cosmos SDK [[ref: group]]
 - `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this Corporation.
 - `active_version` (int) (*mandatory*): active [[ref: CGF]] version.
 
-> Note: members and policies of a Corporation are managed by the underlying Cosmos SDK group module. The Corporation entry adds VPR-level attributes only (DID, governance framework, lifecycle).
+> Note: a Corporation entry has no `id` of its own. Its primary key is the underlying Cosmos SDK [[ref: group]] (1:1, see the `group --- corp` link in the diagram above): a Corporation entry is created, looked up, and referenced by the id of the group it extends. Members and policies of a Corporation are managed by the underlying Cosmos SDK group module; the Corporation entry adds VPR-level attributes only (DID, governance framework, lifecycle).
 
 ### Ecosystem
 
@@ -1766,7 +1764,7 @@ If the [[ref: transaction]] fees are paid by the `corporation` account (via fee 
 
 ##### [AUTHZ-CHECK-5] Corporation Registration check
 
-A `Corporation` entry with `id` equal to the id of the signing `corporation` MUST exist. If none exists, the [[ref: transaction]] MUST abort with an error indicating that the underlying [[ref: group]] has not yet been registered as a [[ref: corporation]] (see [[MOD-CO-MSG-1]](#mod-co-msg-1-create-new-corporation)).
+A `Corporation` entry MUST exist for the signing `corporation` (i.e., keyed by its underlying Cosmos SDK [[ref: group]]). If none exists, the [[ref: transaction]] MUST abort with an error indicating that the underlying [[ref: group]] has not yet been registered as a [[ref: corporation]] (see [[MOD-CO-MSG-1]](#mod-co-msg-1-create-new-corporation)).
 
 > Exception: this check MUST NOT be applied for [[MOD-CO-MSG-1]](#mod-co-msg-1-create-new-corporation), whose explicit purpose is to register a Cosmos SDK [[ref: group]] as a new `Corporation`. That method enforces the inverse precondition (the entry MUST NOT yet exist) in its own basic checks.
 
@@ -1890,7 +1888,7 @@ Any authorized `operator` CAN execute this method on behalf of a Cosmos SDK [[re
 
 An authorized `operator` that would like to register a Cosmos SDK [[ref: group]] as a `Corporation` MUST call this method by specifying:
 
-- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed. For this method specifically, the `id` of `corporation` refers to the id of the underlying Cosmos SDK [[ref: group]] that wants to register itself — no `Corporation` entry exists for that id yet.
+- `corporation` (Corporation): (Signer) the signing corporation on whose behalf this message is executed. For this method specifically, the underlying Cosmos SDK [[ref: group]] of `corporation` is the group that wants to register itself — no `Corporation` entry exists for that group yet.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `did` (string) (*mandatory*): the DID of the Corporation.
 - `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this Corporation.
@@ -1910,7 +1908,7 @@ If any of these precondition checks fail, method MUST abort.
 - `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- A `Corporation` entry with `id` equal to the id of the signing group MUST NOT exist; if one exists, method MUST abort (a group MAY register itself as a `Corporation` at most once).
+- A `Corporation` entry for the signing [[ref: group]] MUST NOT exist; if one exists, method MUST abort (a group MAY register itself as a `Corporation` at most once).
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
 - `language` (string(17)) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 - `doc_url` (string) (*mandatory*): MUST be a valid URL.
@@ -1926,9 +1924,8 @@ If all precondition checks passed, method is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- create and persist a new `Corporation` entry `co`:
+- create and persist a new `Corporation` entry `co` keyed by the signing Cosmos SDK [[ref: group]] (1:1):
 
-- `co.id`: id of the signing Cosmos SDK [[ref: group]] (1:1)
 - `co.did`: `did`
 - `co.created`: current timestamp
 - `co.modified`: `co.created`
@@ -1940,7 +1937,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - `gfv.id`: auto-incremented uint64
 - `gfv.ecosystem_id`: null
-- `gfv.corporation_id`: `co.id`
+- `gfv.corporation_id`: id of the signing [[ref: group]] (i.e., the key of `co`)
 - `gfv.created`: current timestamp
 - `gfv.version`: 1
 - `gfv.active_since`: current timestamp
@@ -1978,7 +1975,7 @@ If any of these precondition checks fail, method MUST abort.
 - `corporation` (Corporation): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- A `Corporation` entry `co` with `co.id` equal to the id of the signing `corporation` MUST exist; if none exists, method MUST abort.
+- A `Corporation` entry `co` for the signing `corporation` MUST exist; if none exists, method MUST abort.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
 - `language` (string(17)) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 
@@ -1992,7 +1989,7 @@ If all precondition checks passed, method is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- load `Corporation` entry `co` from the id of the signing `corporation` and set:
+- load `Corporation` entry `co` for the signing `corporation` and set:
 
 - `co.did`: `did`
 - `co.language`: `language`
@@ -2077,7 +2074,7 @@ Anyone CAN execute this method.
 
 ##### [MOD-CO-QRY-1-1] Get Corporation query parameters
 
-- `id` (uint64) (*mandatory*): the id of the Corporation.
+- `id` (uint64) (*mandatory*): the id of the Cosmos SDK [[ref: group]] that the target `Corporation` entry extends (a `Corporation` has no `id` of its own; its primary key is the underlying group).
 - `active_gf_only` (boolean) (*optional*): if true, include only current governance framework data. If false or null, returns everything.
 - `preferred_language` (string) (*optional*): if set, return only one document per version, preferring `preferred_language`.
 
@@ -2424,7 +2421,7 @@ if a mandatory parameter is not present, method MUST abort.
 - Exactly one of `ecosystem_id` and `corporation_id` MUST be set; if both are set or both are null, method MUST abort.
 - Define `subject` as:
   - if `ecosystem_id` is set: the `Ecosystem` entry with this id. The entry MUST exist and `subject.corporation` MUST be equal to the `corporation` executing the method.
-  - if `corporation_id` is set: the `Corporation` entry with this id. The entry MUST exist and `corporation_id` MUST be equal to the id of the `corporation` executing the method (a Corporation may only edit its own governance framework).
+  - if `corporation_id` is set: the `Corporation` entry keyed by `corporation_id` (i.e., the Corporation whose underlying [[ref: group]] has id `corporation_id`). The entry MUST exist, and `corporation_id` MUST equal the [[ref: group]] id of the signing `corporation` (a Corporation may only edit its own governance framework).
 - `version`: there MUST exist a `GovernanceFrameworkVersion` entry `gfv` whose owner matches `subject` (i.e., `gfv.ecosystem_id = ecosystem_id` if subject is an Ecosystem, else `gfv.corporation_id = corporation_id`) and `gfv.version = version`, OR `version` MUST be exactly equal to the biggest `gfv.version` + 1 of all `GovernanceFrameworkVersion` entries owned by `subject`. `version` MUST be greater than `subject.active_version`.
 - `doc_language` (string) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 - `doc_url` (string) (*mandatory*): MUST be a valid URL.
@@ -2484,7 +2481,7 @@ If any of these precondition checks fail, method MUST abort.
 - Exactly one of `ecosystem_id` and `corporation_id` MUST be set; if both are set or both are null, method MUST abort.
 - Define `subject` as:
   - if `ecosystem_id` is set: the `Ecosystem` entry with this id. The entry MUST exist and `subject.corporation` MUST be equal to the `corporation` executing the method.
-  - if `corporation_id` is set: the `Corporation` entry with this id. The entry MUST exist and `corporation_id` MUST be equal to the id of the `corporation` executing the method.
+  - if `corporation_id` is set: the `Corporation` entry keyed by `corporation_id` (i.e., the Corporation whose underlying [[ref: group]] has id `corporation_id`). The entry MUST exist, and `corporation_id` MUST equal the [[ref: group]] id of the signing `corporation`.
 - Find a `GovernanceFrameworkVersion` entry `gfv` owned by `subject` (matching `gfv.ecosystem_id` or `gfv.corporation_id` as appropriate) whose `gfv.version` is equal to `subject.active_version` + 1. If none is found, transaction MUST abort.
 - Find a `GovernanceFrameworkDocument` `gfd` for `gfd.gfv_id` = `gfv.id` and `gfd.language` = `subject.language`. If no document is found (and thus no document exists for the default language of this version for this subject), transaction MUST abort.
 
@@ -3123,24 +3120,24 @@ issuer --> holder: granted schema permission
 
 ```
 
-The ECOSYSTEM type permissions are created by the Credential Schema owner. All other permissions are created by running an Onboarding Process (or by any account: - for `ISSUER` permissions if issuer_onboarding_mode is equal to `OPEN`, - for `VERIFIER` permissions if verifier_onboarding_mode is equal to `OPEN`).
+The ECOSYSTEM type participants are created by the Credential Schema owner. All other participants are created by running an Onboarding Process (or by any account: - for `ISSUER` permissions if issuer_onboarding_mode is equal to `OPEN`, - for `VERIFIER` permissions if verifier_onboarding_mode is equal to `OPEN`).
 
-An Onboarding Process (OP) is a process which involves an [[ref: applicant]] (which is the [[ref: corporation]] of validation entry stored in a validation [[ref: keeper]]), a [[ref: validator]] permission, and optional validation fees plus transaction fees.
+An Onboarding Process (OP) is a process which involves an [[ref: applicant]] (which is the [[ref: corporation]] of a given Participant entry), and a [[ref: validator]] Participant, and optional validation fees plus transaction fees.
 
-Validation is used by [[ref: applicants]] that want to:
+Onboarding is used by [[ref: applicants]] that want to:
 
 - be an [[ref: issuer]] of a specific [[ref: credential schema]];
 - be a [[ref: verifier]] of a specific [[ref: credential schema]];
 - be an [[ref: issuer grantor]] of a specific [[ref: credential schema]];
 - be a [[ref: verifier grantor]] of a specific [[ref: credential schema]];
 - get issued a credential of a specific [[ref: credential schema]];
-- obtain a HOLDER permission from a issuer of a specific [[ref: credential schema]] and get issued a verifiable credential of this schema (HOLDER permission provide credential status (revoked, etc...));
+- obtain a HOLDER participant entry from a issuer of a specific [[ref: credential schema]] and get issued a verifiable credential of this schema (HOLDER participant provide credential status (revoked, etc...));
 
 In all cases, the process is very similar. Example execution of an onboarding process:
 
-1. Applicant starts an onboarding process by running the [start new validation] [[ref: transaction]]. Onboarding process may be subject to paying validation fees, as defined by validator.
+1. Applicant starts an onboarding process by running the [start new validation] [[ref: transaction]]. Onboarding process may be subject to paying validation fees, as defined in validator Participant entry.
 2. Onboarding process requires that [[ref: applicant]] connects to a validation [[ref: VS]] identified by its [[ref: DID]], and execute a some validation steps, required for the onboarding process to conclude.
-3. If [[ref: applicant]] qualifies, [[ref: validator]] updates the validation entry by running the [set to validated] [[ref: transaction]], and [[ref: applicant]] is granted new permissions, and/or gets issued a credential.
+3. If [[ref: applicant]] qualifies, [[ref: validator]] updates the participant entry by running the [set to validated] [[ref: transaction]], and [[ref: applicant]] is granted new permissions, and/or gets issued a credential.
 
 Validation is valid for a specific period, for example 365 days, as configured in the [[ref: credential schema]] for credential schema related validations, or set by ecosystem for user-agent validation.
 
@@ -3154,8 +3151,8 @@ At any time, [[ref: applicant]] can cancel the onboarding process.
 
 Some special unexpected situation may arise and must be mitigated. Examples:
 
-- if selected validator permission is revoked while applicant's validation is in PENDING state: Applicant CAN cancel the onboarding process [MOD-PP-MSG-6].
-- if selected validator permission is revoked while applicant is in VALIDATED state: Applicant CAN renew the onboarding process by choosing a new validator [MOD-PP-MSG-2].
+- if selected validator Participant entry is revoked while applicant's validation is in PENDING state: Applicant CAN cancel the onboarding process [MOD-PP-MSG-6].
+- if selected validator Participant entry is revoked while applicant is in VALIDATED state: Applicant CAN renew the onboarding process by choosing a new validator [MOD-PP-MSG-2].
 
 #### [MOD-PP-MSG-1] Start Participant OP
 

--- a/spec.md
+++ b/spec.md
@@ -1428,13 +1428,13 @@ A `VSOperatorAuthorization` groups all `ParticipantAuthorizationRecord` entries 
 A `ParticipantAuthorizationRecord` carries the per-permission authorization configuration that was previously stored on `Participant.vs_operator_authz_*` fields. Each record is globally unique by `participant_id`: for any `Participant.id`, at most one record exists system-wide, so `(corporation, vs_operator)` can be derived from `participant_id` via a direct lookup.
 
 - `participant_id` (uint64) (*mandatory*): id of the `Participant` this authorization record applies to. Globally unique across all `ParticipantAuthorizationRecord` entries.
-- `msg_types` (msg_type[]) (*mandatory*): list of delegable message types for which the `vs_operator` is authorized on behalf of `corporation` when acting in the context of `participant_id`. Declared by the applicant at record creation time (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant)). Frozen after creation.
+- `msg_types` (msg_type[]) (*mandatory*): list of delegable message types for which the `vs_operator` is authorized on behalf of `corporation` when acting in the context of `participant_id`. Declared by the applicant at record creation time (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant)). Frozen after creation.
 - `spend_limit` (DenomAmount[]) (*optional*): maximum amount the `vs_operator` is allowed to spend, in the context of this permission, as a direct consequence of executing authorized messages.
 - `remaining_spend` (DenomAmount[]) (*conditional*): runtime balance for `spend_limit`. Present iff `spend_limit` is set. Initialized to `spend_limit` at create time. Decremented per matching `denom` after each authorized operation. Reset to `spend_limit` when the current cycle ends (see `expiration` and `period` below).
 - `fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
 - `remaining_fee_spend` (DenomAmount[]) (*conditional*): runtime balance for `fee_spend_limit`. Present iff `fee_spend_limit` is set. Initialized, decremented and reset following the same rules as `remaining_spend`.
 - `with_feegrant` (bool) (*mandatory*): if true, `corporation` pays the transaction fees for `vs_operator` when executing authorized messages in the context of this permission, through an on-chain `FeeGrant`.
-- `expiration` (timestamp) (*mandatory*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the record is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the record auto-renews until removed via [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)). Initially written to `now` at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp) (disabled until validation) and to `Participant.effective_until` at [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-vp-to-validated) / [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-participant) / [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant).
+- `expiration` (timestamp) (*mandatory*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the record is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the record auto-renews until removed via [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)). Initially written to `now` at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op) (disabled until validation) and to `Participant.effective_until` at [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-op-to-validated) / [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-participant) / [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant).
 - `period` (duration) (*optional*): reset period for `spend_limit` and `fee_spend_limit` in the context of this permission.
 
 ### ExchangeRate
@@ -1706,7 +1706,7 @@ If the transaction fees are paid by the `corporation` account (via fee grant) in
 
 A second authorization grant mode exists for vs-agents. It is used when a corporation delegates a specific permission (and a specific set of message types, scoped to that permission) to a `vs_operator` account. The authorization model differs from other delegable messages: it relies on [VSOperatorAuthorization](#vsoperatorauthorization) / [ParticipantAuthorizationRecord](#participantauthorizationrecord) instead of `OperatorAuthorization`.
 
-> Note: the set of messages a `vs_operator` is authorized to execute in the context of a permission is declared by the applicant at permission creation time (see [[MOD-PP-MSG-1-1]](#mod-pp-msg-1-1-start-participant-vp-parameters) and [[MOD-PP-MSG-14-1]](#mod-pp-msg-14-1-self-create-participant-parameters)) and stored in `record.msg_types`. It is frozen for the lifetime of the record and can only be changed by revoking the permission and starting a new one.
+> Note: the set of messages a `vs_operator` is authorized to execute in the context of a permission is declared by the applicant at permission creation time (see [[MOD-PP-MSG-1-1]](#mod-pp-msg-1-1-start-participant-op-parameters) and [[MOD-PP-MSG-14-1]](#mod-pp-msg-14-1-self-create-participant-parameters)) and stored in `record.msg_types`. It is frozen for the lifetime of the record and can only be changed by revoking the permission and starting a new one.
 
 Given a `corporation`, an `operator` (the `vs_operator`), a **primary permission id** `participant_id` (determined by the calling method), and the current message type `msg_type`:
 
@@ -1733,7 +1733,7 @@ If the [[ref: transaction]] fees are paid by the `corporation` account (via fee 
 
 A corporation group `corporationABC` wants to authorize an operator account `accountABC` to execute the  
 [`mod-pp-msg-10-create-or-update-participant-session`](#mod-pp-msg-10-create-or-update-participant-session),
-[`mod-pp-msg-3-set-participant-vp-to-validated`](#mod-pp-msg-3-set-participant-vp-to-validated), and
+[`mod-pp-msg-3-set-participant-op-to-validated`](#mod-pp-msg-3-set-participant-op-to-validated), and
 [`mod-pp-msg-15-trigger-resolver`](#mod-pp-msg-15-trigger-resolver)
  messages.
 
@@ -1743,7 +1743,7 @@ To achieve this, `corporationABC` MUST:
 
 - create an **authorization** from `corporationABC` to `accountABC` for the  
   [`mod-pp-msg-10-create-or-update-participant-session`](#mod-pp-msg-10-create-or-update-participant-session),
-[`mod-pp-msg-3-set-participant-vp-to-validated`](#mod-pp-msg-3-set-participant-vp-to-validated), and
+[`mod-pp-msg-3-set-participant-op-to-validated`](#mod-pp-msg-3-set-participant-op-to-validated), and
 [`mod-pp-msg-15-trigger-resolver`](#mod-pp-msg-15-trigger-resolver) message types, optionally enabling an associated fee grant.
 
 As a result, `accountABC` is authorized to:
@@ -1777,10 +1777,10 @@ As a result, `accountABC` is authorized to:
 |                                | List CS Module Parameters               | /cs/v1/params                 | Query  | [[MOD-CS-QRY-4]](#mod-cs-qry-4-list-module-parameters)   |N/A  |
 |                  | Get Schema Authorization Policy                         | /cs/v1/sap/get         | Query | [[MOD-CS-QRY-5]](#mod-cs-qry-5-get-schema-authorization-policy) | N/A |
 |                  | List Schema Authorization Policies                      | /cs/v1/sap/list        | Query | [[MOD-CS-QRY-6]](#mod-cs-qry-6-list-schema-authorization-policies) | N/A |
-| Participant                    | Start Participant VP                     |     N/A (Tx)                       | Msg    | [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp)    |corporation + operator |
-|                                | Renew a Participant VP                   |       N/A (Tx)                     | Msg    | [[MOD-PP-MSG-2]](#mod-pp-msg-2-renew-participant-vp)    |corporation + operator |
-|                                | Set Participant VP to Validated          |        N/A (Tx)                     | Msg    | [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-vp-to-validated)    |corporation + operator |
-|                                | Cancel Participant VP Last Request       |         N/A (Tx)                    | Msg    | [[MOD-PP-MSG-6]](#mod-pp-msg-6-cancel-participant-vp-last-request)    |corporation + operator |
+| Participant                    | Start Participant OP                     |     N/A (Tx)                       | Msg    | [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op)    |corporation + operator |
+|                                | Renew a Participant OP                   |       N/A (Tx)                     | Msg    | [[MOD-PP-MSG-2]](#mod-pp-msg-2-renew-participant-op)    |corporation + operator |
+|                                | Set Participant OP to Validated          |        N/A (Tx)                     | Msg    | [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-op-to-validated)    |corporation + operator |
+|                                | Cancel Participant OP Last Request       |         N/A (Tx)                    | Msg    | [[MOD-PP-MSG-6]](#mod-pp-msg-6-cancel-participant-op-last-request)    |corporation + operator |
 |                                | Create Root Participant                  |         N/A (Tx)                | Msg    | [[MOD-PP-MSG-7]](#mod-pp-msg-7-create-root-participant)   |corporation + operator |
 |                                | Adjust Participant                       |         N/A (Tx)            | Msg    | [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-participant)  |corporation + operator |
 |                                | Revoke Participant                       |          N/A (Tx)              | Msg    | [[MOD-PP-MSG-9]](#mod-pp-msg-9-revoke-participant)  |corporation + operator |
@@ -2790,11 +2790,11 @@ Some special unexpected situation may arise and must be mitigated. Examples:
 - if selected validator permission is revoked while applicant's validation is in PENDING state: Applicant CAN cancel the onboarding process [MOD-PP-MSG-6].
 - if selected validator permission is revoked while applicant is in VALIDATED state: Applicant CAN renew the onboarding process by choosing a new validator [MOD-PP-MSG-2].
 
-#### [MOD-PP-MSG-1] Start Participant VP
+#### [MOD-PP-MSG-1] Start Participant OP
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-PP-MSG-1-1] Start Participant VP parameters
+##### [MOD-PP-MSG-1-1] Start Participant OP parameters
 
 An Applicant that would like to start a permission onboarding process MUST execute this method by specifying:
 
@@ -2830,11 +2830,11 @@ Permitted message types to be set in `vs_operator_authz_msg_types` depends on `t
 
 Available compatible perms can be found by using an indexer and presented in a front-end so applicant can choose its validator.
 
-##### [MOD-PP-MSG-1-2] Start Participant VP precondition checks
+##### [MOD-PP-MSG-1-2] Start Participant OP precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-1-2-1] Start Participant VP basic checks
+###### [MOD-PP-MSG-1-2-1] Start Participant OP basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -2842,18 +2842,18 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `type` (ParticipantRole) (*mandatory*) MUST be a valid ParticipantRole: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.
-- `validator_participant_id` (uint64) (*mandatory*): see [MOD-PP-MSG-1-2-2](#mod-pp-msg-1-2-2-start-participant-vp-permission-checks).
+- `validator_participant_id` (uint64) (*mandatory*): see [MOD-PP-MSG-1-2-2](#mod-pp-msg-1-2-2-start-participant-op-permission-checks).
 - `validation_fees` (number) (*optional*): Requested validation_fees for this permission (can be modified by validator).
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
 - `verification_fees` (number) (*optional*): Requested verification_fees for this permission (can be modified by validator).
 - `did`, if specified, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-1-1](#mod-pp-msg-1-1-start-participant-vp-parameters).
+- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-1-1](#mod-pp-msg-1-1-start-participant-op-parameters).
 
 :::note
 A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It's up to the issuer to decide if running the onboarding process is REQUIRED or not.
 :::
 
-###### [MOD-PP-MSG-1-2-2] Start Participant VP permission checks
+###### [MOD-PP-MSG-1-2-2] Start Participant OP permission checks
 
 - Load `Participant` entry `validator_participant` from `validator_participant_id`. It MUST be a [[ref: active participant]] else transaction MUST abort.
 - Load `CredentialSchema` entry `cs` from `validator_participant.schema_id`. It MUST exist.
@@ -2894,7 +2894,7 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 
 At the end, if a [[ref: active participant]] `validator_participant` is not found, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-1-2-3] Start Participant VP fee checks
+###### [MOD-PP-MSG-1-2-3] Start Participant OP fee checks
 
 - Load `Participant` entry `validator_participant` from `validator_participant_id`.
 - Load `CredentialSchema` entry `cs` from `validator_participant.schema_id`.
@@ -2933,7 +2933,7 @@ else if `(cs.pricing_asset_type, cs.pricing_asset)` is set to an arbitrary coin 
 Trust deposit MUST always be paid in [[ref: native denom]]
 :::
 
-###### [MOD-PP-MSG-1-2-4] Start Participant VP overlap checks
+###### [MOD-PP-MSG-1-2-4] Start Participant OP overlap checks
 
 We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different VP with differents validators for the same `schema_id`, `type`.
 
@@ -2943,7 +2943,7 @@ if size of `participants[]` > 0, it means there is already an existing onboardin
 
 > note: this check was not present in v3.
 
-##### [MOD-PP-MSG-1-3] Start Participant VP execution
+##### [MOD-PP-MSG-1-3] Start Participant OP execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -2991,7 +2991,7 @@ If `vs_operator_authz_msg_types` is provided, create the [ParticipantAuthorizati
   - `record.expiration`: `now`
   - `record.period`: `vs_operator_authz_period`
 
-> Note: the record is created with `expiration = now` so authorization is **not yet active**. [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) will reject any attempt to use it until [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-vp-to-validated) updates `expiration` to `applicant_participant.effective_until`. No on-chain `FeeGrant` object is created at this stage even if `with_feegrant` is true (the recompute subroutine in [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) requires `expiration > now`).
+> Note: the record is created with `expiration = now` so authorization is **not yet active**. [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) will reject any attempt to use it until [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-op-to-validated) updates `expiration` to `applicant_participant.effective_until`. No on-chain `FeeGrant` object is created at this stage even if `with_feegrant` is true (the recompute subroutine in [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) requires `expiration > now`).
 
 #### Connecting to the VS of the Validator
 
@@ -3018,7 +3018,7 @@ The [[ref: validator]] may compile a summary file of the onboarding process, doc
 
 For audit or governance purposes, the [[ref: validator]] should register a digest (e.g., hash or SRI) of this summary in `applicant_participant.vp_summary_digest`.
 
-#### [MOD-PP-MSG-2] Renew Participant VP
+#### [MOD-PP-MSG-2] Renew Participant OP
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
@@ -3030,17 +3030,17 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 - Renewal does not allow changing the `participant.validation_fees`, `participant.issuance_fees`, `participant.verification_fees`. To change these values, applicant MUST start a new onboarding process.
 - if permission is revoked, slashed, or repaid, method MUST fail.
 
-##### [MOD-PP-MSG-2-1] Renew Participant VP parameters
+##### [MOD-PP-MSG-2-1] Renew Participant OP parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission for which applicant would like to renew the onboarding process;
 
-##### [MOD-PP-MSG-2-2] Renew Participant VP precondition checks
+##### [MOD-PP-MSG-2-2] Renew Participant OP precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-2-2-1] Renew Participant VP basic checks
+###### [MOD-PP-MSG-2-2-1] Renew Participant OP basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3049,12 +3049,12 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64 and a permission entry with the same id MUST exist.
 
-###### [MOD-PP-MSG-2-2-2] Renew Participant VP permission checks
+###### [MOD-PP-MSG-2-2-2] Renew Participant OP permission checks
 
 - Load `Participant` entry `applicant_participant`. `corporation` running the operation MUST be `applicant_participant.corporation`, else MUST abort. `applicant_participant` MUST be a [[ref: active participant]].
 - Load `Participant` entry `validator_participant` from `applicant_participant.validator_participant_id`. It MUST exist, and be a [[ref: active participant]], else MUST abort.
 
-###### [MOD-PP-MSG-2-2-3] Renew Participant VP fee checks
+###### [MOD-PP-MSG-2-2-3] Renew Participant OP fee checks
 
 - Load `Participant` entry `validator_participant` from `applicant_participant.validator_participant_id`.
 - Load `CredentialSchema` entry `cs` from `validator_participant.schema_id`.
@@ -3093,7 +3093,7 @@ else if `(cs.pricing_asset_type, cs.pricing_asset)` is set to an arbitrary coin 
 Trust deposit MUST always be paid in [[ref: native denom]]
 :::
 
-###### [MOD-PP-MSG-2-3] Renew Participant VP execution
+###### [MOD-PP-MSG-2-3] Renew Participant OP execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -3117,11 +3117,11 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - `applicant_participant.vp_current_deposit` (number): `validation_trust_deposit_in_native_denom`.
   - `applicant_participant.modified`: `now`
 
-#### [MOD-PP-MSG-3] Set Participant VP to Validated
+#### [MOD-PP-MSG-3] Set Participant OP to Validated
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-PP-MSG-3-1] Set Participant VP to Validated parameters
+##### [MOD-PP-MSG-3-1] Set Participant OP to Validated parameters
 
 An [[ref: account]] that would like to set a validation entry to VALIDATED MUST execute this method by specifying:
 
@@ -3136,11 +3136,11 @@ An [[ref: account]] that would like to set a validation entry to VALIDATED MUST 
 - `issuance_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_ONBOARDING_PROCESS mode) or an ISSUER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 - `verification_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_ONBOARDING_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 
-##### [MOD-PP-MSG-3-2] Set Participant VP to Validated precondition checks
+##### [MOD-PP-MSG-3-2] Set Participant OP to Validated precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-3-2-1] Set Participant VP to Validated basic checks
+###### [MOD-PP-MSG-3-2-1] Set Participant OP to Validated basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3200,19 +3200,19 @@ Now, let's verify `effective_until`:
 - else if `applicant_participant.effective_until` is NULL, `effective_until` MUST be greater than current current timestamp AND, if `vp_exp` is not null, lower or equal to `vp_exp`.
 - else `effective_until` MUST be greater than `applicant_participant.effective_until` AND, if `vp_exp` is not null, lower or equal to `vp_exp`.
 
-###### [MOD-PP-MSG-3-2-2] Set Participant VP to Validated validator perms
+###### [MOD-PP-MSG-3-2-2] Set Participant OP to Validated validator perms
 
 - load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active participant]].
 - `corporation` running the method MUST be `validator_participant.corporation`.
 
 If `validator_participant` is not a [[ref: active participant]] (expired, revoked, slashed...) then applicant MUST start a new onboarding process.
 
-###### [MOD-PP-MSG-3-2-3] Set Participant VP to Validated fee checks
+###### [MOD-PP-MSG-3-2-3] Set Participant OP to Validated fee checks
 
 - Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 - if `applicant_participant.vp_current_fees` is not in [[ref: native denom]], `corporation` account MUST have `applicant_participant.vp_current_deposit` available in [[ref: native denom]] on its account for paying the trust deposit.
 
-###### [MOD-PP-MSG-3-2-4] Set Participant VP to Validated overlap checks
+###### [MOD-PP-MSG-3-2-4] Set Participant OP to Validated overlap checks
 
 We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. That should not occur in this method, but better do the check anyway.
 
@@ -3226,7 +3226,7 @@ for each `Participant` entry `p` from `participants[]`:
 
 > note: this check was not present in v3.
 
-##### [MOD-PP-MSG-3-3] Set Participant VP to Validated execution
+##### [MOD-PP-MSG-3-3] Set Participant OP to Validated execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -3288,29 +3288,29 @@ Activate VS Operator Authorization, if any. Call [[MOD-DE-MSG-9]](#mod-de-msg-9-
 - `participant_id`: `applicant_participant.id`
 - `new_expiration`: `applicant_participant.effective_until`
 
-This call is a no-op if no record was created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp) (i.e., the applicant did not declare `vs_operator_authz_msg_types`). If a record exists, its `expiration` is updated from `now` (disabled) to `applicant_participant.effective_until`, and the on-chain `FeeGrant` for the containing VSOA is granted for the first time (or refreshed) via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance).
+This call is a no-op if no record was created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op) (i.e., the applicant did not declare `vs_operator_authz_msg_types`). If a record exists, its `expiration` is updated from `now` (disabled) to `applicant_participant.effective_until`, and the on-chain `FeeGrant` for the containing VSOA is granted for the first time (or refreshed) via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance).
 
 #### [MOD-PP-MSG-4] Void
 
 #### [MOD-PP-MSG-5] Void
 
-#### [MOD-PP-MSG-6] Cancel Participant VP Last Request
+#### [MOD-PP-MSG-6] Cancel Participant OP Last Request
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 At any time, [[ref: applicant]] of a permission onboarding process may request cancellation of the process, provided state is PENDING. Upon method execution, the pending validation is cancelled and escrewed [[ref: trust fees]] are refunded. If `vp_exp` is not null, `vp_state` is set back to VALIDATED, else `vp_state` is set to TERMINATED.
 
-##### [MOD-PP-MSG-6-1] Cancel Participant VP Last Request parameters
+##### [MOD-PP-MSG-6-1] Cancel Participant OP Last Request parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the `Participant` entry;
 
-##### [MOD-PP-MSG-6-2] Cancel Participant VP Last Request precondition checks
+##### [MOD-PP-MSG-6-2] Cancel Participant OP Last Request precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-6-2-1] Cancel Participant VP Last Request basic checks
+###### [MOD-PP-MSG-6-2-1] Cancel Participant OP Last Request basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3323,11 +3323,11 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `applicant_participant.vp_state` MUST be PENDING.
 - if `applicant_participant.deposit` has been slashed and not repaid, MUST abort
 
-###### [MOD-PP-MSG-6-2-2] Cancel Participant VP Last Request fee checks
+###### [MOD-PP-MSG-6-2-2] Cancel Participant OP Last Request fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 
-##### [MOD-PP-MSG-6-3] Cancel Participant VP Last Request execution
+##### [MOD-PP-MSG-6-3] Cancel Participant OP Last Request execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -3347,7 +3347,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - call [MOD-TD-MSG-1] to reduce trust deposit of `applicant_participant.corporation` by `applicant_participant.vp_current_deposit`
   - set `applicant_participant.vp_current_deposit` to 0.
 
-If `applicant_participant.vp_state` was set to TERMINATED (i.e. `applicant_participant.vp_exp` was null so validation never completed), call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any disabled authorization record created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp). The call is a no-op if no record exists. If `applicant_participant.vp_state` was set back to VALIDATED, no VSOA changes are needed (the existing record's `expiration` remains at the value set by the previous successful validation).
+If `applicant_participant.vp_state` was set to TERMINATED (i.e. `applicant_participant.vp_exp` was null so validation never completed), call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any disabled authorization record created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op). The call is a no-op if no record exists. If `applicant_participant.vp_state` was set back to VALIDATED, no VSOA changes are needed (the existing record's `expiration` remains at the value set by the previous successful validation).
 
 #### [MOD-PP-MSG-7] Create Root Participant
 
@@ -3561,7 +3561,7 @@ Synchronise VS Operator Authorization expiration, if any. Call [[MOD-DE-MSG-9]](
 - `participant_id`: `applicant_participant.id`
 - `new_expiration`: `applicant_participant.effective_until`
 
-This call is a no-op if no record exists for `applicant_participant.id`. If a record exists, its `expiration` is updated and the on-chain `FeeGrant` for the containing VSOA is refreshed via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance). Adjust Participant does **not** accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant)). Adjust also cannot create a record that does not already exist.
+This call is a no-op if no record exists for `applicant_participant.id`. If a record exists, its `expiration` is updated and the on-chain `FeeGrant` for the containing VSOA is refreshed via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance). Adjust Participant does **not** accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant)). Adjust also cannot create a record that does not already exist.
 
 #### [MOD-PP-MSG-9] Revoke Participant
 
@@ -4415,7 +4415,7 @@ If `vs_operator_authz_msg_types` is provided, create the [ParticipantAuthorizati
   - `record.expiration`: `participant.effective_until`
   - `record.period`: `vs_operator_authz_period`
 
-> Note: unlike [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp), the record is created with `expiration = participant.effective_until` and is therefore immediately active. If `with_feegrant` is true and `participant.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
+> Note: unlike [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op), the record is created with `expiration = participant.effective_until` and is therefore immediately active. If `with_feegrant` is true and `participant.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
 
 #### [MOD-PP-MSG-15] Trigger Resolver
 
@@ -4757,7 +4757,7 @@ actor "Validator\n(issuer grantor)\nAccount" as ValidatorAccount
 
 participant "Verifiable Public Registry" as VPR #3fbdb6
 
-ApplicantAccount --> VPR: Start Participant VP
+ApplicantAccount --> VPR: Start Participant OP
 VPR <-- VPR: create permission entry.
 ApplicantAccount <-- VPR: permission entry created,\nassigned participant.validator_participant_id from ISSUER_GRANTOR permissions.
 ApplicantBrowser --> ValidatorVS: connect to validator VS DID found in validator_participant.did\nby creating a DIDComm connection
@@ -4778,7 +4778,7 @@ ApplicantBrowser <-- ValidatorVS: Are you a legitimate issuer?\nProve it, by fil
 ApplicantBrowser --> ValidatorVS: perform requested tasks...
 note over ApplicantBrowser, ValidatorVS #EEEEEE: tasks completed
 ApplicantBrowser <-- ValidatorVS: Your are a legitimate issuer. I'll now create an ISSUER permission for your account and DID.
-ValidatorAccount --> VPR #3fbdb6: Set Participant VP to Validated\nset validation.state to VALIDATED\n.
+ValidatorAccount --> VPR #3fbdb6: Set Participant OP to Validated\nset validation.state to VALIDATED\n.
 VPR --> ValidatorAccount: Receive trust fees.
 ApplicantBrowser <-- ValidatorVS: notify permission added for your DID.\nDID can now issue credentials of this schema.
 ```
@@ -5375,7 +5375,7 @@ MUST abort if one of these conditions fails:
 
 This method can only be called directly by the following Participant module methods, with no signer check:
 
-- [Start Participant VP](#mod-pp-msg-1-start-participant-vp)
+- [Start Participant OP](#mod-pp-msg-1-start-participant-op)
 - [Self Create Participant](#mod-pp-msg-14-self-create-participant)
 
 It creates a new [ParticipantAuthorizationRecord](#participantauthorizationrecord) inside `VSOperatorAuthorization[corporation, vs_operator]` and, if the record enables a fee grant and its `expiration` is in the future, synchronises the on-chain `FeeGrant` for the containing VSOA.
@@ -5436,7 +5436,7 @@ This is a shared subroutine invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-o
 
 This method can only be called directly by the following Participant module methods, with no signer check:
 
-- [Cancel Participant VP Last Request](#mod-pp-msg-6-cancel-participant-vp-last-request) (only when the cancellation terminates the permission)
+- [Cancel Participant OP Last Request](#mod-pp-msg-6-cancel-participant-op-last-request) (only when the cancellation terminates the permission)
 - [Revoke Participant](#mod-pp-msg-9-revoke-participant)
 - [Slash Participant Trust Deposit](#mod-pp-msg-12-slash-participant-trust-deposit)
 
@@ -5470,7 +5470,7 @@ This method does NOT read `Participant` state.
 
 This method can only be called directly by the following Participant module methods, with no signer check:
 
-- [Set Participant VP to Validated](#mod-pp-msg-3-set-participant-vp-to-validated)
+- [Set Participant OP to Validated](#mod-pp-msg-3-set-participant-op-to-validated)
 - [Adjust Participant](#mod-pp-msg-8-adjust-participant)
 
 It updates the `expiration` of the unique record identified by `participant_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no record exists for `participant_id`.

--- a/spec.md
+++ b/spec.md
@@ -1183,7 +1183,7 @@ entity "TrustDeposit" as td {
   slash_count: number
 }
 
-group --o fg: grantor
+corp --o fg: grantor
 account --o fg: grantee
 fg "1" --- "0..n" da: spend_limit
 fg "1" --- "0..n" da: remaining_spend
@@ -1198,10 +1198,10 @@ xr --- "1..n" account: update_whitelist
 
 cs o-- pricingassettype: pricing_asset_type 
 
-group --o oauthz: corporation
+corp --o oauthz: corporation
 account --o oauthz: operator
 
-group --o vsoauthz: corporation
+corp --o vsoauthz: corporation
 account --o vsoauthz: vs_operator
 vsoauthz "1" --- "1..n" par: records
 par o-- csp: participant_id
@@ -1240,16 +1240,16 @@ gfv "1" --- "1..n" gfd: documents
 
 group "1" --- "1" corp
 
-group --o tr: corporation
-group --o csp: corporation
-group --o csps: corporation
+corp --o tr: corporation
+corp --o csp: corporation
+corp --o csps: corporation
 
 account --o csp: vs_operator
 
 csps o-- account: vs_operator
 
 valstate --o csp: op_state
-group  --o td: corporation
+corp --o td: corporation
 
 @enduml
 

--- a/spec.md
+++ b/spec.md
@@ -50,12 +50,12 @@ Before exploring this spec, it is highly recommended to **first read** the [Veri
 
 *This section is non-normative.*
 
-An ecosystem is an approved list of recognized ecosystem participants, such as ecosystem operators, credential [[ref: issuers]] and [[ref: verifiers]] that are authorized to onboard ecosystem participants, and or issue/verify certain credentials in an ecosystem.
+An ecosystem is an approved list of recognized participants, such as ecosystem operators, credential [[ref: issuers]] and [[ref: verifiers]], that are authorized to onboard ecosystem participants, and or issue/verify certain credentials in an ecosystem.
 
 An ecosystem typically expose APIs that are consumed by services that would like to [[ref: query]] its database, and take decisions based on the returned result:
 
 - can [[ref: participant]] #1 issue credential for `schema` ABC of `ecosystem` E1?
-- can [[ref: participant]] #2 request credential presentation of credential issued by `issuer` DEF from `schema` GHI of `ecosystem` E2, for `jurisdiction` France in `context` CONTEXT?
+- can [[ref: participant]] #2 request credential presentation of credential issued by `issuer` DEF from `schema` GHI of `ecosystem` E2 in `context` CONTEXT?
 
 ### What is a Verifiable Public Registry?
 
@@ -64,10 +64,11 @@ An ecosystem typically expose APIs that are consumed by services that would like
 A Verifiable Public Registry (VPR) is a “registry of registries”, a public service that provides foundational infrastructure for decentralized trust ecosystems. It offers:
 
 - ecosystem management:  
-  ecosystems can create and manage their own ecosystems, each with:
-  - defined [[ref: credential schemas]]
-  - assigned roles for [[ref: issuers]], [[ref: verifiers]], and [[ref: grantors]] (ecosystem operators)
+  - governance framework publication and versionning
+  - [[ref: credential schemas]] publication
+  - participant onboarding
   - custom business models and permission policies
+  - and more.
 
 - query API for trust resolution:  
   A standardized API used by [[ref: verifiable services]] (VSs) and [[ref: verifiable user agents]] (VUAs) to perform trust resolution, enabling them to query registry data and validate roles and permissions in real time.
@@ -215,16 +216,16 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 ~ A fake denom that is not usable as a token (cannot be transferred, or used for paying in transactions). Trust unit is used to define fees in Permissions. Fees defined in trust units are automatically converted to [[ref: native denom]] when a transaction is executed, using an exchange rate `TU/[[ref: native denom]]`. Trust unit is used to compensate [[ref: native denom]] fluctuation.
 
 [[def:ecosystem, ecosystems]]
-~ An approved list of [[ref: issuers]] and [[ref: verifiers]] that are authorized to issue/verify certain credentials in an ecosystem.
+~ An approved list of [[ref: participants]] that are authorized to issue/verify certain credentials in an ecosystem.
 
 [[def: URI, URIs]]
 ~ An Universal Resource Identifier, as specified in [rfc3986](https://datatracker.ietf.org/doc/html/rfc3986).
 
-[[def: active permission, active permissions]]:
-~ A credential schema permission of a given type, which effective_from timestamp is lower than current timestamp, and (effective_until timestamp is null or greater than current timestamp), and revoked is null and slashed is null.
+[[def: active participant, active participants]]:
+~ A participant of a given role, which effective_from timestamp is lower than current timestamp, and (effective_until timestamp is null or greater than current timestamp), and revoked is null and slashed is null.
 
-[[def: future permission, future permissions]]:
-~ A credential schema permission of a given type, which effective_from timestamp is higher than current timestamp, and (effective_until timestamp is null or greater than effective_from timestamp), and revoked is null and slashed is null.
+[[def: future participant, future participants]]:
+~ A participant of a given role, which effective_from timestamp is higher than current timestamp, and (effective_until timestamp is null or greater than effective_from timestamp), and revoked is null and slashed is null.
 
 [[def: validation process]]:
 ~ A process run by [[ref: applicants]] that want to, for a specific [[ref: credential schema]], be a [[ref: issuer]], be a [[ref: verifier]], or simply hold a verifiable credential linked to the [[ref: credential schema]].
@@ -2854,7 +2855,7 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 
 ###### [MOD-PP-MSG-1-2-2] Start Participant VP permission checks
 
-- Load `Participant` entry `validator_participant` from `validator_participant_id`. It MUST be a [[ref: active permission]] else transaction MUST abort.
+- Load `Participant` entry `validator_participant` from `validator_participant_id`. It MUST be a [[ref: active participant]] else transaction MUST abort.
 - Load `CredentialSchema` entry `cs` from `validator_participant.schema_id`. It MUST exist.
 
 - if `type` (ParticipantRole) is equal to ISSUER:
@@ -2891,7 +2892,7 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
   
   - else abort.
 
-At the end, if a [[ ref: active permission]] `validator_participant` is not found, [[ref: transaction]] MUST abort.
+At the end, if a [[ref: active participant]] `validator_participant` is not found, [[ref: transaction]] MUST abort.
 
 ###### [MOD-PP-MSG-1-2-3] Start Participant VP fee checks
 
@@ -3050,8 +3051,8 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 ###### [MOD-PP-MSG-2-2-2] Renew Participant VP permission checks
 
-- Load `Participant` entry `applicant_participant`. `corporation` running the operation MUST be `applicant_participant.corporation`, else MUST abort. `applicant_participant` MUST be a [[ref: active permission]].
-- Load `Participant` entry `validator_participant` from `applicant_participant.validator_participant_id`. It MUST exist, and be a [[ref: active permission]], else MUST abort.
+- Load `Participant` entry `applicant_participant`. `corporation` running the operation MUST be `applicant_participant.corporation`, else MUST abort. `applicant_participant` MUST be a [[ref: active participant]].
+- Load `Participant` entry `validator_participant` from `applicant_participant.validator_participant_id`. It MUST exist, and be a [[ref: active participant]], else MUST abort.
 
 ###### [MOD-PP-MSG-2-2-3] Renew Participant VP fee checks
 
@@ -3201,10 +3202,10 @@ Now, let's verify `effective_until`:
 
 ###### [MOD-PP-MSG-3-2-2] Set Participant VP to Validated validator perms
 
-- load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active permission]].
+- load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active participant]].
 - `corporation` running the method MUST be `validator_participant.corporation`.
 
-If `validator_participant` is not a [[ ref: active permission]] (expired, revoked, slashed...) then applicant MUST start a new validation process.
+If `validator_participant` is not a [[ref: active participant]] (expired, revoked, slashed...) then applicant MUST start a new validation process.
 
 ###### [MOD-PP-MSG-3-2-3] Set Participant VP to Validated fee checks
 
@@ -3215,7 +3216,7 @@ If `validator_participant` is not a [[ ref: active permission]] (expired, revoke
 
 We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. That should not occur in this method, but better do the check anyway.
 
-Find all [[ref: active permissions]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_participant_id`, `corporation`.
+Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_participant_id`, `corporation`.
 
 for each `Participant` entry `p` from `participants[]`:
 
@@ -3420,7 +3421,7 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
 We want to make sure that 2 permissions cannot be active at the same time. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-participant) to set or adjust the `effective_until` value.
 
-Find all [[ref: active permissions]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, ECOSYSTEM,  `corporation`.
+Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, ECOSYSTEM,  `corporation`.
 
 > Note: unlike overlap checks from other methods, here we do not need to check for `validator_participant_id`, as for ECOSYSTEM type permissions it is NULL.
 
@@ -3502,7 +3503,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
 - Load `Participant` entry `applicant_participant` from `id`. If no entry found, abort.
-- `applicant_participant` MUST be a [[ref: active permission]]
+- `applicant_participant` MUST be a [[ref: active participant]]
 - `applicant_participant.effective_until` MUST be greater than now().
 - else MUST abort.
 
@@ -3516,12 +3517,12 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 2. Self-created permissions
 
-- load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active permission]] of type ECOSYSTEM. `corporation` running the method MUST be `applicant_participant.corporation`.
+- load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active participant]] of type ECOSYSTEM. `corporation` running the method MUST be `applicant_participant.corporation`.
 
 3. VP managed permissions
 
 - `effective_until` MUST be lower or equal to `applicant_participant.vp_exp` else MUST abort.
-- load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active permission]]. `corporation` running the method MUST be `validator_participant.corporation`.
+- load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active participant]]. `corporation` running the method MUST be `validator_participant.corporation`.
 
 ###### [MOD-PP-MSG-8-2-3] Adjust Participant fee checks
 
@@ -3531,7 +3532,7 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[re
 
 We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-participant) to set or adjust the `effective_until` value.
 
-Find all [[ref: active permissions]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_participant_id`, `corporation`.
+Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_participant_id`, `corporation`.
 
 for each `Participant` entry `p` from `participants[]`:
 
@@ -3591,7 +3592,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
 - Load `Participant` entry `applicant_participant` from `id`. If no entry found, abort.
-- `applicant_participant` MUST be a [[ref: active permission]]
+- `applicant_participant` MUST be a [[ref: active participant]]
 
 ###### [MOD-PP-MSG-9-2-2] Revoke Participant advanced checks
 
@@ -3604,7 +3605,7 @@ if `applicant_participant.validator_participant_id` is defined:
 - set `validator_participant` = `applicant_participant`
 - while `validator_participant.validator_participant_id` is defined, 
   - load `validator_participant` from `validator_participant.validator_participant_id`.
-  - if `validator_participant` is a [[ref: active permission]] and `validator_participant.corporation` is who is running the method, => return true.
+  - if `validator_participant` is a [[ref: active participant]] and `validator_participant.corporation` is who is running the method, => return true.
 - end
 - return false.
 
@@ -3621,9 +3622,9 @@ Example:
 
 In the following permission tree, "Verifier E" permission can be revoked:
 
-- by "Verifier E", if the corresponding permission is a [[ref: active permission]];
-- by "Verifier Grantor D", if the corresponding permission is a [[ref: active permission]];
-- by "Ecosystem A", if the corresponding root permission is a [[ref: active permission]];
+- by "Verifier E", if the corresponding permission is a [[ref: active participant]];
+- by "Verifier Grantor D", if the corresponding permission is a [[ref: active participant]];
+- by "Ecosystem A", if the corresponding root permission is a [[ref: active participant]];
 - by the `Ecosystem` object controller, obtained by resolving perm => credential schema => ecosystem.
 
 ```plantuml
@@ -3764,7 +3765,7 @@ if `issuer_participant_id` is not null:
 
 - Load `issuer_participant` from `issuer_participant_id`.
 - if `issuer_participant.role` is not ISSUER, abort.
-- if `issuer_participant` is not a [[ref: active permission]], abort.
+- if `issuer_participant` is not a [[ref: active participant]], abort.
 - if `issuer_participant.vs_operator` is not equal to `operator`, abort.
 - if `issuer_participant.corporation` is not equal to `corporation`, abort.
 - if `digest_sri` is present but not a valid digest SRI, abort.
@@ -3773,7 +3774,7 @@ if `verifier_participant_id` is not null:
 
 - Load `verifier_participant` from `verifier_participant_id`.
 - if `verifier_participant.role` is not VERIFIER, abort.
-- if `verifier_participant` is not a [[ref: active permission]], abort.
+- if `verifier_participant` is not a [[ref: active participant]], abort.
 - if `verifier_participant.vs_operator` is not equal to `operator`, abort.
 - if `verifier_participant.corporation` is not equal to `corporation`, abort.
 - if `digest_sri` is present but not a valid digest SRI, abort.
@@ -3787,13 +3788,13 @@ agent:
 
 - Load `agent_participant` from `agent_participant_id`.
 - if `agent_participant.role` is not ISSUER, abort.
-- if `agent_participant` is not a [[ref: active permission]], abort.
+- if `agent_participant` is not a [[ref: active participant]], abort.
 
 wallet_agent:
 
 - Load `wallet_agent_participant` from `wallet_agent_participant_id`.
 - if `wallet_agent_participant.role` is not ISSUER, abort.
-- if `wallet_agent_participant` is not a [[ref: active permission]], abort.
+- if `wallet_agent_participant` is not a [[ref: active participant]], abort.
 
 :::warning
 we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a permission that is not controlled by its owner.
@@ -4200,7 +4201,7 @@ if `applicant_participant.validator_participant_id` is defined:
 - set `validator_participant` = `applicant_participant`
 - while `validator_participant.validator_participant_id` is defined, 
   - load `validator_participant` from `validator_participant.validator_participant_id`.
-  - if `validator_participant` is a [[ref: active permission]] and `validator_participant.corporation` is who is running the method, => return true.
+  - if `validator_participant` is a [[ref: active participant]] and `validator_participant.corporation` is who is running the method, => return true.
 - end
 - return false.
 
@@ -4295,7 +4296,7 @@ Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `type` (ParticipantRole) (*mandatory*): ISSUER or VERIFIER.
-- `validator_participant_id` (uint64) (*mandatory*): MUST be an ECOSYSTEM [[ref: active permission]] or [[ref: future permission]].
+- `validator_participant_id` (uint64) (*mandatory*): MUST be an ECOSYSTEM [[ref: active participant]] or [[ref: future participant]].
 - `vs_operator` (account) (*optional*): the account we want to authorize to create permission sessions linked to this permission. **Required** for payment delegation.
 - `did` (string) (*mandatory*): [[ref: DID]] of the VS grantee service.
 - `effective_from` (timestamp) (*optional*): timestamp from when (exclusive) this Perm is effective. MUST be in the future.
@@ -4333,7 +4334,7 @@ Load `Participant` `validator_participant` from `validator_participant_id`.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `type` (ParticipantRole) (*mandatory*): MUST be ISSUER or VERIFIER, else abort.
-- `validator_participant_id` (uint64) (*mandatory*): `validator_participant` MUST be an ECOSYSTEM [[ref: active permission]] or [[ref: future permission]].
+- `validator_participant_id` (uint64) (*mandatory*): `validator_participant` MUST be an ECOSYSTEM [[ref: active participant]] or [[ref: future participant]].
 - `vs_operator` (account) (*optional*): no check required.
 - `did`, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
 - `effective_from` MUST be in the future AND
@@ -4364,7 +4365,7 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
 We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-participant) to set or adjust the `effective_until` value.
 
-Find all [[ref: active permissions]] `participants[]` (not revoked, not slashed, not repaid) for `cs.id`, `type`, `validator_participant_id`, `corporation`.
+Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `cs.id`, `type`, `validator_participant_id`, `corporation`.
 
 for each `Participant` entry `p` from `participants[]`:
 
@@ -4449,7 +4450,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - `id` MUST be a valid uint64.
 - Load `Participant` entry `perm` from `id`. If no entry found, abort.
-- `perm` MUST be an [[ref: active permission]], else abort.
+- `perm` MUST be an [[ref: active participant]], else abort.
 - `participant.did` MUST NOT be null, else abort.
 
 ###### [MOD-PP-MSG-15-2-2] Trigger Resolver authorization checks
@@ -4470,7 +4471,7 @@ The target `perm` itself is excluded from this walk; only its ancestors (from th
 - set `v` = `perm`.
 - while `v.validator_participant_id` is defined and != `participant.id` :
   - load `v` from `v.validator_participant_id`.
-  - if `v` is not an [[ref: active permission]], continue with the next iteration.
+  - if `v` is not an [[ref: active participant]], continue with the next iteration.
   - if corporation != v.corporation, continue with the next iteration.
   - if [AUTHZ-CHECK-1](#authz-check-1-operator-authorization-checks) pass for this (`corporation`, `operator`) tuple and message `TriggerResolver` AND [AUTHZ-CHECK-2](#authz-check-2-fee-grant-checks) pass for this (`corporation`, `operator`) tuple and message `TriggerResolver`, then authorization is granted => match.
 
@@ -4500,7 +4501,7 @@ Generic query used for (at least):
 - for a given validator, get PENDING validation processes;
 - find all permissions of a given grantee;
 - find all permissions of a given did;
-- find all ISSUER_GRANTOR active permission, so that I can apply to an ISSUER permission;
+- find all ISSUER_GRANTOR active participants, so that I can apply to an ISSUER permission;
 ...
 
 ##### [MOD-PP-QRY-1-1] List Participants parameters
@@ -4510,7 +4511,7 @@ Generic query used for (at least):
 - `did` (string) (*optional*): the did the permission refers to.
 - `participant_id` (number) (*optional*): limit to permissions where the `validator_participant_id` is `participant_id`.
 - `type` (ParticipantRole) (*optional*): if we want to limit to a specific permission type.
-- `only_valid` (boolean) (*optional*): if set to true, only return active permissions.
+- `only_valid` (boolean) (*optional*): if set to true, only return active participants.
 - `only_slashed` (boolean) (*optional*): if set to true, only return slashed permissions.
 - `only_repaid` (boolean) (*optional*): if set to true, only return repaid slashed permissions.
 - `modified_after` (timestamp) (*optional*): limit to permissions modified after (or equal to) `modified_after`.
@@ -4637,8 +4638,8 @@ v --> vg
 ##### [MOD-PP-QRY-4-2] Find Beneficiaries checks
 
 - if `issuer_participant_id` and `verifier_participant_id` are unset then MUST abort.
-- if `issuer_participant_id` is specified, load `issuer_participant` from `issuer_participant_id`, Participant MUST exist and MUST be a [[ref: active permission]].
-- if `verifier_participant_id` is specified, load `verifier_participant` from `verifier_participant_id`, Participant MUST exist and MUST be a [[ref: active permission]].
+- if `issuer_participant_id` is specified, load `issuer_participant` from `issuer_participant_id`, Participant MUST exist and MUST be a [[ref: active participant]].
+- if `verifier_participant_id` is specified, load `verifier_participant` from `verifier_participant_id`, Participant MUST exist and MUST be a [[ref: active participant]].
 
 ##### [MOD-PP-QRY-4-3] Find Beneficiaries execution
 

--- a/spec.md
+++ b/spec.md
@@ -28,7 +28,7 @@
 
 Decentralized trust ecosystems need shared infrastructure to answer a fundamental question: who is authorized to issue, verify, or govern credentials in a given context? Without a common registry layer, each ecosystem operates in isolation, trust decisions depend on ad hoc configurations, and there is no interoperable way for Verifiable Services and Verifiable User Agents to resolve the legitimacy of a credential or its issuer.
 
-The **Verifiable Public Registry (VPR)** is a decentralized "registry of registries" that provides this foundational infrastructure. It allows ecosystems to create and manage their own trust registries, define credential schemas with fine-grained permission policies, and assign roles — issuers, verifiers, grantors — through a transparent, on-chain governance model.
+The **Verifiable Public Registry (VPR)** is a decentralized "registry of registries" that provides this foundational infrastructure. It allows ecosystems to create and manage their own ecosystems, define credential schemas with fine-grained permission policies, and assign roles — issuers, verifiers, grantors — through a transparent, on-chain governance model.
 
 The VPR exposes a standardized query API that Verifiable Services and Verifiable User Agents use during trust resolution to confirm, in real time, whether a given participant is authorized to perform a specific action under a specific credential schema. This is what makes the trust in [Verifiable Trust](https://verana-labs.github.io/verifiable-trust-spec/) actually verifiable.
 
@@ -38,7 +38,7 @@ This specification defines the data model, API, and normative requirements for i
 
 ## About this Document
 
-In order to fully understand the concepts developed in this document, you should have some basic knowledge of [[ref:DID]], [[ref:DIDComm]], [[ref:VS]], [[ref:trust registry]], ledger-based applications, and more generally, all terms present in the [Terminology](#terminology) section.
+In order to fully understand the concepts developed in this document, you should have some basic knowledge of [[ref:DID]], [[ref:DIDComm]], [[ref:VS]], [[ref:ecosystem]], ledger-based applications, and more generally, all terms present in the [Terminology](#terminology) section.
 
 :::note
 Before exploring this spec, it is highly recommended to **first read** the [Verifiable Trust Spec](https://verana-labs.github.io/verifiable-trust-spec/).
@@ -46,13 +46,13 @@ Before exploring this spec, it is highly recommended to **first read** the [Veri
 
 ## Introduction
 
-### What is a Trust Registry?
+### What is an Ecosystem?
 
 *This section is non-normative.*
 
-A trust registry is an approved list of recognized ecosystem participants, such as trust registry operators, credential [[ref: issuers]] and [[ref: verifiers]] that are authorized to onboard ecosystem participants, and or issue/verify certain credentials in an ecosystem.
+An ecosystem is an approved list of recognized ecosystem participants, such as ecosystem operators, credential [[ref: issuers]] and [[ref: verifiers]] that are authorized to onboard ecosystem participants, and or issue/verify certain credentials in an ecosystem.
 
-A trust registry typically expose APIs that are consumed by services that would like to [[ref: query]] its database, and take decisions based on the returned result:
+An ecosystem typically expose APIs that are consumed by services that would like to [[ref: query]] its database, and take decisions based on the returned result:
 
 - can [[ref: participant]] #1 issue credential for `schema` ABC of `ecosystem` E1?
 - can [[ref: participant]] #2 request credential presentation of credential issued by `issuer` DEF from `schema` GHI of `ecosystem` E2, for `jurisdiction` France in `context` CONTEXT?
@@ -63,10 +63,10 @@ A trust registry typically expose APIs that are consumed by services that would 
 
 A Verifiable Public Registry (VPR) is a “registry of registries”, a public service that provides foundational infrastructure for decentralized trust ecosystems. It offers:
 
-- trust registry management:  
-  ecosystems can create and manage their own trust registries, each with:
+- ecosystem management:  
+  ecosystems can create and manage their own ecosystems, each with:
   - defined [[ref: credential schemas]]
-  - assigned roles for [[ref: issuers]], [[ref: verifiers]], and [[ref: grantors]] (trust registry operators)
+  - assigned roles for [[ref: issuers]], [[ref: verifiers]], and [[ref: grantors]] (ecosystem operators)
   - custom business models and permission policies
 
 - query API for trust resolution:  
@@ -79,21 +79,21 @@ scale max 800 width
  
 package "Verifiable Public Registry" as vpr {
 
-    object "Trust Registry of Ecosystem #A" as tra #3fbdb6 {
+    object "Ecosystem #A" as tra #3fbdb6 {
     }
 
-    object "Trust Registry of Ecosystem #B" as trb #3fbdb6 {
-
-    }
-
-    object "Trust Registry of Ecosystem #C" as trc #3fbdb6 {
+    object "Ecosystem #B" as trb #3fbdb6 {
 
     }
 
-    object "Trust Registry of Ecosystem #D" as trd #3fbdb6 {
+    object "Ecosystem #C" as trc #3fbdb6 {
 
     }
-    object "Trust Registry of Ecosystem #E" as tre #3fbdb6 {
+
+    object "Ecosystem #D" as trd #3fbdb6 {
+
+    }
+    object "Ecosystem #E" as tre #3fbdb6 {
 
     }
     
@@ -164,7 +164,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 ~ The governance authority (GA) of a [[ref: VPR]].
 
 [[def: grantor, grantors]]:
-~ A role an [[ref: entity]] is granted by an [[ref: ecosystem]] for operating its [[ref: trust registry]].
+~ A role an [[ref: entity]] is granted by an [[ref: ecosystem]] for operating its [[ref: ecosystem]].
 
 [[def: group, groups]]:
 ~ A [[ref: verifiable public registry]] group.
@@ -176,7 +176,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 ~ A role an [[ref: entity]] is granted by an [[ref: ecosystem]] or an [[ref: issuer grantor]] for issuing credentials of a given [[ref: credential schema]] to [[ref: holders]].
 
 [[def: issuer grantor, issuer grantors]]:
-~ A trust registry operator role an [[ref: entity]] is granted by an [[ref: ecosystem]] for a given [[ref: credential schema]] for adding or revoking issuers.
+~ An ecosystem operator role an [[ref: entity]] is granted by an [[ref: ecosystem]] for a given [[ref: credential schema]] for adding or revoking issuers.
 
 [[def: json schema, json schemas, Json Schema, Json Schemas]]
 ~ a Json Schema, as specified in [https://json-schema.org/specification](https://json-schema.org/specification).
@@ -214,7 +214,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 [[def: trust unit, trust units, TU, TUs]]:
 ~ A fake denom that is not usable as a token (cannot be transferred, or used for paying in transactions). Trust unit is used to define fees in Permissions. Fees defined in trust units are automatically converted to [[ref: native denom]] when a transaction is executed, using an exchange rate `TU/[[ref: native denom]]`. Trust unit is used to compensate [[ref: native denom]] fluctuation.
 
-[[def:trust registry, trust registries]]
+[[def:ecosystem, ecosystems]]
 ~ An approved list of [[ref: issuers]] and [[ref: verifiers]] that are authorized to issue/verify certain credentials in an ecosystem.
 
 [[def: URI, URIs]]
@@ -233,7 +233,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 ~ A role an [[ref: entity]] performs by participating in validation processes with [[ref: applicants]] in order to register them as [[ref: issuer]], or [[ref: verifier]] of a [[ref: credential schema]], or to deliver a verifiable credential to them.
 
 [[def: verifiable public registry, VPR, VPRs]]:
-~ a public, normally decentralized, ledger-based network, which provides: trust registry features, that can be used by all its [[ref: participants]]: create trust registries, for each trust registry, define its credential schemas, who can issue, verify credential of a specific credential schema,... and a tokenized business model for charging/rewarding [[ref: participants]].
+~ a public, normally decentralized, ledger-based network, which provides: ecosystem features, that can be used by all its [[ref: participants]]: create ecosystems, for each ecosystem, define its credential schemas, who can issue, verify credential of a specific credential schema,... and a tokenized business model for charging/rewarding [[ref: participants]].
 
 [[def: verifiable service, verifiable services, VS, VSs]]:
 ~ A service, identified by a resolvable [[ref: DID]] that can be deployed anywhere by its owner, and that is conforming to this spec and has a resolvable Proof-of-Trust. See [[ref: VT Spec]].
@@ -248,7 +248,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 ~ A role an [[ref: entity]] is granted by an [[ref: ecosystem]] or a [[ref: verifier grantor]] for verifying credentials of a given [[ref: credential schema]].
 
 [[def: verifier grantor, verifier grantors]]:
-~ A trust registry operator role an [[ref: entity]] is granted by an [[ref: ecosystem]] for a given [[ref: credential schema]] for adding or revoking verifiers.
+~ An ecosystem operator role an [[ref: entity]] is granted by an [[ref: ecosystem]] for a given [[ref: credential schema]] for adding or revoking verifiers.
 
 [[def: verifiable credential, verifiable credentials]]:
 ~ A verifiable credential as defined in [[spec-norm:VC-DATA-MODEL]].
@@ -267,11 +267,11 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 
 ## Features of a Verifiable Public Registry (VPR)
 
-### Trust Registry Management
+### Ecosystem Management
 
 *This section is non-normative.*
 
-In an [[ref: VPR]], any [[ref: corporation]] can create a `TrustRegistry` entry that represents a [[ref: trust registry]] of an ecosystem. Each `TrustRegistry` entry must provide, at a minimum:
+In an [[ref: VPR]], any [[ref: corporation]] can create a `Ecosystem` entry that represents a [[ref: ecosystem]] of an ecosystem. Each `Ecosystem` entry must provide, at a minimum:
 
 - an ecosystem controlled resolvable [[ref: DID]];
 - one or more [[ref: ecosystem governance framework]] document(s);
@@ -284,7 +284,7 @@ The Verifiable Public Registry (VPR) is agnostic to the specific DID methods use
 @startuml
 scale max 800 width
  
-object "Trust Registry" as tra #3fbdb6 {
+object "Ecosystem" as tra #3fbdb6 {
     ecosystem did
     ecosystem credential schemas
     ecosystem governance framework docs
@@ -298,17 +298,17 @@ object "Trust Registry" as tra #3fbdb6 {
 
 *This section is non-normative.*
 
-[[ref: Credential schemas]] are created and managed by trust registry corporation ([[ref: ecosystems]]). Each [[ref: Credential schema]] includes, at a minimum:
+[[ref: Credential schemas]] are created and managed by ecosystem corporation ([[ref: ecosystems]]). Each [[ref: Credential schema]] includes, at a minimum:
 
 - A **Json Schema** that defines the structure of the corresponding [[ref: verifiable credential]]
 - A **IssuerOnboardingMode** for **issuance policy**, which determines how `ISSUER` permissions are granted. Modes include:
   - `OPEN`: `ISSUER` permissions can be self-created by anyone.
-  - `ECOSYSTEM_VALIDATION_PROCESS`: `ISSUER` permissions are granted directly by the [[ref: ecosystem]], the trust registry corporation through the execution of a Validation Process.
-  - `GRANTOR_VALIDATION_PROCESS`: `ISSUER` permissions are granted by one or several [[ref: issuer grantor]](s) (trust registry operator(s) responsible for selecting issuers for the credential schema of this [[ref: ecosystem]]), selected by the [[ref: ecosystem]] through the execution of a Validation Process.
+  - `ECOSYSTEM_VALIDATION_PROCESS`: `ISSUER` permissions are granted directly by the [[ref: ecosystem]], the ecosystem corporation through the execution of a Validation Process.
+  - `GRANTOR_VALIDATION_PROCESS`: `ISSUER` permissions are granted by one or several [[ref: issuer grantor]](s) (ecosystem operator(s) responsible for selecting issuers for the credential schema of this [[ref: ecosystem]]), selected by the [[ref: ecosystem]] through the execution of a Validation Process.
 - A **VerifierOnboardingMode** for **verification policy**, which determines how `VERIFIER` permissions are granted. Modes include:
   - `OPEN`: `VERIFIER` permissions can be created by anyone.
-  - `ECOSYSTEM_VALIDATION_PROCESS`: `VERIFIER` permissions are granted directly by the [[ref: ecosystem]], the Trust Registry corporation through the execution of a Validation Process.
-  - `GRANTOR_VALIDATION_PROCESS`: `VERIFIER` permissions are granted by one or several [[ref: verifier grantor]](s) (trust registry operator(s) responsible for selecting verifiers for the credential schema of this [[ref: ecosystem]]), selected by the [[ref: ecosystem]], through the execution of a Validation Process.
+  - `ECOSYSTEM_VALIDATION_PROCESS`: `VERIFIER` permissions are granted directly by the [[ref: ecosystem]], the Ecosystem corporation through the execution of a Validation Process.
+  - `GRANTOR_VALIDATION_PROCESS`: `VERIFIER` permissions are granted by one or several [[ref: verifier grantor]](s) (ecosystem operator(s) responsible for selecting verifiers for the credential schema of this [[ref: ecosystem]]), selected by the [[ref: ecosystem]], through the execution of a Validation Process.
 - An **HolderOnboardingMode** for **holder policy**, which determines how `HOLDER` permissions are granted. Modes include:
   - `ISSUER_VALIDATION_PROCESS`: `HOLDER` permissions are granted directly by issuers to holder through the execution of a Validation Process.
   - `PERMISSIONLESS`: holder that want to obtain credentials from an issuer do not require a permission in the VPR.
@@ -365,9 +365,9 @@ Participant roles are defined in the table below:
 
 | **Participant Role**   | **Description**                                                  |
 |-----------------------|------------------------------------------------------------------|
-| **Ecosystem**    | Create and control trust registries and credential Schemas. Recognize other participants by granting permission(s) to them.        |
-| **Issuer Grantor**    | Trust Registry operator that grants Issuer permissions to candidate issuers.                   |
-| **Verifier Grantor**  | Trust Registry operator that grants Verifier permissions to candidate verifiers.               |
+| **Ecosystem**    | Create and control ecosystems and credential Schemas. Recognize other participants by granting permission(s) to them.        |
+| **Issuer Grantor**    | Ecosystem operator that grants Issuer permissions to candidate issuers.                   |
+| **Verifier Grantor**  | Ecosystem operator that grants Verifier permissions to candidate verifiers.               |
 | **Issuer**            | Can issue credentials of this schema.                            |
 | **Verifier**          | Can request presentation of credentials of this schema.          |
 | **Holder**            | Holds a credential. Holder permission provide credential status (active, revoked...)  |
@@ -480,7 +480,7 @@ vg --> verifier : granted schema permission
 
 *This section is non-normative.*
 
-The Permission registry is a can be used by crawlers to index the metadata associated with [[ref: verifiable services]].
+The Participant registry is a can be used by crawlers to index the metadata associated with [[ref: verifiable services]].
 
 Search engines can iterate over the permissions, and index [[ref: VSs]] by resolving the service identifier (at the moment a [[ref: DID]], that could be extended in the future), verify if service is a [[ref: verifiable service]], and in such a case extracting their verifiable metadata, such as [[ref: linked-vp]] presented credentials.
 
@@ -491,14 +491,14 @@ The index is particularly important for [[ref: verifiable user agents]], such as
 
 @startuml
 scale max 800 width
-object "Permission registry" as didd
+object "Participant registry" as didd
 object "Crawler" as crawler #3fbdb6
 object "Index" as index #3fbdb6
 object "VS #1" as dts1 #7677ed
 object "VS #2" as dts2 #7677ed
 object "VUA" as browser #00b0f0
 object "User" as user
-didd <|-- crawler : iterate over Permission registry
+didd <|-- crawler : iterate over Participant registry
 crawler --|> dts1 : resolve DID, get linked-vps, index data
 crawler --|> dts2 : resolve DID, get linked-vps, index data
 browser --|> index: query index
@@ -539,13 +539,13 @@ This system ensures that participation in the trust ecosystem is backed by econo
 
 The following operations **only require payment of network fees** (no trust deposit is involved):
 
-- **Trust Registries**: requires paying only [[ref: network fees]]  
+- **Ecosystems**: requires paying only [[ref: network fees]]  
 - **Credential Schemas**: requires paying only [[ref: network fees]]  
 
 
-- Updating the **governance framework documents** of an ecosystem trust registry  
+- Updating the **governance framework documents** of an ecosystem ecosystem  
 - Updating a Credential Schema
-- Updating a Trust Registry
+- Updating an Ecosystem
 - ...
 
 #### Validation process trust fees
@@ -938,7 +938,7 @@ For example, a **key-value store** may be more appropriate for a **ledger-based 
 @startuml
 scale max 800 width
 
-entity "TrustRegistry" as tr {
+entity "Ecosystem" as tr {
   *id: uint64
   +did: string
   +created: timestamp
@@ -1034,7 +1034,7 @@ entity "OperatorAuthorization" as oauthz {
 entity "VSOperatorAuthorization" as vsoauthz {
 }
 
-entity "PermissionAuthorizationRecord" as par {
+entity "ParticipantAuthorizationRecord" as par {
    *participant_id: uint64
    +msg_types: msg_type[]
    +with_feegrant: boolean
@@ -1112,13 +1112,13 @@ enum "ValidationState" as valstate {
   TERMINATED
 }
 
-entity "PermissionSession" as csps {
+entity "ParticipantSession" as csps {
   *id: uuid
   +created: timestamp
   +modified: timestamp
 }
 
-entity "PermissionSessionRecord" as cspsr {
+entity "ParticipantSessionRecord" as cspsr {
   *id: uint64
   +created: timestamp
 }
@@ -1128,7 +1128,7 @@ entity "Digest" as digest {
   +created: timestamp
 }
 
-enum "PermissionType" as cspt {
+enum "ParticipantRole" as cspt {
   ISSUER
   VERIFIER
   ISSUER_GRANTOR
@@ -1234,18 +1234,18 @@ group  --o td: corporation
 
 ```
 
-### TrustRegistry
+### Ecosystem
 
-`TrustRegistry`:
+`Ecosystem`:
 
-- `id` (uint64) (*mandatory*): the id of the trust registry.
+- `id` (uint64) (*mandatory*): the id of the ecosystem.
 - `did` (string) (*mandatory*): the did of the ecosystem.
 - `corporation` (group) (*mandatory*): [[ref: group]] that controls this entry.
-- `created` (timestamp) (*mandatory*): timestamp this TrustRegistry has been created.
-- `modified` (timestamp) (*mandatory*): timestamp this TrustRegistry has been modified.
-- `archived` (timestamp) (*mandatory*): timestamp this TrustRegistry has been archived.
-- `aka` (string) (*optional*): optional additional URI of this trust registry.
-- `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this trust registry.
+- `created` (timestamp) (*mandatory*): timestamp this Ecosystem has been created.
+- `modified` (timestamp) (*mandatory*): timestamp this Ecosystem has been modified.
+- `archived` (timestamp) (*mandatory*): timestamp this Ecosystem has been archived.
+- `aka` (string) (*optional*): optional additional URI of this ecosystem.
+- `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this ecosystem.
 - `active_version` (int): (*mandatory*) active governance framework version.
 
 ### GovernanceFrameworkVersion
@@ -1253,7 +1253,7 @@ group  --o td: corporation
 `GovernanceFrameworkVersion`:
 
 - `id` (uint64) (*mandatory*): the id of the schema.
-- `ecosystem_id` (uint64) (*mandatory*): the id of the trust registry that controls this `GovernanceFrameworkVersion` entry.
+- `ecosystem_id` (uint64) (*mandatory*): the id of the ecosystem that controls this `GovernanceFrameworkVersion` entry.
 - `created` (timestamp) (*mandatory*): timestamp this GovernanceFrameworkVersion has been created.
 - `version` (int) (*mandatory*): version of this GF. MUST Starts with 1.
 
@@ -1264,7 +1264,7 @@ group  --o td: corporation
 - `id` (uint64) (*mandatory*): the id of the schema.
 - `gfv_id` (uint64) (*mandatory*): the id of the `GovernanceFrameworkVersion` entry.
 - `created` (timestamp) (*mandatory*): timestamp this GovernanceFrameworkDocument has been created.
-- `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this trust registry.
+- `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this ecosystem.
 - `url` (string) (*mandatory*): URL where the document is published.
 - `digest_sri` (string) (*mandatory*): digest_sri of the document.
 
@@ -1275,7 +1275,7 @@ group  --o td: corporation
 **General Info**:
 
 - `id` (uint64) (*mandatory*): the id of the schema.
-- `ecosystem_id` (uint64) (*mandatory*): the id of the trust registry that controls this `CredentialSchema` entry.
+- `ecosystem_id` (uint64) (*mandatory*): the id of the ecosystem that controls this `CredentialSchema` entry.
 - `created` (timestamp) (*mandatory*): timestamp this CredentialSchema has been created.
 - `modified` (timestamp) (*mandatory*): timestamp this CredentialSchema has been modified.
 - `archived` (timestamp) (*mandatory*): timestamp this CredentialSchema has been archived.
@@ -1285,8 +1285,8 @@ group  --o td: corporation
 - `issuer_validation_validity_period` (number) (*mandatory*): number of days after which an issuer validation process expires and must be renewed.
 - `verifier_validation_validity_period` (number) (*mandatory*): number of days after which a verifier validation process expires and must be renewed.
 - `holder_validation_validity_period` (number) (*mandatory*): number of days after which an holder validation process expires and must be renewed.
-- `issuer_onboarding_mode` (IssuerOnboardingMode) (*mandatory*): defines how permissions are managed for issuers of this `CredentialSchema`. OPEN means anyone can issue credential of this schema; GRANTOR_VALIDATION_PROCESS means a validation process MUST be run between a candidate ISSUER and an ISSUER_GRANTOR in order to create an ISSUER permission; ECOSYSTEM_VALIDATION_PROCESS means a validation process MUST be run between a candidate ISSUER and the trust registry owner (ecosystem) of the `CredentialSchema` entry in order to create an ISSUER permission;
-- `verifier_onboarding_mode` (VerifierOnboardingMode) (*mandatory*): defines how permissions are managed for verifiers of this `CredentialSchema`. OPEN means anyone can verify credentials of this schema (does not implies that a payment is not necessary); GRANTOR_VALIDATION_PROCESS means a validation process MUST be run between a candidate VERIFIER and a VERIFIER_GRANTOR in order to create a VERIFIER permission; ECOSYSTEM_VALIDATION_PROCESS means a validation process MUST be run between a candidate VERIFIER and the trust registry owner (ecosystem) of the `CredentialSchema` entry in order to create a VERIFIER permission;
+- `issuer_onboarding_mode` (IssuerOnboardingMode) (*mandatory*): defines how permissions are managed for issuers of this `CredentialSchema`. OPEN means anyone can issue credential of this schema; GRANTOR_VALIDATION_PROCESS means a validation process MUST be run between a candidate ISSUER and an ISSUER_GRANTOR in order to create an ISSUER permission; ECOSYSTEM_VALIDATION_PROCESS means a validation process MUST be run between a candidate ISSUER and the ecosystem owner (ecosystem) of the `CredentialSchema` entry in order to create an ISSUER permission;
+- `verifier_onboarding_mode` (VerifierOnboardingMode) (*mandatory*): defines how permissions are managed for verifiers of this `CredentialSchema`. OPEN means anyone can verify credentials of this schema (does not implies that a payment is not necessary); GRANTOR_VALIDATION_PROCESS means a validation process MUST be run between a candidate VERIFIER and a VERIFIER_GRANTOR in order to create a VERIFIER permission; ECOSYSTEM_VALIDATION_PROCESS means a validation process MUST be run between a candidate VERIFIER and the ecosystem owner (ecosystem) of the `CredentialSchema` entry in order to create a VERIFIER permission;
 - `holder_onboarding_mode` (HolderOnboardingMode) (*mandatory*): defines how permissions are managed for holders of this `CredentialSchema`. ISSUER_VALIDATION_PROCESS means a validation process MUST be run between a candidate HOLDER and an ISSUER in order to create a HOLDER permission. HOLDER permission is used to check credential revocation status; PERMISSIONLESS means no onboarding is required to take place on the VPR (and thus an ISSUER cannot use the VPR to charge validation fees to candidate holders);
 - `pricing_asset_type` (PricingAssetType) (*mandatory*): used asset for paying business fees. Can be TU ([[ref: trust unit]]),  COIN (a token available on the VPR chain), FIAT (means chain is used for settlement only and payment is done off-chain). Not that in all cases, trust deposits are always handled in `denom`.
 - `pricing_asset` (string) (*mandatory*): `"tu"` if `pricing_asset_type` is set to TU, else examples: COIN: `denom` `"uvna"`, `"ufoo"`, `"ibc/3A0F9C2E4E2A9B7D6F..."`, `"factory/verana1.../ueurv"`, FIAT: `"USD"`, `"GBP"`,...
@@ -1307,33 +1307,33 @@ group  --o td: corporation
 - `effective_until` (timestamp) (*optional*): timestamp until which this policy version is in force, if time-limited.
 - `revoked` (boolean) (*mandatory*): indicates whether this policy version has been revoked and must no longer be used.
 
-### Permission
+### Participant
 
-`Permission`:
+`Participant`:
 
 - `id` (uint64) (*mandatory*): the id of the participant.
 - `schema_id` (uint64) (*mandatory*): the id of the related `CredentialSchema` entry.
-- `type` (PermissionType): ISSUER, VERIFIER, ISSUER_GRANTOR, VERIFIER_GRANTOR, ECOSYSTEM, HOLDER
+- `type` (ParticipantRole): ISSUER, VERIFIER, ISSUER_GRANTOR, VERIFIER_GRANTOR, ECOSYSTEM, HOLDER
 - `did` (string) (*optional*): [[ref: DID]] this permission refers to. MUST conform to [[spec-norm:RFC3986]].
 - `corporation` (group) (*mandatory*): [[ref: group]] that owns this permission.
 - `vs_operator` (account) (*mandatory*): verifiable service agent account. This is the account that will have the right to create or update permission sessions.
-- `created` (timestamp) (*mandatory*): timestamp this `Permission` has been created.
-- `adjusted` (timestamp) (*mandatory*): timestamp this `Permission` has been adjusted.
-- `slashed` (timestamp) (*mandatory*): timestamp this `Permission` has been slashed.
-- `repaid` (timestamp) (*mandatory*): timestamp this `Permission` has been repaid.
-- `effective_from` (timestamp) (*optional*): timestamp from which (inclusive) this `Permission` is effective.
-- `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this `Permission` is effective, null if no time limit has been set for this permission.
+- `created` (timestamp) (*mandatory*): timestamp this `Participant` has been created.
+- `adjusted` (timestamp) (*mandatory*): timestamp this `Participant` has been adjusted.
+- `slashed` (timestamp) (*mandatory*): timestamp this `Participant` has been slashed.
+- `repaid` (timestamp) (*mandatory*): timestamp this `Participant` has been repaid.
+- `effective_from` (timestamp) (*optional*): timestamp from which (inclusive) this `Participant` is effective.
+- `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this `Participant` is effective, null if no time limit has been set for this permission.
 - `modified` (timestamp) (*mandatory*): timestamp this Permission has been modified.
 - `validation_fees` (number) (*mandatory*): price to pay by an applicant to a validator (`corporation` grantee of this perm) for running a validation process for a given validation period. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
 - `issuance_fees` (number) (*mandatory*): fees requested by grantee `corporation` of this perm when a credential is issued. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
 - `verification_fees` (number) (*mandatory*): fees requested by grantee `corporation` of this perm when a credential is verified. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
-- `deposit` (number) (*mandatory*): accumulated *grantee* deposit in the context of the *use* of this permission (including the validation process), in [[ ref: native denom ]]. Usually, it is incremented when for example, for a ISSUER type `Permission` `perm`, issuer issues credentials that require paying issuance fees: an additional % of the fees is charged to issuer and sent to its deposit, corresponding deposit amount increases this `participant.deposit` value as well. If `perm` is, let's say revoked, then corresponding `participant.deposit` value is freed from `participant.grantee` Trust Deposit.
+- `deposit` (number) (*mandatory*): accumulated *grantee* deposit in the context of the *use* of this permission (including the validation process), in [[ ref: native denom ]]. Usually, it is incremented when for example, for a ISSUER type `Participant` `perm`, issuer issues credentials that require paying issuance fees: an additional % of the fees is charged to issuer and sent to its deposit, corresponding deposit amount increases this `participant.deposit` value as well. If `perm` is, let's say revoked, then corresponding `participant.deposit` value is freed from `participant.grantee` Trust Deposit.
 - `slashed_deposit` (number) (*mandatory*): part of the deposit in [[ ref: native denom ]] that has been slashed.
 - `repaid_deposit` (number) (*mandatory*): part of the slashed deposit in [[ ref: native denom ]] that has been repaid.
 - `revoked` (timestamp) (*optional*): manual revocation timestamp of this Perm.
-- `validator_participant_id` (uint64) (*optional*): permission of the validator assigned to the validation process of this permission, ie *parent node* in the `Permission` tree.
+- `validator_participant_id` (uint64) (*optional*): permission of the validator assigned to the validation process of this permission, ie *parent node* in the `Participant` tree.
 - `vp_state` (enum) (*mandatory*): one of PENDING, VALIDATED, TERMINATED.
-- `vp_exp` (timestamp) (*optional*): validation expiration timestamp. This expiration timestamp is for the validation process itself, not for the issued credential or `Permission` expiration timestamp.
+- `vp_exp` (timestamp) (*optional*): validation expiration timestamp. This expiration timestamp is for the validation process itself, not for the issued credential or `Participant` expiration timestamp.
 - `vp_last_state_change` (timestamp) (*mandatory*)
 - `vp_validator_deposit`: number (*optional*): accumulated validator trust deposit, in [[ref: denom]].
 - `vp_current_fees` (number) (*mandatory*): current action escrowed fees that will be paid to [[ref: validator]] upon validation process completion, in [[ref: denom]].
@@ -1342,28 +1342,28 @@ group  --o td: corporation
 - `issuance_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_VALIDATION_PROCESS mode) or an ISSUER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 - `verification_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_VALIDATION_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 
-> Note: VS operator authorization settings (spend limits, feegrant, expiration, authorized message types) are no longer stored on `Permission`. They live in `PermissionAuthorizationRecord` entries inside [VSOperatorAuthorization](#vsoperatorauthorization), keyed by `Permission.id`. See [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) and [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks).
+> Note: VS operator authorization settings (spend limits, feegrant, expiration, authorized message types) are no longer stored on `Participant`. They live in `ParticipantAuthorizationRecord` entries inside [VSOperatorAuthorization](#vsoperatorauthorization), keyed by `Permission.id`. See [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) and [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks).
 
-### PermissionSession
+### ParticipantSession
 
-`PermissionSession`:
+`ParticipantSession`:
 
 - `id` (uuid) (*mandatory*): session uuid.
 - `corporation` (group) (*mandatory*): corporation that controls the entry.
 - `vs_operator` (account) (*mandatory*): verifiable service agent account that controls the entry (agent crypto account).
-- `created` (timestamp) (*mandatory*): timestamp this PermissionSession has been created.
-- `modified` (timestamp) (*mandatory*): timestamp this PermissionSession has been modified.
-- `session_records` (PermissionSessionRecord[]) (*mandatory*): session records, for this session.
+- `created` (timestamp) (*mandatory*): timestamp this ParticipantSession has been created.
+- `modified` (timestamp) (*mandatory*): timestamp this ParticipantSession has been modified.
+- `session_records` (ParticipantSessionRecord[]) (*mandatory*): session records, for this session.
 
-### PermissionSessionRecord
+### ParticipantSessionRecord
 
-`PermissionSessionRecord`:
+`ParticipantSessionRecord`:
 
 - `created` (timestamp) (*mandatory*): timestamp this record has been created.
-- `issuer_participant_id` (uint64) (*optional*): related issuer `Permission` id (if applicable).
-- `verifier_participant_id` (uint64) (*optional*): related verifier `Permission` id (if applicable).
-- `wallet_agent_participant_id` (uint64) (*optional*): related wallet agent `Permission` id (if applicable).
-- `agent_participant_id` (uint64) (*optional*): permission id of the agent `Permission` id (if applicable).
+- `issuer_participant_id` (uint64) (*optional*): related issuer `Participant` id (if applicable).
+- `verifier_participant_id` (uint64) (*optional*): related verifier `Participant` id (if applicable).
+- `wallet_agent_participant_id` (uint64) (*optional*): related wallet agent `Participant` id (if applicable).
+- `agent_participant_id` (uint64) (*optional*): permission id of the agent `Participant` id (if applicable).
 
 ### TrustDeposit
 
@@ -1416,24 +1416,24 @@ group  --o td: corporation
 
 ### VSOperatorAuthorization
 
-A `VSOperatorAuthorization` groups all `PermissionAuthorizationRecord` entries delegated by one `corporation` to one `vs_operator`. It is keyed by the `(corporation, vs_operator)` pair. The entry exists if, and only if, it has at least one record.
+A `VSOperatorAuthorization` groups all `ParticipantAuthorizationRecord` entries delegated by one `corporation` to one `vs_operator`. It is keyed by the `(corporation, vs_operator)` pair. The entry exists if, and only if, it has at least one record.
 
 - `corporation` (group) (*mandatory*): the corporation group granting the authorization.
 - `vs_operator` (account) (*mandatory*): the operator account receiving the authorization.
-- `records` (PermissionAuthorizationRecord[]) (*mandatory*): per-permission authorization records granted to `vs_operator` by `corporation`.
+- `records` (ParticipantAuthorizationRecord[]) (*mandatory*): per-permission authorization records granted to `vs_operator` by `corporation`.
 
-### PermissionAuthorizationRecord
+### ParticipantAuthorizationRecord
 
-A `PermissionAuthorizationRecord` carries the per-permission authorization configuration that was previously stored on `Permission.vs_operator_authz_*` fields. Each record is globally unique by `participant_id`: for any `Permission.id`, at most one record exists system-wide, so `(corporation, vs_operator)` can be derived from `participant_id` via a direct lookup.
+A `ParticipantAuthorizationRecord` carries the per-permission authorization configuration that was previously stored on `Permission.vs_operator_authz_*` fields. Each record is globally unique by `participant_id`: for any `Permission.id`, at most one record exists system-wide, so `(corporation, vs_operator)` can be derived from `participant_id` via a direct lookup.
 
-- `participant_id` (uint64) (*mandatory*): id of the `Permission` this authorization record applies to. Globally unique across all `PermissionAuthorizationRecord` entries.
-- `msg_types` (msg_type[]) (*mandatory*): list of delegable message types for which the `vs_operator` is authorized on behalf of `corporation` when acting in the context of `participant_id`. Declared by the applicant at record creation time (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission)). Frozen after creation.
+- `participant_id` (uint64) (*mandatory*): id of the `Participant` this authorization record applies to. Globally unique across all `ParticipantAuthorizationRecord` entries.
+- `msg_types` (msg_type[]) (*mandatory*): list of delegable message types for which the `vs_operator` is authorized on behalf of `corporation` when acting in the context of `participant_id`. Declared by the applicant at record creation time (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant)). Frozen after creation.
 - `spend_limit` (DenomAmount[]) (*optional*): maximum amount the `vs_operator` is allowed to spend, in the context of this permission, as a direct consequence of executing authorized messages.
 - `remaining_spend` (DenomAmount[]) (*conditional*): runtime balance for `spend_limit`. Present iff `spend_limit` is set. Initialized to `spend_limit` at create time. Decremented per matching `denom` after each authorized operation. Reset to `spend_limit` when the current cycle ends (see `expiration` and `period` below).
 - `fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
 - `remaining_fee_spend` (DenomAmount[]) (*conditional*): runtime balance for `fee_spend_limit`. Present iff `fee_spend_limit` is set. Initialized, decremented and reset following the same rules as `remaining_spend`.
 - `with_feegrant` (bool) (*mandatory*): if true, `corporation` pays the transaction fees for `vs_operator` when executing authorized messages in the context of this permission, through an on-chain `FeeGrant`.
-- `expiration` (timestamp) (*mandatory*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the record is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the record auto-renews until removed via [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)). Initially written to `now` at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) (disabled until validation) and to `Permission.effective_until` at [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-permission-vp-to-validated) / [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-permission) / [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission).
+- `expiration` (timestamp) (*mandatory*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the record is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the record auto-renews until removed via [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)). Initially written to `now` at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp) (disabled until validation) and to `Permission.effective_until` at [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-vp-to-validated) / [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-participant) / [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant).
 - `period` (duration) (*optional*): reset period for `spend_limit` and `fee_spend_limit` in the context of this permission.
 
 ### ExchangeRate
@@ -1501,12 +1501,12 @@ All [[ref: VPR]] modules MUST, at least, provide:
 Note about Query REST API:
 
 - all query methods MUST return valid JSON.
-- objects MUST be nested when needed, such as when returning a trust registry.
-- JSON formatting MUST obey to data model regarding attribute names. A method that returns a `TrustRegistry` entry MUST return an entry called "trust_registry". A method that returns a list of Trust Registries MUST return an entry called "trustRegistries" that contain a list of `TrustRegistry` entries.
+- objects MUST be nested when needed, such as when returning an ecosystem.
+- JSON formatting MUST obey to data model regarding attribute names. A method that returns a `Ecosystem` entry MUST return an entry called "trust_registry". A method that returns a list of Ecosystems MUST return an entry called "trustRegistries" that contain a list of `Ecosystem` entries.
 
 Examples:
 
-Get a `TrustRegistry`
+Get a `Ecosystem`
 
 ```json
 "trust_registry": {
@@ -1703,13 +1703,13 @@ If the transaction fees are paid by the `corporation` account (via fee grant) in
 
 ##### [AUTHZ-CHECK-3] VS Operator Authorization checks
 
-A second authorization grant mode exists for vs-agents. It is used when a corporation delegates a specific permission (and a specific set of message types, scoped to that permission) to a `vs_operator` account. The authorization model differs from other delegable messages: it relies on [VSOperatorAuthorization](#vsoperatorauthorization) / [PermissionAuthorizationRecord](#permissionauthorizationrecord) instead of `OperatorAuthorization`.
+A second authorization grant mode exists for vs-agents. It is used when a corporation delegates a specific permission (and a specific set of message types, scoped to that permission) to a `vs_operator` account. The authorization model differs from other delegable messages: it relies on [VSOperatorAuthorization](#vsoperatorauthorization) / [ParticipantAuthorizationRecord](#participantauthorizationrecord) instead of `OperatorAuthorization`.
 
-> Note: the set of messages a `vs_operator` is authorized to execute in the context of a permission is declared by the applicant at permission creation time (see [[MOD-PP-MSG-1-1]](#mod-pp-msg-1-1-start-permission-vp-parameters) and [[MOD-PP-MSG-14-1]](#mod-pp-msg-14-1-self-create-permission-parameters)) and stored in `record.msg_types`. It is frozen for the lifetime of the record and can only be changed by revoking the permission and starting a new one.
+> Note: the set of messages a `vs_operator` is authorized to execute in the context of a permission is declared by the applicant at permission creation time (see [[MOD-PP-MSG-1-1]](#mod-pp-msg-1-1-start-participant-vp-parameters) and [[MOD-PP-MSG-14-1]](#mod-pp-msg-14-1-self-create-participant-parameters)) and stored in `record.msg_types`. It is frozen for the lifetime of the record and can only be changed by revoking the permission and starting a new one.
 
 Given a `corporation`, an `operator` (the `vs_operator`), a **primary permission id** `participant_id` (determined by the calling method), and the current message type `msg_type`:
 
-1. A `PermissionAuthorizationRecord` `record` MUST exist for `participant_id`. Abort if not found.
+1. A `ParticipantAuthorizationRecord` `record` MUST exist for `participant_id`. Abort if not found.
 2. `record` MUST belong to `VSOperatorAuthorization[corporation, operator]`, that is: the containing `VSOperatorAuthorization` MUST have `corporation` as its `corporation` and `operator` as its `vs_operator`. Abort otherwise.
 3. `msg_type` MUST be in `record.msg_types`. Abort otherwise.
 4. Cycle / expiration check:
@@ -1722,7 +1722,7 @@ Given a `corporation`, an `operator` (the `vs_operator`), a **primary permission
 
 ##### [AUTHZ-CHECK-4] VS Operator Fee Grant checks
 
-If the [[ref: transaction]] fees are paid by the `corporation` account (via fee grant) instead of the `operator` account, using the same `PermissionAuthorizationRecord` `record` looked up in [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks):
+If the [[ref: transaction]] fees are paid by the `corporation` account (via fee grant) instead of the `operator` account, using the same `ParticipantAuthorizationRecord` `record` looked up in [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks):
 
 1. `record.with_feegrant` MUST be true, else abort.
 2. The cycle / expiration check from [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) step 4 has already been performed against the same `record`; `record.remaining_fee_spend` is therefore current.
@@ -1731,8 +1731,8 @@ If the [[ref: transaction]] fees are paid by the `corporation` account (via fee 
 #### Example
 
 A corporation group `corporationABC` wants to authorize an operator account `accountABC` to execute the  
-[`mod-pp-msg-10-create-or-update-permission-session`](#mod-pp-msg-10-create-or-update-permission-session),
-[`mod-pp-msg-3-set-permission-vp-to-validated`](#mod-pp-msg-3-set-permission-vp-to-validated), and
+[`mod-pp-msg-10-create-or-update-participant-session`](#mod-pp-msg-10-create-or-update-participant-session),
+[`mod-pp-msg-3-set-participant-vp-to-validated`](#mod-pp-msg-3-set-participant-vp-to-validated), and
 [`mod-pp-msg-15-trigger-resolver`](#mod-pp-msg-15-trigger-resolver)
  messages.
 
@@ -1741,8 +1741,8 @@ Additionally, the corporation wants `accountABC` to pay the transaction fees for
 To achieve this, `corporationABC` MUST:
 
 - create an **authorization** from `corporationABC` to `accountABC` for the  
-  [`mod-pp-msg-10-create-or-update-permission-session`](#mod-pp-msg-10-create-or-update-permission-session),
-[`mod-pp-msg-3-set-permission-vp-to-validated`](#mod-pp-msg-3-set-permission-vp-to-validated), and
+  [`mod-pp-msg-10-create-or-update-participant-session`](#mod-pp-msg-10-create-or-update-participant-session),
+[`mod-pp-msg-3-set-participant-vp-to-validated`](#mod-pp-msg-3-set-participant-vp-to-validated), and
 [`mod-pp-msg-15-trigger-resolver`](#mod-pp-msg-15-trigger-resolver) message types, optionally enabling an associated fee grant.
 
 As a result, `accountABC` is authorized to:
@@ -1754,15 +1754,15 @@ As a result, `accountABC` is authorized to:
 
 | Module                         | Method Name                             | Relative REST API path           | Type   |Requirements      | Signers |
 |--------------------------------|-----------------------------------------|----------------------------------|--------|------------------|---|
-| Trust Registry                 | Create a Trust Registry                 |    N/A (Tx)                    | Msg    | [[MOD-ES-MSG-1]](#mod-es-msg-1-create-new-trust-registry)   | corporation + operator |
+| Ecosystem                 | Create an Ecosystem                 |    N/A (Tx)                    | Msg    | [[MOD-ES-MSG-1]](#mod-es-msg-1-create-new-ecosystem)   | corporation + operator |
 |                                | Add Governance Framework Document       |     N/A (Tx)                      | Msg    | [[MOD-ES-MSG-2]](#mod-es-msg-2-add-governance-framework-document)   |corporation + operator |
 |                                | Increase Active Governance Framework Version |      N/A (Tx)                   | Msg    | [[MOD-ES-MSG-3]](#mod-es-msg-3-increase-active-governance-framework-version)   |corporation + operator |
-|                                | Update Trust Registry                   |       N/A (Tx)                   | Msg    | [[MOD-ES-MSG-4]](#mod-es-msg-4-update-trust-registry)   |corporation + operator |
-|                                | Archive Trust Registry                  |        N/A (Tx)                 | Msg    | [[MOD-ES-MSG-5]](#mod-es-msg-5-archive-trust-registry)   |corporation + operator |
-|                                | Update TR Module Parameters             |         N/A (Tx)                 | Msg    | [[MOD-ES-MSG-6]](#mod-es-msg-6-update-module-parameters)   |governance proposal |
-|                                | Get Trust Registry                      | /es/v1/get                  | Query  | [[MOD-ES-QRY-1]](#mod-es-qry-1-get-trust-registry)   |N/A |
-|                                | List Trust Registries                   | /es/v1/list                 | Query  | [[MOD-ES-QRY-2]](#mod-es-qry-2-list-trust-registries)   |N/A |
-|                                | List TR Module Parameters               | /es/v1/params                 | Query  | [[MOD-ES-QRY-3]](#mod-es-qry-3-list-module-parameters)   |N/A |
+|                                | Update Ecosystem                   |       N/A (Tx)                   | Msg    | [[MOD-ES-MSG-4]](#mod-es-msg-4-update-ecosystem)   |corporation + operator |
+|                                | Archive Ecosystem                  |        N/A (Tx)                 | Msg    | [[MOD-ES-MSG-5]](#mod-es-msg-5-archive-ecosystem)   |corporation + operator |
+|                                | Update Ecosystem Module Parameters             |         N/A (Tx)                 | Msg    | [[MOD-ES-MSG-6]](#mod-es-msg-6-update-module-parameters)   |governance proposal |
+|                                | Get Ecosystem                      | /es/v1/get                  | Query  | [[MOD-ES-QRY-1]](#mod-es-qry-1-get-ecosystem)   |N/A |
+|                                | List Ecosystems                   | /es/v1/list                 | Query  | [[MOD-ES-QRY-2]](#mod-es-qry-2-list-ecosystems)   |N/A |
+|                                | List Ecosystem Module Parameters               | /es/v1/params                 | Query  | [[MOD-ES-QRY-3]](#mod-es-qry-3-list-module-parameters)   |N/A |
 | Credential Schema              | Create a Credential Schema              |       N/A (Tx)                   | Msg    | [[MOD-CS-MSG-1]](#mod-cs-msg-1-create-new-credential-schema)   |corporation + operator |
 |                                | Update a Credential Schema              |      N/A (Tx)                     | Msg    | [[MOD-CS-MSG-2]](#mod-cs-msg-2-update-credential-schema)   |corporation + operator |
 |                                | Archive Credential Schema               |       N/A (Tx)                      | Msg    | [[MOD-CS-MSG-3]](#mod-cs-msg-3-archive-credential-schema)   |corporation + operator |
@@ -1776,24 +1776,24 @@ As a result, `accountABC` is authorized to:
 |                                | List CS Module Parameters               | /cs/v1/params                 | Query  | [[MOD-CS-QRY-4]](#mod-cs-qry-4-list-module-parameters)   |N/A  |
 |                  | Get Schema Authorization Policy                         | /cs/v1/sap/get         | Query | [[MOD-CS-QRY-5]](#mod-cs-qry-5-get-schema-authorization-policy) | N/A |
 |                  | List Schema Authorization Policies                      | /cs/v1/sap/list        | Query | [[MOD-CS-QRY-6]](#mod-cs-qry-6-list-schema-authorization-policies) | N/A |
-| Permission                     | Start Permission VP                     |     N/A (Tx)                       | Msg    | [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp)    |corporation + operator |
-|                                | Renew a Permission VP                   |       N/A (Tx)                     | Msg    | [[MOD-PP-MSG-2]](#mod-pp-msg-2-renew-permission-vp)    |corporation + operator |
-|                                | Set Permission VP to Validated          |        N/A (Tx)                     | Msg    | [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-permission-vp-to-validated)    |corporation + operator |
-|                                | Cancel Permission VP Last Request       |         N/A (Tx)                    | Msg    | [[MOD-PP-MSG-6]](#mod-pp-msg-6-cancel-permission-vp-last-request)    |corporation + operator |
-|                                | Create Root Permission                  |         N/A (Tx)                | Msg    | [[MOD-PP-MSG-7]](#mod-pp-msg-7-create-root-permission)   |corporation + operator |
-|                                | Adjust Permission                       |         N/A (Tx)            | Msg    | [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-permission)  |corporation + operator |
-|                                | Revoke Permission                       |          N/A (Tx)              | Msg    | [[MOD-PP-MSG-9]](#mod-pp-msg-9-revoke-permission)  |corporation + operator |
-|                                | Create or update Permission Session     |           N/A (Tx)              | Msg    | [[MOD-PP-MSG-10]](#mod-pp-msg-10-create-or-update-permission-session)  |corporation + operator |
-|                                | Update Permission Module Parameters     |           N/A (Tx)             | Msg    | [[MOD-PP-MSG-11]](#mod-pp-msg-11-update-permission-module-parameters) |governance proposal |
-|                                | Slash Permission Trust Deposit          |                N/A (Tx)       | Msg    | [[MOD-PP-MSG-12]](#mod-pp-msg-12-slash-permission-trust-deposit) |corporation + operator |
-|                                | Repay Permission Slashed Trust Deposit  |     N/A (Tx)                | Msg    | [[MOD-PP-MSG-13]](#mod-pp-msg-13-repay-permission-slashed-trust-deposit) |corporation + operator |
-|                                | Self Create Permission (OPEN mode)      |         N/A (Tx)              | Msg    | [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission) |corporation + operator  |
+| Permission                     | Start Participant VP                     |     N/A (Tx)                       | Msg    | [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp)    |corporation + operator |
+|                                | Renew a Participant VP                   |       N/A (Tx)                     | Msg    | [[MOD-PP-MSG-2]](#mod-pp-msg-2-renew-participant-vp)    |corporation + operator |
+|                                | Set Participant VP to Validated          |        N/A (Tx)                     | Msg    | [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-vp-to-validated)    |corporation + operator |
+|                                | Cancel Participant VP Last Request       |         N/A (Tx)                    | Msg    | [[MOD-PP-MSG-6]](#mod-pp-msg-6-cancel-participant-vp-last-request)    |corporation + operator |
+|                                | Create Root Participant                  |         N/A (Tx)                | Msg    | [[MOD-PP-MSG-7]](#mod-pp-msg-7-create-root-participant)   |corporation + operator |
+|                                | Adjust Participant                       |         N/A (Tx)            | Msg    | [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-participant)  |corporation + operator |
+|                                | Revoke Participant                       |          N/A (Tx)              | Msg    | [[MOD-PP-MSG-9]](#mod-pp-msg-9-revoke-participant)  |corporation + operator |
+|                                | Create or update Participant Session     |           N/A (Tx)              | Msg    | [[MOD-PP-MSG-10]](#mod-pp-msg-10-create-or-update-participant-session)  |corporation + operator |
+|                                | Update Participant Module Parameters     |           N/A (Tx)             | Msg    | [[MOD-PP-MSG-11]](#mod-pp-msg-11-update-participant-module-parameters) |governance proposal |
+|                                | Slash Participant Trust Deposit          |                N/A (Tx)       | Msg    | [[MOD-PP-MSG-12]](#mod-pp-msg-12-slash-participant-trust-deposit) |corporation + operator |
+|                                | Repay Participant Slashed Trust Deposit  |     N/A (Tx)                | Msg    | [[MOD-PP-MSG-13]](#mod-pp-msg-13-repay-participant-slashed-trust-deposit) |corporation + operator |
+|                                | Self Create Participant (OPEN mode)      |         N/A (Tx)              | Msg    | [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant) |corporation + operator  |
 |                                | Trigger Resolver                        |         N/A (Tx)              | Msg    | [[MOD-PP-MSG-15]](#mod-pp-msg-15-trigger-resolver) |corporation + operator |
-|                                | List Permissions                        | /pp/v1/list                | Query  | [[MOD-PP-QRY-1]](#mod-pp-qry-1-list-permissions)    |N/A |
-|                                | Get a Permission                        | /pp/v1/get                 | Query  | [[MOD-PP-QRY-2]](#mod-pp-qry-2-get-permission)    |N/A |
+|                                | List Participants                        | /pp/v1/list                | Query  | [[MOD-PP-QRY-1]](#mod-pp-qry-1-list-participants)    |N/A |
+|                                | Get a Participant                        | /pp/v1/get                 | Query  | [[MOD-PP-QRY-2]](#mod-pp-qry-2-get-participant)    |N/A |
 |                                | Find Beneficiaries                      | /pp/v1/beneficiaries       | Query  | [[MOD-PP-QRY-4]](#mod-pp-qry-4-find-beneficiaries)  |N/A |
-|                                | Get Permission Session                  | /pp/v1/session/get         | Query  | [[MOD-PP-QRY-5]](#mod-pp-qry-5-get-permissionsession) |N/A |
-|                                | List Permission Module Parameters     |  /pp/v1/params         | Query    | [[MOD-PP-QRY-6]](#mod-pp-qry-6-list-permission-module-parameters)   |N/A |
+|                                | Get Participant Session                  | /pp/v1/session/get         | Query  | [[MOD-PP-QRY-5]](#mod-pp-qry-5-get-participantsession) |N/A |
+|                                | List Participant Module Parameters     |  /pp/v1/params         | Query    | [[MOD-PP-QRY-6]](#mod-pp-qry-6-list-participant-module-parameters)   |N/A |
 | Trust Deposit                  | Adjust Trust Deposit                    |   N/A (Tx)                       | Msg    | [[MOD-TD-MSG-1]](#mod-td-msg-1-adjust-trust-deposit)   | module call |
 |                                | Reclaim Trust Deposit Yield         |     N/A (Tx)           | Msg    | [[MOD-TD-MSG-2]](#mod-td-msg-2-reclaim-trust-deposit-yield)   |corporation + operator |
 |                                | Update TD Module Parameters             |      N/A (Tx)               | Msg  | [[MOD-TD-MSG-4]](#mod-td-msg-4-update-module-parameters)   |governance proposal |
@@ -1825,31 +1825,31 @@ As a result, `accountABC` is authorized to:
 Any method failure in the precondition/basic checks SHOULD lead to a CLI ERROR / HTTP BAD REQUEST error with a human readable message giving a clue of the reason why method failed.
 :::
 
-### Trust Registry Module
+### Ecosystem Module
 
-#### [MOD-ES-MSG-1] Create New Trust Registry
+#### [MOD-ES-MSG-1] Create New Ecosystem
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-ES-MSG-1-1] Create New Trust Registry parameters
+##### [MOD-ES-MSG-1-1] Create New Ecosystem parameters
 
-An authorized `operator` that would like to create a [[ref: trust registry]] MUST call this method by specifying:
+An authorized `operator` that would like to create a [[ref: ecosystem]] MUST call this method by specifying:
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `did` (string) (*mandatory*): the did of the ecosystem that is creating the trust registry.
-- `aka` (string) (*optional*): optional additional URI of this trust registry.
-- `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this trust registry.
+- `did` (string) (*mandatory*): the did of the ecosystem that is creating the ecosystem.
+- `aka` (string) (*optional*): optional additional URI of this ecosystem.
+- `language` (string) (*mandatory*): primary language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of this ecosystem.
 - `doc_url` (string) (*mandatory*): URL where the document is published.
 - `doc_digest_sri` (string) (*mandatory*): digest_sri of the document.
 
-Provided document must be of the same language that the primary language of the trust registry.
+Provided document must be of the same language that the primary language of the ecosystem.
 
-##### [MOD-ES-MSG-1-2] Create New Trust Registry precondition checks
+##### [MOD-ES-MSG-1-2] Create New Ecosystem precondition checks
 
 If any of these precondition checks fail, method MUST abort.
 
-###### [MOD-ES-MSG-1-2-1] Create New Trust Registry basic checks
+###### [MOD-ES-MSG-1-2-1] Create New Ecosystem basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
 
@@ -1857,26 +1857,26 @@ If any of these precondition checks fail, method MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- `aka` (string) (*optional*): optional additional URI of this trust registry. MUST be an [[ref: URI]].
+- `aka` (string) (*optional*): optional additional URI of this ecosystem. MUST be an [[ref: URI]].
 - `language` (string(17)) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 - `doc_url` (string) (*mandatory*): MUST be a valid URL .
 - `doc_digest_sri` (string) (*mandatory*): MUST be a valid digest_sri as specified in [integrity of related resources spec](https://www.w3.org/TR/vc-data-model-2.0/#integrity-of-related-resources). Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
 
 :::note
-It is not a problem if several trust registries are created with the same ecosystem DID. Identifier of a `TrustRegistry` is its id, and the Verifiable Trust Spec includes the id of the `TrustRegistry` in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.
+It is not a problem if several ecosystems are created with the same ecosystem DID. Identifier of a `Ecosystem` is its id, and the Verifiable Trust Spec includes the id of the `Ecosystem` in the DID Document. DID unique constraint is then not needed: proof of control of the DID is verified by resolving the DID outside of the context of the VPR.
 :::
 
-###### [MOD-ES-MSG-1-2-2] Create New Trust Registry fee checks
+###### [MOD-ES-MSG-1-2-2] Create New Ecosystem fee checks
 
 Fee payer MUST have an available balance to cover the [[ref: estimated transaction fees]].
 
-##### [MOD-ES-MSG-1-3] Create New Trust Registry execution
+##### [MOD-ES-MSG-1-3] Create New Ecosystem execution
 
 If all precondition checks passed, method is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- create and persist a new `TrustRegistry` entry `tr`:
+- create and persist a new `Ecosystem` entry `tr`:
 
 - `ecosystem.id` : auto-incremented uint64
 - `ecosystem.did`: `did`
@@ -1912,7 +1912,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): the id of the trust registry.
+- `id` (uint64) (*mandatory*): the id of the ecosystem.
 - `doc_language` (string) (*mandatory*): language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)) of the [[ref: EGF]] document, provided by the [[ref: EGA]].
 - `doc_url` (string) (*mandatory*): URL where the document is published.
 - `doc_digest_sri` (string) (*mandatory*): digest_sri of the document.
@@ -1931,7 +1931,7 @@ if a mandatory parameter is not present, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `id` (uint64) (*mandatory*): a `TrustRegistry` entry with this id MUST exist and `corporation` executing the method MUST be the `corporation` of the `TrustRegistry` entry.
+- `id` (uint64) (*mandatory*): a `Ecosystem` entry with this id MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry.
 - `version`: there MUST exist a `GovernanceFrameworkVersion` entry `gfv` where `gfv.ecosystem_id` is equal to `id` and `gfv.version` = `version`, or `version` MUST be exactly equal to the biggest found `gfv.version` + 1 of all `GovernanceFrameworkVersion` entries found for this `gfv.ecosystem_id` equal to `id`. `version` MUST be greater than the `ecosystem.active_version`.
 - `doc_language` (string) (*mandatory*): MUST be a language tag ([BCP 47](https://www.rfc-editor.org/info/bcp47)).
 - `doc_url` (string) (*mandatory*): MUST be a valid URL.
@@ -1972,7 +1972,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): the id of the trust registry.
+- `id` (uint64) (*mandatory*): the id of the ecosystem.
 
 ##### [MOD-ES-MSG-3-2] Increase Active Governance Framework Version precondition checks
 
@@ -1985,9 +1985,9 @@ If any of these precondition checks fail, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `id` (uint64) (*mandatory*): a `TrustRegistry` entry with this id MUST exist and `corporation` executing the method MUST be the `corporation` of the `TrustRegistry` entry.
-- load `TrustRegistry` entry `tr` from its `id`. Find a `GovernanceFrameworkVersion` entry `gfv` where version is equal to `ecosystem.active_version` + 1. If none is found, transaction MUST abort.
-- find `GovernanceFrameworkDocument` `gfd` for `gfd.gfv_id` = `gfv.id` and `gfd.language` = `ecosystem.language`. If no document is found (and thus no document exist for the default language of this version for this trust registry), transaction MUST abort.
+- `id` (uint64) (*mandatory*): a `Ecosystem` entry with this id MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry.
+- load `Ecosystem` entry `tr` from its `id`. Find a `GovernanceFrameworkVersion` entry `gfv` where version is equal to `ecosystem.active_version` + 1. If none is found, transaction MUST abort.
+- find `GovernanceFrameworkDocument` `gfd` for `gfd.gfv_id` = `gfv.id` and `gfd.language` = `ecosystem.language`. If no document is found (and thus no document exist for the default language of this version for this ecosystem), transaction MUST abort.
 
 ###### [MOD-ES-MSG-3-2-2] Increase Active Governance Framework Version fee checks
 
@@ -1999,89 +1999,89 @@ If all precondition checks passed, method is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- load `TrustRegistry` entry `tr` from its `id`. Find a `GovernanceFrameworkVersion` entry `gfv` where version is equal to `ecosystem.active_version` + 1. If none is found, transaction MUST abort. Else, update `ecosystem.active_version` to `ecosystem.active_version` + 1. Set `ecosystem.modified` to current timestamp, and set `gfv.active_since` to current timestamp and persist changes.
+- load `Ecosystem` entry `tr` from its `id`. Find a `GovernanceFrameworkVersion` entry `gfv` where version is equal to `ecosystem.active_version` + 1. If none is found, transaction MUST abort. Else, update `ecosystem.active_version` to `ecosystem.active_version` + 1. Set `ecosystem.modified` to current timestamp, and set `gfv.active_since` to current timestamp and persist changes.
 
-#### [MOD-ES-MSG-4] Update Trust Registry
+#### [MOD-ES-MSG-4] Update Ecosystem
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-ES-MSG-4-1] Update Trust Registry parameters
+##### [MOD-ES-MSG-4-1] Update Ecosystem parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): the id of the trust registry.
-- `did` (string) (*mandatory*): the did of the trust registry.
-- `aka` (string) (*optional*): optional additional URI of this trust registry. If null, it means replace existing value with null.
+- `id` (uint64) (*mandatory*): the id of the ecosystem.
+- `did` (string) (*mandatory*): the did of the ecosystem.
+- `aka` (string) (*optional*): optional additional URI of this ecosystem. If null, it means replace existing value with null.
 
-##### [MOD-ES-MSG-4-2] Update Trust Registry precondition checks
+##### [MOD-ES-MSG-4-2] Update Ecosystem precondition checks
 
 If any of these precondition checks fail, method MUST abort.
 
-###### [MOD-ES-MSG-4-2-1] Update Trust Registry basic checks
+###### [MOD-ES-MSG-4-2-1] Update Ecosystem basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
 
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `id` (uint64) (*mandatory*): a `TrustRegistry` entry `tr` with id `id` MUST exist and `corporation` executing the method MUST be the `corporation` of the `TrustRegistry` entry `tr`.
+- `id` (uint64) (*mandatory*): a `Ecosystem` entry `tr` with id `id` MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry `tr`.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- `aka` (string) (*optional*): optional additional URI of this trust registry. MUST be an [[ref: URI]] or null.
+- `aka` (string) (*optional*): optional additional URI of this ecosystem. MUST be an [[ref: URI]] or null.
 
-###### [MOD-ES-MSG-4-2-2] Update Trust Registry fee checks
+###### [MOD-ES-MSG-4-2-2] Update Ecosystem fee checks
 
 Fee payer must have available balance in its [[ref: account]] to cover the required [[ref: transaction fees]].
 
-##### [MOD-ES-MSG-4-3] Update Trust Registry execution
+##### [MOD-ES-MSG-4-3] Update Ecosystem execution
 
 If all precondition checks passed, method is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- load `TrustRegistry` entry `tr` from `id` and set:
+- load `Ecosystem` entry `tr` from `id` and set:
 
 - `ecosystem.did`: `did`
 - `ecosystem.aka`: `aka`
 - `ecosystem.modified`: current timestamp
 
-#### [MOD-ES-MSG-5] Archive Trust Registry
+#### [MOD-ES-MSG-5] Archive Ecosystem
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-ES-MSG-5-1] Archive Trust Registry parameters
+##### [MOD-ES-MSG-5-1] Archive Ecosystem parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*) id of the trust registry (*mandatory*);
+- `id` (uint64) (*mandatory*) id of the ecosystem (*mandatory*);
 - `archive` (boolean) (*mandatory*), true means archive, false means unarchive.
 
-##### [MOD-ES-MSG-5-2] Archive Trust Registry precondition checks
+##### [MOD-ES-MSG-5-2] Archive Ecosystem precondition checks
 
 If any of these precondition checks fail, method MUST abort.
 
-###### [MOD-ES-MSG-5-2-1] Archive Trust Registry basic checks
+###### [MOD-ES-MSG-5-2-1] Archive Ecosystem basic checks
 
 - if a mandatory parameter is not present, method MUST abort.
 
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- load `TrustRegistry` `tr` from `id`. `ecosystem.corporation` MUST be the corporation executing the method, else MUST abort.
+- load `Ecosystem` `tr` from `id`. `ecosystem.corporation` MUST be the corporation executing the method, else MUST abort.
 - `archive` (boolean) (*mandatory*) MUST be a boolean.
-  - If `archive` is true and `ecosystem.archived` is not null, MUST abort as `TrustRegistry` is already archived.
-  - If `archive` is false and `ecosystem.archived` is null, MUST abort as `TrustRegistry` is already not archived.
+  - If `archive` is true and `ecosystem.archived` is not null, MUST abort as `Ecosystem` is already archived.
+  - If `archive` is false and `ecosystem.archived` is null, MUST abort as `Ecosystem` is already not archived.
 
-###### [MOD-ES-MSG-5-2-2] Archive Trust Registry fee checks
+###### [MOD-ES-MSG-5-2-2] Archive Ecosystem fee checks
 
 Fee payer MUST have an available balance in its [[ref: account]] to cover the required [[ref: transaction fees]].
 
-##### [MOD-ES-MSG-5-3] Archive Trust Registry execution
+##### [MOD-ES-MSG-5-3] Archive Ecosystem execution
 
 If all precondition checks passed, method is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- update `TrustRegistry` entry `tr` with `ecosystem.id` equal to `id`:
+- update `Ecosystem` entry `tr` with `ecosystem.id` equal to `id`:
 - if `archived` is true: set `ecosystem.archived` to current timestamp.
 - if `archived` is false: set `ecosystem.archived` to null.
 - `ecosystem.modified`: current timestamp
@@ -2118,41 +2118,41 @@ for each parameter `param` <`key`, `value`> in `parameters`:
 
 - update parameter set value = `value` where key = `key`.
 
-#### [MOD-ES-QRY-1] Get Trust Registry
+#### [MOD-ES-QRY-1] Get Ecosystem
 
 Anyone CAN execute this method.
 
-##### [MOD-ES-QRY-1-1] Get Trust Registry parameters
+##### [MOD-ES-QRY-1-1] Get Ecosystem parameters
 
-- `id` (uint64) (*mandatory*): id of the [[ref: trust registry]].
+- `id` (uint64) (*mandatory*): id of the [[ref: ecosystem]].
 - `active_gf_only` (boolean) (*optional*): if true, include only current governance framework data. If false or null, returns everything.
 - `preferred_language` (string) (*optional*): if set, return only one document per version, with language=`preferred_language` when possible, else if no document exist with this language, return language. If not set, return all documents of all languages.
 
-##### [MOD-ES-QRY-1-2] Get Trust Registry checks
+##### [MOD-ES-QRY-1-2] Get Ecosystem checks
 
-##### [MOD-ES-QRY-1-3] Get Trust Registry execution
+##### [MOD-ES-QRY-1-3] Get Ecosystem execution
 
-return found `TrustRegistry` entry (if any), as well as *all its nested* `GovernanceFrameworkVersion` and `GovernanceFrameworkDocument` entries. If `active_gf_only` is true, return only nested `GovernanceFrameworkVersion` and `GovernanceFrameworkDocument` entries for the active version.
+return found `Ecosystem` entry (if any), as well as *all its nested* `GovernanceFrameworkVersion` and `GovernanceFrameworkDocument` entries. If `active_gf_only` is true, return only nested `GovernanceFrameworkVersion` and `GovernanceFrameworkDocument` entries for the active version.
 
-#### [MOD-ES-QRY-2] List Trust Registries
+#### [MOD-ES-QRY-2] List Ecosystems
 
-##### [MOD-ES-QRY-2-1] List Trust Registries query parameters
+##### [MOD-ES-QRY-2-1] List Ecosystems query parameters
 
 The following parameters are optional:
 
 - `corporation` (group) (*optional*): if specified, filter by corporation.
-- `modified_after` (timestamp) (*optional*): if specified, returns only `TrustRegistry` entries with `TrustRegistry.modified` greater than `modified`.
+- `modified_after` (timestamp) (*optional*): if specified, returns only `Ecosystem` entries with `Ecosystem.modified` greater than `modified`.
 - `active_gf_only` (boolean) (*optional*): if true, include only current governance framework data. If false or null, returns everything.
 - `preferred_language` (string) (*optional*): if set, return only one document per version, with language=`preferred_language` when possible, else if no document exist with this language, return language. If not set, return all documents of all languages.
 - `response_max_size` (small number) (*optional*): default to 64. Max 1,024.
 
-##### [MOD-ES-QRY-2-2] List Trust Registries query checks
+##### [MOD-ES-QRY-2-2] List Ecosystems query checks
 
 If any of these checks fail, [[ref: query]] MUST fail.
 
 - `response_max_size` must be between 1 and 1,024. Default to 64 if unspecified.
 
-##### [MOD-ES-QRY-2-3] List Trust Registries execution of the query
+##### [MOD-ES-QRY-2-3] List Ecosystems execution of the query
 
 If all precondition checks passed, [[ref: query]] is executed and result (may be empty) returned. If `modified_after` is specified, order by `modified` desc.
 
@@ -2193,7 +2193,7 @@ An [[ref: account]] that would like to create a [[ref: credential schema]] MUST 
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `ecosystem_id` id of the trust registry (*mandatory*);
+- `ecosystem_id` id of the ecosystem (*mandatory*);
 - `json_schema` the [[ref: Json Schema]] of the credential (*mandatory*).
 - `issuer_grantor_validation_validity_period` (*mandatory*), default to 0 (days).
 - `verifier_grantor_validation_validity_period` (*mandatory*), default to 0 (days).
@@ -2218,7 +2218,7 @@ If any of these precondition checks fail, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `ecosystem_id` MUST represent an existing `TrustRegistry` entry `tr` and `ecosystem.corporation` MUST be the `corporation` executing the method.
+- `ecosystem_id` MUST represent an existing `Ecosystem` entry `tr` and `ecosystem.corporation` MUST be the `corporation` executing the method.
 - `json_schema` MUST be a valid [[ref: Json Schema]], and size must not be greater than `GlobalVariables.credential_schema_schema_max_size`. `$id` of the [[ref: Json Schema]] is ignored and will be replaced during execution by the auto-generated id of this `CredentialSchema`.
 - `issuer_grantor_validation_validity_period` must be between 0 (never expire) and `GlobalVariables.credential_schema_issuer_grantor_validation_validity_period_max_days` days.
 - `verifier_grantor_validation_validity_period` must be between 0 (never expire) and `GlobalVariables.credential_schema_verifier_grantor_validation_validity_period_max_days` days.
@@ -2253,7 +2253,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - create and persist a new `CredentialSchema` entry `cs`:
 
   - `cs.id`: auto-incremented uint64.
-  - `cs.ecosystem_id`: id of the `TrustRegistry` entry that will be the owner of `cs`.
+  - `cs.ecosystem_id`: id of the `Ecosystem` entry that will be the owner of `cs`.
   - `cs.json_schema`: `json_schema`, with VPR_CREDENTIAL_SCHEMA_ID string replaced by generated `cs.id`, and then canonicalize it using the [JSON Canonicalization Scheme (JCS)](https://www.rfc-editor.org/rfc/rfc8785) as defined in RFC 8785. Schema MUST be saved canonized.
   - `cs.issuer_grantor_validation_validity_period`: `issuer_grantor_validation_validity_period`
   - `cs.verifier_grantor_validation_validity_period`: `verifier_grantor_validation_validity_period`
@@ -2270,7 +2270,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - `cs.digest_algorithm`: `digest_algorithm`
 
 :::note
-If needed, depending on configuration mode, Trust Registry controller MAY need to create a ECOSYSTEM `Permission` so that validation processes can be run.
+If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM `Participant` so that validation processes can be run.
 :::
 
 #### [MOD-CS-MSG-2] Update Credential Schema
@@ -2304,7 +2304,7 @@ If any of these precondition checks fail, method MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST represent an existing `CredentialSchema` entry `cs`.
-- load `TrustRegistry` `tr` from `cs.ecosystem_id`. `ecosystem.corporation` MUST be the `corporation` executing the method, else MUST abort.
+- load `Ecosystem` `tr` from `cs.ecosystem_id`. `ecosystem.corporation` MUST be the `corporation` executing the method, else MUST abort.
 - `issuer_grantor_validation_validity_period` MUST be between 0 (never expire) and `GlobalVariables.credential_schema_issuer_grantor_validation_validity_period_max_days` days.
 - `verifier_grantor_validation_validity_period` MUST be between 0 (never expire) and `GlobalVariables.credential_schema_verifier_grantor_validation_validity_period_max_days` days.
 - `issuer_validation_validity_period` MUST be between 0 (never expire) and `GlobalVariables.credential_schema_issuer_validation_validity_period_max_days` days.
@@ -2355,7 +2355,7 @@ If any of these precondition checks fail, method MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST represent an existing `CredentialSchema` entry `cs`.
-- load `TrustRegistry` `tr` from `cs.ecosystem_id`. `ecosystem.corporation` MUST be the `corporation` executing the method, else MUST abort.
+- load `Ecosystem` `tr` from `cs.ecosystem_id`. `ecosystem.corporation` MUST be the `corporation` executing the method, else MUST abort.
 - `archive` (boolean) (*mandatory*) MUST be a boolean. 
   - If `archive` is true and `cs.archived` is not null, MUST abort as Credential Schema is already archived.
   - If `archive` is false and `cs.archived` is null, MUST abort as Credential Schema is already not archived.
@@ -2555,7 +2555,7 @@ Method execution MUST perform the following task in a [[ref: transaction]]:
 
 ##### [MOD-CS-QRY-1-1] List Credential Schemas parameters
 
-- `ecosystem_id` (uint64) (*optional*): to filter by trust registry id.
+- `ecosystem_id` (uint64) (*optional*): to filter by ecosystem id.
 - `modified_after` (timestamp) (*optional*): show schemas modified after this timestamp.
 - `response_max_size` (small number) (*optional*): default to 64. Max 1,024.
 - `only_active` (boolean): if set to true, returns only not archived entries.
@@ -2701,9 +2701,9 @@ Returned entries MUST include at least the following fields:
 
 Entries MUST be ordered by ascending `version`.
 
-### Permission Module
+### Participant Module
 
-#### Permission Module Overview
+#### Participant Module Overview
 
 *This section is non-normative.*
 
@@ -2716,7 +2716,7 @@ scale max 800 width
  
 package "Example Credential Schema Permission Tree" as cs {
 
-    object "Trust Registry A" as tr #3fbdb6 {
+    object "Ecosystem A" as tr #3fbdb6 {
         permissionType: ECOSYSTEM (Root)
         did:example:trA
     }
@@ -2774,7 +2774,7 @@ In all cases, the process is very similar. Example execution of a validation pro
 2. Validation process requires that [[ref: applicant]] connects to a validation [[ref: VS]] identified by its [[ref: DID]], and execute a some validation steps, required for the validation process to conclude.
 3. If [[ref: applicant]] qualifies, [[ref: validator]] updates the validation entry by running the [set to validated] [[ref: transaction]], and [[ref: applicant]] is granted new permissions, and/or gets issued a credential.
 
-Validation is valid for a specific period, for example 365 days, as configured in the [[ref: credential schema]] for credential schema related validations, or set by trust registry for user-agent validation.
+Validation is valid for a specific period, for example 365 days, as configured in the [[ref: credential schema]] for credential schema related validations, or set by ecosystem for user-agent validation.
 
 :::note
 In some cases, even if the validation is valid for a period of time, the resulting created permission or issued credential might have a shorter expiration timestamp because the validated attribute(s) might expire before validation expiration: in this case, the [[ref: applicant]] must provide updated information to the [[ref: validator]] before attribute expiration, in order to get issued an updated new permission and/or an updated credential.
@@ -2789,27 +2789,27 @@ Some special unexpected situation may arise and must be mitigated. Examples:
 - if selected validator permission is revoked while applicant's validation is in PENDING state: Applicant CAN cancel the validation process [MOD-PP-MSG-6].
 - if selected validator permission is revoked while applicant is in VALIDATED state: Applicant CAN renew the validation process by choosing a new validator [MOD-PP-MSG-2].
 
-#### [MOD-PP-MSG-1] Start Permission VP
+#### [MOD-PP-MSG-1] Start Participant VP
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-PP-MSG-1-1] Start Permission VP parameters
+##### [MOD-PP-MSG-1-1] Start Participant VP parameters
 
 An Applicant that would like to start a permission validation process MUST execute this method by specifying:
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `vs_operator` (account) (*optional*): the account of the Veriable Service we want to authorize to create permission sessions linked to this permission. If not specified, Verifiable Service will not be able to use the payment delegation feature. **Required** to use the payment delegation feature.
-- `type` (PermissionType) (*mandatory*): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the permission that the applicant would like to get;
+- `type` (ParticipantRole) (*mandatory*): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the permission that the applicant would like to get;
 - `validator_participant_id` (uint64) (*mandatory*): the [[ref: validator]] permission (parent permission in the tree), chosen by the applicant.
 - `validation_fees` (number) (*optional*): Requested validation_fees for this permission (can be modified by validator).
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
 - `verification_fees` (number) (*optional*): Requested verification_fees for this permission (can be modified by validator).
 - `did` (string) (*required*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
 
-The following VS Operator Authorization parameters are **optional** and collectively define the initial [PermissionAuthorizationRecord](#permissionauthorizationrecord) that will be created for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode (the corporation signs and pays for its own permission-related transactions directly). VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
+The following VS Operator Authorization parameters are **optional** and collectively define the initial [ParticipantAuthorizationRecord](#participantauthorizationrecord) that will be created for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode (the corporation signs and pays for its own permission-related transactions directly). VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
 
-- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `PermissionAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified. The permitted list of message types is provided below.
+- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `ParticipantAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified. The permitted list of message types is provided below.
 - `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.
 - `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this permission.
 - `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
@@ -2820,8 +2820,8 @@ Permitted message types to be set in `vs_operator_authz_msg_types` depends on `t
 |Permission type|Permitted Messages|
 |-|-|
 | HOLDER | TriggerResolver |
-| ISSUER | CreateOrUpdatePermissionSession, SetPermissionVPtoValidated |
-| VERIFIER | CreateOrUpdatePermissionSession |
+| ISSUER | CreateOrUpdateParticipantSession, SetPermissionVPtoValidated |
+| VERIFIER | CreateOrUpdateParticipantSession |
 | ISSUER_GRANTOR | SetPermissionVPtoValidated |
 | VERIFIER_GRANTOR | SetPermissionVPtoValidated |
 | ECOSYSTEM | SetPermissionVPtoValidated |
@@ -2829,35 +2829,35 @@ Permitted message types to be set in `vs_operator_authz_msg_types` depends on `t
 
 Available compatible perms can be found by using an indexer and presented in a front-end so applicant can choose its validator.
 
-##### [MOD-PP-MSG-1-2] Start Permission VP precondition checks
+##### [MOD-PP-MSG-1-2] Start Participant VP precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-1-2-1] Start Permission VP basic checks
+###### [MOD-PP-MSG-1-2-1] Start Participant VP basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `type` (PermissionType) (*mandatory*) MUST be a valid PermissionType: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.
-- `validator_participant_id` (uint64) (*mandatory*): see [MOD-PP-MSG-1-2-2](#mod-pp-msg-1-2-2-start-permission-vp-permission-checks).
+- `type` (ParticipantRole) (*mandatory*) MUST be a valid ParticipantRole: ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER.
+- `validator_participant_id` (uint64) (*mandatory*): see [MOD-PP-MSG-1-2-2](#mod-pp-msg-1-2-2-start-participant-vp-permission-checks).
 - `validation_fees` (number) (*optional*): Requested validation_fees for this permission (can be modified by validator).
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
 - `verification_fees` (number) (*optional*): Requested verification_fees for this permission (can be modified by validator).
 - `did`, if specified, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
-- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-1-1](#mod-pp-msg-1-1-start-permission-vp-parameters).
+- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-1-1](#mod-pp-msg-1-1-start-participant-vp-parameters).
 
 :::note
 A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It's up to the issuer to decide if running the validation process is REQUIRED or not.
 :::
 
-###### [MOD-PP-MSG-1-2-2] Start Permission VP permission checks
+###### [MOD-PP-MSG-1-2-2] Start Participant VP permission checks
 
-- Load `Permission` entry `validator_participant` from `validator_participant_id`. It MUST be a [[ref: active permission]] else transaction MUST abort.
+- Load `Participant` entry `validator_participant` from `validator_participant_id`. It MUST be a [[ref: active permission]] else transaction MUST abort.
 - Load `CredentialSchema` entry `cs` from `validator_participant.schema_id`. It MUST exist.
 
-- if `type` (PermissionType) is equal to ISSUER:
+- if `type` (ParticipantRole) is equal to ISSUER:
 
   - if `cs.issuer_onboarding_mode` is equal to GRANTOR_VALIDATION_PROCESS: `validator_participant.role` MUST be ISSUER_GRANTOR, else MUST abort.
   
@@ -2865,13 +2865,13 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 
   - else MUST abort.
 
-- else if `type` (PermissionType) is equal to ISSUER_GRANTOR:
+- else if `type` (ParticipantRole) is equal to ISSUER_GRANTOR:
 
   - if `cs.issuer_onboarding_mode` is equal to GRANTOR_VALIDATION_PROCESS:  `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
   
   - else abort.
 
-- else if `type` (PermissionType) is equal to VERIFIER:
+- else if `type` (ParticipantRole) is equal to VERIFIER:
 
   - if `cs.verifier_onboarding_mode` is equal to GRANTOR: `validator_participant.role` MUST be VERIFIER_GRANTOR, else MUST abort.
   
@@ -2879,13 +2879,13 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 
   - else abort.
 
-- else if `type` (PermissionType) is equal to VERIFIER_GRANTOR:
+- else if `type` (ParticipantRole) is equal to VERIFIER_GRANTOR:
 
   - if `cs.verifier_onboarding_mode` is equal to GRANTOR_VALIDATION_PROCESS: `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
   
   - else abort.
 
-- else if `type` (PermissionType) is equal to HOLDER:
+- else if `type` (ParticipantRole) is equal to HOLDER:
 
   - if `cs.holder_onboarding_mode` is equal to ISSUER_VALIDATION_PROCESS: `validator_participant.role` MUST be ISSUER, else MUST abort.
   
@@ -2893,9 +2893,9 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 
 At the end, if a [[ ref: active permission]] `validator_participant` is not found, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-1-2-3] Start Permission VP fee checks
+###### [MOD-PP-MSG-1-2-3] Start Participant VP fee checks
 
-- Load `Permission` entry `validator_participant` from `validator_participant_id`.
+- Load `Participant` entry `validator_participant` from `validator_participant_id`.
 - Load `CredentialSchema` entry `cs` from `validator_participant.schema_id`.
 
 - Fee payer MUST have an available balance in its [[ref: account]], to cover the [[ref: estimated transaction fees]];
@@ -2932,7 +2932,7 @@ else if `(cs.pricing_asset_type, cs.pricing_asset)` is set to an arbitrary coin 
 Trust deposit MUST always be paid in [[ref: native denom]]
 :::
 
-###### [MOD-PP-MSG-1-2-4] Start Permission VP overlap checks
+###### [MOD-PP-MSG-1-2-4] Start Participant VP overlap checks
 
 We want to make sure that 2 validation processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different VP with differents validators for the same `schema_id`, `type`.
 
@@ -2942,13 +2942,13 @@ if size of `participants[]` > 0, it means there is already an existing validatio
 
 > note: this check was not present in v3.
 
-##### [MOD-PP-MSG-1-3] Start Permission VP execution
+##### [MOD-PP-MSG-1-3] Start Participant VP execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- Load `Permission` entry `validator_participant` of the selected validator.
+- Load `Participant` entry `validator_participant` of the selected validator.
 
 - calculate `validation_fees_in_denom` and `validation_trust_deposit_in_native_denom` as explained above in fee checks.
 - use [MOD-TD-MSG-1] to increase by `validation_trust_deposit_in_native_denom` the [[ref: trust deposit]] of `corporation` running the method and transfer the corresponding amount to `TrustDeposit` module.
@@ -2977,7 +2977,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - `applicant_participant.vp_summary_digest`: null.
   - `applicant_participant.vp_validator_deposit`: 0.
 
-If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizationRecord](#permissionauthorizationrecord) in **disabled** state (`expiration = now`) by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
+If `vs_operator_authz_msg_types` is provided, create the [ParticipantAuthorizationRecord](#participantauthorizationrecord) in **disabled** state (`expiration = now`) by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
 
 - `corporation`: `corporation`
 - `vs_operator`: `vs_operator`
@@ -2990,7 +2990,7 @@ If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizatio
   - `record.expiration`: `now`
   - `record.period`: `vs_operator_authz_period`
 
-> Note: the record is created with `expiration = now` so authorization is **not yet active**. [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) will reject any attempt to use it until [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-permission-vp-to-validated) updates `expiration` to `applicant_participant.effective_until`. No on-chain `FeeGrant` object is created at this stage even if `with_feegrant` is true (the recompute subroutine in [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) requires `expiration > now`).
+> Note: the record is created with `expiration = now` so authorization is **not yet active**. [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks) will reject any attempt to use it until [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-vp-to-validated) updates `expiration` to `applicant_participant.effective_until`. No on-chain `FeeGrant` object is created at this stage even if `with_feegrant` is true (the recompute subroutine in [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) requires `expiration > now`).
 
 #### Connecting to the VS of the Validator
 
@@ -3017,7 +3017,7 @@ The [[ref: validator]] may compile a summary file of the validation process, doc
 
 For audit or governance purposes, the [[ref: validator]] should register a digest (e.g., hash or SRI) of this summary in `applicant_participant.vp_summary_digest`.
 
-#### [MOD-PP-MSG-2] Renew Permission VP
+#### [MOD-PP-MSG-2] Renew Participant VP
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
@@ -3029,17 +3029,17 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 - Renewal does not allow changing the `participant.validation_fees`, `participant.issuance_fees`, `participant.verification_fees`. To change these values, applicant MUST start a new validation process.
 - if permission is revoked, slashed, or repaid, method MUST fail.
 
-##### [MOD-PP-MSG-2-1] Renew Permission VP parameters
+##### [MOD-PP-MSG-2-1] Renew Participant VP parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission for which applicant would like to renew the validation process;
 
-##### [MOD-PP-MSG-2-2] Renew Permission VP precondition checks
+##### [MOD-PP-MSG-2-2] Renew Participant VP precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-2-2-1] Renew Permission VP basic checks
+###### [MOD-PP-MSG-2-2-1] Renew Participant VP basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3048,14 +3048,14 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64 and a permission entry with the same id MUST exist.
 
-###### [MOD-PP-MSG-2-2-2] Renew Permission VP permission checks
+###### [MOD-PP-MSG-2-2-2] Renew Participant VP permission checks
 
-- Load `Permission` entry `applicant_participant`. `corporation` running the operation MUST be `applicant_participant.corporation`, else MUST abort. `applicant_participant` MUST be a [[ref: active permission]].
-- Load `Permission` entry `validator_participant` from `applicant_participant.validator_participant_id`. It MUST exist, and be a [[ref: active permission]], else MUST abort.
+- Load `Participant` entry `applicant_participant`. `corporation` running the operation MUST be `applicant_participant.corporation`, else MUST abort. `applicant_participant` MUST be a [[ref: active permission]].
+- Load `Participant` entry `validator_participant` from `applicant_participant.validator_participant_id`. It MUST exist, and be a [[ref: active permission]], else MUST abort.
 
-###### [MOD-PP-MSG-2-2-3] Renew Permission VP fee checks
+###### [MOD-PP-MSG-2-2-3] Renew Participant VP fee checks
 
-- Load `Permission` entry `validator_participant` from `applicant_participant.validator_participant_id`.
+- Load `Participant` entry `validator_participant` from `applicant_participant.validator_participant_id`.
 - Load `CredentialSchema` entry `cs` from `validator_participant.schema_id`.
 
 - Fee payer MUST have an available balance in its [[ref: account]], to cover the [[ref: estimated transaction fees]];
@@ -3092,14 +3092,14 @@ else if `(cs.pricing_asset_type, cs.pricing_asset)` is set to an arbitrary coin 
 Trust deposit MUST always be paid in [[ref: native denom]]
 :::
 
-###### [MOD-PP-MSG-2-3] Renew Permission VP execution
+###### [MOD-PP-MSG-2-3] Renew Participant VP execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- Load `Permission` entry `applicant_participant`. 
-- Load `Permission` entry `validator_participant` from `applicant_participant.validator_participant_id`.
+- Load `Participant` entry `applicant_participant`. 
+- Load `Participant` entry `validator_participant` from `applicant_participant.validator_participant_id`.
 
 - calculate `validation_fees_in_denom` and `validation_trust_deposit_in_native_denom` as explained above in fee checks.
 - use [MOD-TD-MSG-1] to increase by `validation_trust_deposit_in_native_denom` the [[ref: trust deposit]] of `corporation` running the method and transfer the corresponding amount to `TrustDeposit` module.
@@ -3116,18 +3116,18 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - `applicant_participant.vp_current_deposit` (number): `validation_trust_deposit_in_native_denom`.
   - `applicant_participant.modified`: `now`
 
-#### [MOD-PP-MSG-3] Set Permission VP to Validated
+#### [MOD-PP-MSG-3] Set Participant VP to Validated
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-##### [MOD-PP-MSG-3-1] Set Permission VP to Validated parameters
+##### [MOD-PP-MSG-3-1] Set Participant VP to Validated parameters
 
 An [[ref: account]] that would like to set a validation entry to VALIDATED MUST execute this method by specifying:
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the validation process;
-- `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this `Permission` is effective, null if no time limit should been set for this permission or if we want it to be aligned with the validation process expiration timestamp calculated by this method.
+- `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this `Participant` is effective, null if no time limit should been set for this permission or if we want it to be aligned with the validation process expiration timestamp calculated by this method.
 - `validation_fees` (number) (*mandatory*): Agreed validation_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
 - `issuance_fees` (number) (*mandatory*): Agreed issuance_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
 - `verification_fees` (number) (*mandatory*): Agreed verification_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
@@ -3135,19 +3135,19 @@ An [[ref: account]] that would like to set a validation entry to VALIDATED MUST 
 - `issuance_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_VALIDATION_PROCESS mode) or an ISSUER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 - `verification_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_VALIDATION_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 
-##### [MOD-PP-MSG-3-2] Set Permission VP to Validated precondition checks
+##### [MOD-PP-MSG-3-2] Set Participant VP to Validated precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-3-2-1] Set Permission VP to Validated basic checks
+###### [MOD-PP-MSG-3-2-1] Set Participant VP to Validated basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `applicant_participant` from `id`. If no entry found, abort.
-- Load `Permission` entry `validator_participant` from `applicant_participant_validator_participant_id`.
+- Load `Participant` entry `applicant_participant` from `id`. If no entry found, abort.
+- Load `Participant` entry `validator_participant` from `applicant_participant_validator_participant_id`.
 - Authorization:
 
 either (executed by any operator of corporation):
@@ -3165,7 +3165,7 @@ else MUST abort.
 - `vp_summary_digest` (string) (*optional*): MUST be null if `validation.type` is set to HOLDER (for HOLDER, proofs can be stored in credentials). Else, MUST be a valid digest. Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
 
 - Load `CredentialSchema` `cs` from `applicant_participant.schema_id`.
-- Load `Permission` `validator_participant` from `applicant_participant.validator_participant_id`.
+- Load `Participant` `validator_participant` from `applicant_participant.validator_participant_id`.
 
 - `issuance_fee_discount` : (number) (*mandatory*):
   - if `applicant_participant.effective_from` is not null (renewal), then `issuance_fee_discount` must be equal to `applicant_participant.issuance_fee_discount` else MUST abort.
@@ -3199,25 +3199,25 @@ Now, let's verify `effective_until`:
 - else if `applicant_participant.effective_until` is NULL, `effective_until` MUST be greater than current current timestamp AND, if `vp_exp` is not null, lower or equal to `vp_exp`.
 - else `effective_until` MUST be greater than `applicant_participant.effective_until` AND, if `vp_exp` is not null, lower or equal to `vp_exp`.
 
-###### [MOD-PP-MSG-3-2-2] Set Permission VP to Validated validator perms
+###### [MOD-PP-MSG-3-2-2] Set Participant VP to Validated validator perms
 
 - load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active permission]].
 - `corporation` running the method MUST be `validator_participant.corporation`.
 
 If `validator_participant` is not a [[ ref: active permission]] (expired, revoked, slashed...) then applicant MUST start a new validation process.
 
-###### [MOD-PP-MSG-3-2-3] Set Permission VP to Validated fee checks
+###### [MOD-PP-MSG-3-2-3] Set Participant VP to Validated fee checks
 
 - Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 - if `applicant_participant.vp_current_fees` is not in [[ref: native denom]], `corporation` account MUST have `applicant_participant.vp_current_deposit` available in [[ref: native denom]] on its account for paying the trust deposit.
 
-###### [MOD-PP-MSG-3-2-4] Set Permission VP to Validated overlap checks
+###### [MOD-PP-MSG-3-2-4] Set Participant VP to Validated overlap checks
 
 We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. That should not occur in this method, but better do the check anyway.
 
 Find all [[ref: active permissions]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_participant_id`, `corporation`.
 
-for each `Permission` entry `p` from `participants[]`:
+for each `Participant` entry `p` from `participants[]`:
 
 - if `p.effective_until` is greater than `effective_from`, method execution MUST abort.
 - if `p.effective_from` is lower than `effective_until`, method execution MUST abort.
@@ -3225,14 +3225,14 @@ for each `Permission` entry `p` from `participants[]`:
 
 > note: this check was not present in v3.
 
-##### [MOD-PP-MSG-3-3] Set Permission VP to Validated execution
+##### [MOD-PP-MSG-3-3] Set Participant VP to Validated execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- Load `Permission` entry `applicant_participant` from `id`.
-- Load `Permission` entry `validator_participant` from `applicant_participant.validator_participant_id`.
+- Load `Participant` entry `applicant_participant` from `id`.
+- Load `Participant` entry `validator_participant` from `applicant_participant.validator_participant_id`.
 - define `now` timestamp of now().
 
 Calculate `vp_exp`:
@@ -3264,7 +3264,7 @@ Fees and Trust Deposits:
 
 > Important: if `applicant_participant.vp_current_fees` is not in [[ref: native denom]], `corporation` account MUST have `applicant_participant.vp_current_deposit` available for paying the trust deposit.
 
-Update `Permission` `applicant_participant`:
+Update `Participant` `applicant_participant`:
 
 - set `applicant_participant.modified` to `now`.
 - set `applicant_participant.vp_state` to VALIDATED.
@@ -3287,29 +3287,29 @@ Activate VS Operator Authorization, if any. Call [[MOD-DE-MSG-9]](#mod-de-msg-9-
 - `participant_id`: `applicant_participant.id`
 - `new_expiration`: `applicant_participant.effective_until`
 
-This call is a no-op if no record was created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) (i.e., the applicant did not declare `vs_operator_authz_msg_types`). If a record exists, its `expiration` is updated from `now` (disabled) to `applicant_participant.effective_until`, and the on-chain `FeeGrant` for the containing VSOA is granted for the first time (or refreshed) via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance).
+This call is a no-op if no record was created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp) (i.e., the applicant did not declare `vs_operator_authz_msg_types`). If a record exists, its `expiration` is updated from `now` (disabled) to `applicant_participant.effective_until`, and the on-chain `FeeGrant` for the containing VSOA is granted for the first time (or refreshed) via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance).
 
 #### [MOD-PP-MSG-4] Void
 
 #### [MOD-PP-MSG-5] Void
 
-#### [MOD-PP-MSG-6] Cancel Permission VP Last Request
+#### [MOD-PP-MSG-6] Cancel Participant VP Last Request
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 At any time, [[ref: applicant]] of a permission validation process may request cancellation of the process, provided state is PENDING. Upon method execution, the pending validation is cancelled and escrewed [[ref: trust fees]] are refunded. If `vp_exp` is not null, `vp_state` is set back to VALIDATED, else `vp_state` is set to TERMINATED.
 
-##### [MOD-PP-MSG-6-1] Cancel Permission VP Last Request parameters
+##### [MOD-PP-MSG-6-1] Cancel Participant VP Last Request parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): id of the `Permission` entry;
+- `id` (uint64) (*mandatory*): id of the `Participant` entry;
 
-##### [MOD-PP-MSG-6-2] Cancel Permission VP Last Request precondition checks
+##### [MOD-PP-MSG-6-2] Cancel Participant VP Last Request precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-6-2-1] Cancel Permission VP Last Request basic checks
+###### [MOD-PP-MSG-6-2-1] Cancel Participant VP Last Request basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3317,22 +3317,22 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `applicant_participant` with this id. It MUST exist.
+- Load `Participant` entry `applicant_participant` with this id. It MUST exist.
 - `corporation` running the [[ref: transaction]] MUST be `applicant_participant.corporation`.
 - `applicant_participant.vp_state` MUST be PENDING.
 - if `applicant_participant.deposit` has been slashed and not repaid, MUST abort
 
-###### [MOD-PP-MSG-6-2-2] Cancel Permission VP Last Request fee checks
+###### [MOD-PP-MSG-6-2-2] Cancel Participant VP Last Request fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 
-##### [MOD-PP-MSG-6-3] Cancel Permission VP Last Request execution
+##### [MOD-PP-MSG-6-3] Cancel Participant VP Last Request execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- Load `Permission` entry `applicant_participant` with `id`. It MUST exist.
+- Load `Participant` entry `applicant_participant` with `id`. It MUST exist.
 - define `now`: current timestamp.
 
 - set `applicant_participant.modified` to `now`.
@@ -3346,17 +3346,17 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - call [MOD-TD-MSG-1] to reduce trust deposit of `applicant_participant.corporation` by `applicant_participant.vp_current_deposit`
   - set `applicant_participant.vp_current_deposit` to 0.
 
-If `applicant_participant.vp_state` was set to TERMINATED (i.e. `applicant_participant.vp_exp` was null so validation never completed), call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any disabled authorization record created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp). The call is a no-op if no record exists. If `applicant_participant.vp_state` was set back to VALIDATED, no VSOA changes are needed (the existing record's `expiration` remains at the value set by the previous successful validation).
+If `applicant_participant.vp_state` was set to TERMINATED (i.e. `applicant_participant.vp_exp` was null so validation never completed), call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any disabled authorization record created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp). The call is a no-op if no record exists. If `applicant_participant.vp_state` was set back to VALIDATED, no VSOA changes are needed (the existing record's `expiration` remains at the value set by the previous successful validation).
 
-#### [MOD-PP-MSG-7] Create Root Permission
+#### [MOD-PP-MSG-7] Create Root Participant
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-This method is used by controller authorities of Trust Registries. When they create a Credential Schema, they need to create (a) permission(s) of type ECOSYSTEM so that other participants can run validation processes (if schema mode is ECOSYSTEM) or self create their permissions (schema mode set to OPEN).
+This method is used by controller authorities of Ecosystems. When they create a Credential Schema, they need to create (a) permission(s) of type ECOSYSTEM so that other participants can run validation processes (if schema mode is ECOSYSTEM) or self create their permissions (schema mode set to OPEN).
 
-##### [MOD-PP-MSG-7-1] Create Root Permission parameters
+##### [MOD-PP-MSG-7-1] Create Root Participant parameters
 
-An [[ref: account]] that would like to create a `Permission` entry MUST call this method by specifying:
+An [[ref: account]] that would like to create a `Participant` entry MUST call this method by specifying:
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
@@ -3369,25 +3369,25 @@ An [[ref: account]] that would like to create a `Permission` entry MUST call thi
 - `issuance_fees` (number) (*mandatory*): price to pay by the issuer of a credential of this schema to the grantee of this perm when a credential is issued, in the denom specified in the credential schema. Default to 0.
 - `verification_fees` (number) (*mandatory*): price to pay by the verifier of a credential of this schema to the grantee of this perm when a credential is verified, in the denom specified in the credential schema. Default to 0.
 
-The following VS Operator Authorization parameters are **optional** and collectively define the initial [PermissionAuthorizationRecord](#permissionauthorizationrecord) for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
+The following VS Operator Authorization parameters are **optional** and collectively define the initial [ParticipantAuthorizationRecord](#participantauthorizationrecord) for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
 
-- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `PermissionAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified. The permitted list of message types is provided below.
+- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `ParticipantAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified. The permitted list of message types is provided below.
 - `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.
 - `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this permission.
 - `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
 - `vs_operator_authz_period` (duration) (*optional*): reset period for `vs_operator_authz_spend_limit` and `vs_operator_authz_fee_spend_limit` in the context of this permission.
 
-Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`. Since [Create Root Permission](#mod-pp-msg-7-create-root-permission) always creates an ECOSYSTEM permission, only the following is allowed:
+Permitted message types to be set in `vs_operator_authz_msg_types` depends on `type`. Since [Create Root Participant](#mod-pp-msg-7-create-root-participant) always creates an ECOSYSTEM permission, only the following is allowed:
 
 |Permission type|Permitted Messages|
 |-|-|
 | ECOSYSTEM | SetPermissionVPtoValidated |
 
-##### [MOD-PP-MSG-7-2] Create Root Permission precondition checks
+##### [MOD-PP-MSG-7-2] Create Root Participant precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-7-2-1] Create Root Permission basic checks
+###### [MOD-PP-MSG-7-2-1] Create Root Participant basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3401,30 +3401,30 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `validation_fees` (number) (*mandatory*): MUST be >= 0.
 - `issuance_fees` (number) (*mandatory*): MUST be >= 0.
 - `verification_fees` (number) (*mandatory*): MUST be >= 0.
-- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-7-1](#mod-pp-msg-7-1-create-root-permission-parameters).
+- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-7-1](#mod-pp-msg-7-1-create-root-participant-parameters).
 
-###### [MOD-PP-MSG-7-2-2] Create Root Permission permission checks
+###### [MOD-PP-MSG-7-2-2] Create Root Participant permission checks
 
 To execute this method, [[ref: account]] MUST match at least one these rules, else [[ref: transaction]] MUST abort.
 
 - The related `CredentialSchema` entry is loaded with `schema_id`, and will be named `cs` in this section.
-- The related `TrustRegistry` entry `tr` is loaded from `cs.ecosystem_id`.
+- The related `Ecosystem` entry `tr` is loaded from `cs.ecosystem_id`.
 - `corporation` executing the method MUST be `ecosystem.corporation`.
 - else MUST abort.
 
-###### [MOD-PP-MSG-7-2-3] Create Root Permission fee checks
+###### [MOD-PP-MSG-7-2-3] Create Root Participant fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
-###### [MOD-PP-MSG-7-2-4] Create Root Permission overlap checks
+###### [MOD-PP-MSG-7-2-4] Create Root Participant overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-permission) to set or adjust the `effective_until` value.
+We want to make sure that 2 permissions cannot be active at the same time. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-participant) to set or adjust the `effective_until` value.
 
 Find all [[ref: active permissions]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, ECOSYSTEM,  `corporation`.
 
 > Note: unlike overlap checks from other methods, here we do not need to check for `validator_participant_id`, as for ECOSYSTEM type permissions it is NULL.
 
-for each `Permission` entry `p` from `participants[]`:
+for each `Participant` entry `p` from `participants[]`:
 
 - if `p.effective_until` is greater than `effective_from`, method execution MUST abort.
 - if `p.effective_from` is lower than `effective_until`, method execution MUST abort.
@@ -3432,7 +3432,7 @@ for each `Permission` entry `p` from `participants[]`:
 
 > note: this check was not present in v3.
 
-##### [MOD-PP-MSG-7-3] Create Root Permission execution
+##### [MOD-PP-MSG-7-3] Create Root Participant execution
 
 If all precondition checks passed, method is executed.
 
@@ -3440,7 +3440,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - define `now`: current timestamp.
 
-A new entry `Permission` `perm` MUST be created:
+A new entry `Participant` `perm` MUST be created:
 
 - `participant.id`: auto-incremented uint64.
 - `participant.schema_id`: `schema_id`.
@@ -3457,7 +3457,7 @@ A new entry `Permission` `perm` MUST be created:
 - `participant.verification_fees`: `verification_fees`
 - `participant.deposit`: 0
 
-If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizationRecord](#permissionauthorizationrecord) in **active** state by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
+If `vs_operator_authz_msg_types` is provided, create the [ParticipantAuthorizationRecord](#participantauthorizationrecord) in **active** state by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
 
 - `corporation`: `corporation`
 - `vs_operator`: `vs_operator`
@@ -3470,9 +3470,9 @@ If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizatio
   - `record.expiration`: `participant.effective_until`
   - `record.period`: `vs_operator_authz_period`
 
-> Note: like [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission), the record is created with `expiration = participant.effective_until` and is therefore immediately active. If `with_feegrant` is true and `participant.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
+> Note: like [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant), the record is created with `expiration = participant.effective_until` and is therefore immediately active. If `with_feegrant` is true and `participant.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
 
-#### [MOD-PP-MSG-8] Adjust Permission
+#### [MOD-PP-MSG-8] Adjust Participant
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
@@ -3482,18 +3482,18 @@ This method can be called:
 - by `participant.corporation`, if it is a self-created permission (schema configuration is open)
 - by a `corporation` of a validator permission (if permission is managed by a VP).
 
-##### [MOD-PP-MSG-8-1] Adjust Permission parameters
+##### [MOD-PP-MSG-8-1] Adjust Participant parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
-- `effective_until` (timestamp) (*mandatory*): timestamp until when (exclusive) this `Permission` will be effective.
+- `effective_until` (timestamp) (*mandatory*): timestamp until when (exclusive) this `Participant` will be effective.
 
-##### [MOD-PP-MSG-8-2] Adjust Permission precondition checks
+##### [MOD-PP-MSG-8-2] Adjust Participant precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-8-2-1] Adjust Permission basic checks
+###### [MOD-PP-MSG-8-2-1] Adjust Participant basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3501,14 +3501,14 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `applicant_participant` from `id`. If no entry found, abort.
+- Load `Participant` entry `applicant_participant` from `id`. If no entry found, abort.
 - `applicant_participant` MUST be a [[ref: active permission]]
 - `applicant_participant.effective_until` MUST be greater than now().
 - else MUST abort.
 
 > Note: This method can be used to both Extend or Reduce the `effective_until`, or set an `effective_until` if it was null,  which was not the case in spec v3.
 
-###### [MOD-PP-MSG-8-2-2] Adjust Permission advanced checks
+###### [MOD-PP-MSG-8-2-2] Adjust Participant advanced checks
 
 1. ECOSYSTEM permissions
 
@@ -3523,17 +3523,17 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `effective_until` MUST be lower or equal to `applicant_participant.vp_exp` else MUST abort.
 - load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active permission]]. `corporation` running the method MUST be `validator_participant.corporation`.
 
-###### [MOD-PP-MSG-8-2-3] Adjust Permission fee checks
+###### [MOD-PP-MSG-8-2-3] Adjust Participant fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-8-2-4] Adjust Permission overlap checks
+###### [MOD-PP-MSG-8-2-4] Adjust Participant overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-permission) to set or adjust the `effective_until` value.
+We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-participant) to set or adjust the `effective_until` value.
 
 Find all [[ref: active permissions]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `type`, `validator_participant_id`, `corporation`.
 
-for each `Permission` entry `p` from `participants[]`:
+for each `Participant` entry `p` from `participants[]`:
 
 - if `p.effective_until` is greater than `effective_from`, method execution MUST abort.
 - if `p.effective_from` is lower than `effective_until`, method execution MUST abort.
@@ -3541,7 +3541,7 @@ for each `Permission` entry `p` from `participants[]`:
 
 > note: this check was not present in v3.
 
-##### [MOD-PP-MSG-8-3] Adjust Permission execution
+##### [MOD-PP-MSG-8-3] Adjust Participant execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -3549,7 +3549,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - define `now`: current timestamp.
 
-- Load `Permission` entry `applicant_participant` from `id`.
+- Load `Participant` entry `applicant_participant` from `id`.
 - set `applicant_participant.effective_until` to `effective_until`
 - set `applicant_participant.adjusted` to `now`
 - set `applicant_participant.modified` to `now`
@@ -3560,9 +3560,9 @@ Synchronise VS Operator Authorization expiration, if any. Call [[MOD-DE-MSG-9]](
 - `participant_id`: `applicant_participant.id`
 - `new_expiration`: `applicant_participant.effective_until`
 
-This call is a no-op if no record exists for `applicant_participant.id`. If a record exists, its `expiration` is updated and the on-chain `FeeGrant` for the containing VSOA is refreshed via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance). Adjust Permission does **not** accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-permission)). Adjust also cannot create a record that does not already exist.
+This call is a no-op if no record exists for `applicant_participant.id`. If a record exists, its `expiration` is updated and the on-chain `FeeGrant` for the containing VSOA is refreshed via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance). Adjust Participant does **not** accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant)). Adjust also cannot create a record that does not already exist.
 
-#### [MOD-PP-MSG-9] Revoke Permission
+#### [MOD-PP-MSG-9] Revoke Participant
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
@@ -3570,19 +3570,19 @@ This method can only be called:
 
 - by an ancestor (`corporation` of a validator in the permission branch until the root permission (GRANTOR, ECOSYSTEM, OPEN schema mode)).
 - by the grantee `corporation` (OPEN, GRANTOR, ECOSYSTEM schema mode).
-- by the `TrustRegistry` `corporation` (owner of the credential schema).
+- by the `Ecosystem` `corporation` (owner of the credential schema).
 
-##### [MOD-PP-MSG-9-1] Revoke Permission parameters
+##### [MOD-PP-MSG-9-1] Revoke Participant parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
 
-##### [MOD-PP-MSG-9-2] Revoke Permission precondition checks
+##### [MOD-PP-MSG-9-2] Revoke Participant precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-9-2-1] Revoke Permission basic checks
+###### [MOD-PP-MSG-9-2-1] Revoke Participant basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3590,10 +3590,10 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `applicant_participant` from `id`. If no entry found, abort.
+- Load `Participant` entry `applicant_participant` from `id`. If no entry found, abort.
 - `applicant_participant` MUST be a [[ref: active permission]]
 
-###### [MOD-PP-MSG-9-2-2] Revoke Permission advanced checks
+###### [MOD-PP-MSG-9-2-2] Revoke Participant advanced checks
 
 Either Option #1, #2 or #3 MUST return true, else abort.
 
@@ -3608,10 +3608,10 @@ if `applicant_participant.validator_participant_id` is defined:
 - end
 - return false.
 
-*Option #2*: executed by `TrustRegistry` controller
+*Option #2*: executed by `Ecosystem` controller
 
 - load `CredentialSchema` `cs` from `applicant_participant.schema_id`
-- load `TrustRegistry` `tr` from `cs.ecosystem_id`
+- load `Ecosystem` `tr` from `cs.ecosystem_id`
 - if `corporation` running the method is `ecosystem.corporation`, return true.
 - else return false.
 
@@ -3624,7 +3624,7 @@ In the following permission tree, "Verifier E" permission can be revoked:
 - by "Verifier E", if the corresponding permission is a [[ref: active permission]];
 - by "Verifier Grantor D", if the corresponding permission is a [[ref: active permission]];
 - by "Ecosystem A", if the corresponding root permission is a [[ref: active permission]];
-- by the `TrustRegistry` object controller, obtained by resolving perm => credential schema => trust registry.
+- by the `Ecosystem` object controller, obtained by resolving perm => credential schema => ecosystem.
 
 ```plantuml
 
@@ -3673,11 +3673,11 @@ issuer --> holder: granted schema permission
 
 ```
 
-###### [MOD-PP-MSG-9-2-3] Revoke Permission fee checks
+###### [MOD-PP-MSG-9-2-3] Revoke Participant fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 
-##### [MOD-PP-MSG-9-3] Revoke Permission execution
+##### [MOD-PP-MSG-9-3] Revoke Participant execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -3685,17 +3685,17 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - define `now`: current timestamp.
 
-- Load `Permission` entry `applicant_participant` from `id`.
+- Load `Participant` entry `applicant_participant` from `id`.
 - set `applicant_participant.revoked` to `now`
 - set `applicant_participant.modified` to `now`
 
 Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any authorization record for this permission. The call is a no-op if no record exists.
 
-#### [MOD-PP-MSG-10] Create or Update Permission Session
+#### [MOD-PP-MSG-10] Create or Update Participant Session
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-Any credential exchange that requires issuer or verifier to pay fees, register a digest_sri, or produce a proof implies the creation of a `PermissionSession`.
+Any credential exchange that requires issuer or verifier to pay fees, register a digest_sri, or produce a proof implies the creation of a `ParticipantSession`.
 
 If the peer wants to issue a credential, the `agent`, the Verifiable User Agent or Verifiable Service that receive the request MUST send to peer:
 
@@ -3734,20 +3734,20 @@ Issued <-- Issued: Store credential in wallet agent
 
 See [[ref: VT spec]].
 
-##### [MOD-PP-MSG-10-1] Create or Update Permission Session parameters
+##### [MOD-PP-MSG-10-1] Create or Update Participant Session parameters
 
-An [[ref: account]] that would like to create or update a `PermissionSession` entry MUST send a Msg by specifying:
+An [[ref: account]] that would like to create or update a `ParticipantSession` entry MUST send a Msg by specifying:
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uuid) (*mandatory*): id of the `PermissionSession`.
+- `id` (uuid) (*mandatory*): id of the `ParticipantSession`.
 - `issuer_participant_id` (uint64) (*optional*): the id of the perm of the issuer, if we are dealing with the issuance of a credential.
 - `verifier_participant_id` (uint64) (*optional*): the id of the perm of the verifier, if we are dealing with the verification of a credential.
 - `agent_participant_id` (uint64) (*optional*): the agent credential issuer permission id (extracted from the agent credential that VUA has in its wallet) of the agent that received the request (credential offer for issuance, presentation request for verification). Only set by VUAs, MUST NOT be specified when peer is a VS.
 - `wallet_agent_participant_id` (uint64) (*optional*): the wallet credential issuer permission id of the VUA where the credential will be or is stored. Can be the same perm than `agent_participant_id` if agent and wallet_agent are the same agent. Only set by VUAs, MUST NOT be specified when peer is a VS.
 - `digest` (string) (*optional*): digest derived from an issued or verified credential.
 
-##### [MOD-PP-MSG-10-2] Create or Update Permission Session precondition checks
+##### [MOD-PP-MSG-10-2] Create or Update Participant Session precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
@@ -3799,7 +3799,7 @@ wallet_agent:
 we might want to check that credential schema of agent and wallet_agent perms is an Essential Credential Schema of type UserAgent. At the moment there is no way of doing it. We consider User Agent will not report a permission that is not controlled by its owner.
 :::
 
-###### [MOD-PP-MSG-10-3] Create or Update Permission Session fee checks
+###### [MOD-PP-MSG-10-3] Create or Update Participant Session fee checks
 
 - Load `CredentialSchema` entry `cs` from `issuer_participant.schema_id` if `issuer_participant` is not null, else from `verifier_participant.schema_id`.
 - Fee payer MUST have sufficient available balance for the required [[ref: estimated transaction fees]].
@@ -3960,7 +3960,7 @@ Required balance check:
 - When paying with COIN ≠ [[ref: native denom]] or with FIAT, payer pays trust deposits on behalf of payees (since payees receive non-native assets that cannot be directly staked).
 :::
 
-##### [MOD-PP-MSG-10-4] Create or Update Permission Session execution
+##### [MOD-PP-MSG-10-4] Create or Update Participant Session execution
 
 If all precondition checks passed, method is executed.
 
@@ -4096,7 +4096,7 @@ If `wallet_agent_participant_id` is set AND `accumulated_wallet_agent_reward` > 
 
 > Now that all transfers have been done, we can create the entries
 
-Create a `PermissionSessionRecord` `cspsr`:
+Create a `ParticipantSessionRecord` `cspsr`:
 
 - `cspsr.created`: `now`
 - `cspsr.issuer_participant_id`: `issuer_participant_id`
@@ -4104,7 +4104,7 @@ Create a `PermissionSessionRecord` `cspsr`:
 - `cspsr.agent_participant_id`: `agent_participant_id`
 - `cspsr.wallet_agent_participant_id`: `wallet_agent_participant_id`
 
-If new, create entry `PermissionSession` `session`:
+If new, create entry `ParticipantSession` `session`:
 
 - `session.id`: `id`
 - `session.corporation`: `corporation`
@@ -4124,29 +4124,29 @@ if current transaction if for issuance of a credential, persist the digest SRI b
 `session.authz[]` can contain null `issuer_participant_id` OR `verifier_participant_id`
 :::
 
-#### [MOD-PP-MSG-11] Update Permission Module Parameters
+#### [MOD-PP-MSG-11] Update Participant Module Parameters
 
-Update Permission Module Parameters.
+Update Participant Module Parameters.
 
 Can only be executed through a governance proposal.
 
-##### [MOD-PP-MSG-11-1] Update Permission Module Parameters parameters
+##### [MOD-PP-MSG-11-1] Update Participant Module Parameters parameters
 
 - `params` (KeySet<String, String>): the parameters to update and their values.
 
-##### [MOD-PP-MSG-11-2] Update Permission Module Parameters precondition checks
+##### [MOD-PP-MSG-11-2] Update Participant Module Parameters precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-11-2-1] Update Permission Module Parameters basic checks
+###### [MOD-PP-MSG-11-2-1] Update Participant Module Parameters basic checks
 
 - `params`: size of `params` MUST be greater than 0. For each `param` <`key`, `value`> `key` MUST exist, else abort.
 
-###### [MOD-PP-MSG-11-2-2] Update Permission Module Parameters fee checks
+###### [MOD-PP-MSG-11-2-2] Update Participant Module Parameters fee checks
 
 provided transaction fees MUST be sufficient for execution
 
-##### [MOD-PP-MSG-11-3] Update Permission Module Parameters execution
+##### [MOD-PP-MSG-11-3] Update Participant Module Parameters execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -4156,25 +4156,25 @@ for each parameter `param` <`key`, `value`> in `parameters`:
 
 - update parameter set value = `value` where key = `key`.
 
-#### [MOD-PP-MSG-12] Slash Permission Trust Deposit
+#### [MOD-PP-MSG-12] Slash Participant Trust Deposit
 
 This method can only be called by either:
 
 - a `corporation` ancestor validator of this permission;
-- the `corporation` controller of the `TrustRegistry` object, owner of the corresponding credential schema.
+- the `corporation` controller of the `Ecosystem` object, owner of the corresponding credential schema.
 
-##### [MOD-PP-MSG-12-1] Slash Permission Trust Deposit parameters
+##### [MOD-PP-MSG-12-1] Slash Participant Trust Deposit parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
 - `amount` (number) (*mandatory*): the amount to slash
 
-##### [MOD-PP-MSG-12-2] Slash Permission Trust Deposit precondition checks
+##### [MOD-PP-MSG-12-2] Slash Participant Trust Deposit precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-12-2-1] Slash Permission Trust Deposit basic checks
+###### [MOD-PP-MSG-12-2-1] Slash Participant Trust Deposit basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -4182,14 +4182,14 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `applicant_participant` from `id`. If no entry found, abort.
+- Load `Participant` entry `applicant_participant` from `id`. If no entry found, abort.
 - `amount` MUST be lower or equal to `applicant_participant.deposit` else MUST abort.
 
 :::note
 Even if the permission has expired or is revoked, it is still possible to slash it.
 :::
 
-###### [MOD-PP-MSG-12-2-2] Slash Permission Trust Deposit validator perms
+###### [MOD-PP-MSG-12-2-2] Slash Participant Trust Deposit validator perms
 
 Either Option #1, or #2 MUST return true, else abort.
 
@@ -4204,18 +4204,18 @@ if `applicant_participant.validator_participant_id` is defined:
 - end
 - return false.
 
-*Option #2*: executed by `TrustRegistry` controller
+*Option #2*: executed by `Ecosystem` controller
 
 - load `CredentialSchema` `cs` from `applicant_participant.schema_id`
-- load `TrustRegistry` `tr` from `cs.ecosystem_id`
+- load `Ecosystem` `tr` from `cs.ecosystem_id`
 - if `corporation` running the method is `ecosystem.corporation`, return true.
 - else return false.
 
-###### [MOD-PP-MSG-12-2-3] Slash Permission Trust Deposit fee checks
+###### [MOD-PP-MSG-12-2-3] Slash Participant Trust Deposit fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 
-##### [MOD-PP-MSG-12-3] Slash Permission Trust Deposit execution
+##### [MOD-PP-MSG-12-3] Slash Participant Trust Deposit execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -4223,8 +4223,8 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 - define `now`: current timestamp.
 
-- Load `Permission` entry `applicant_participant` from `id`.
-- Load `Permission` entry `validator_participant` from `applicant_participant.validator_participant_id`.
+- Load `Participant` entry `applicant_participant` from `id`.
+- Load `Participant` entry `validator_participant` from `applicant_participant.validator_participant_id`.
 - set `applicant_participant.slashed` to `now`
 - set `applicant_participant.modified` to `now`
 - set `applicant_participant.slashed_deposit` to `applicant_participant.slashed_deposit` + `amount`
@@ -4233,23 +4233,23 @@ use [MOD-TD-MSG-7](#mod-td-msg-7-burn-ecosystem-slashed-trust-deposit) to burn t
 
 Call [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization) Revoke VS Operator Authorization with `participant_id = applicant_participant.id` to remove any authorization record for this permission. The call is a no-op if no record exists.
 
-#### [MOD-PP-MSG-13] Repay Permission Slashed Trust Deposit
+#### [MOD-PP-MSG-13] Repay Participant Slashed Trust Deposit
 
 This method can only be called by the `corporation` that want to repay the deposit of a slashed perm they own. This won't make the perm re-usable: it will be needed for the `corporation` associated to this permission to request a new permission, as slashed permissions cannot be revived (same happen for revoked, etc...).
 
 Nevertheless, to get a new permission for a given ecosystem, it is needed, using this method, to repay the deposit of a slashed permission first.
 
-##### [MOD-PP-MSG-13-1] Repay Permission Slashed Trust Deposit parameters
+##### [MOD-PP-MSG-13-1] Repay Participant Slashed Trust Deposit parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission
 
-##### [MOD-PP-MSG-13-2] Repay Permission Slashed Trust Deposit precondition checks
+##### [MOD-PP-MSG-13-2] Repay Participant Slashed Trust Deposit precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-13-2-1] Repay Permission Slashed Trust Deposit basic checks
+###### [MOD-PP-MSG-13-2-1] Repay Participant Slashed Trust Deposit basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -4257,15 +4257,15 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `applicant_participant` from `id`. If no entry found, abort.
+- Load `Participant` entry `applicant_participant` from `id`. If no entry found, abort.
 - if `applicant_participant.corporation` is not equal to `corporation`, abort.
 
-###### [MOD-PP-MSG-13-2-2] Repay Permission Slashed Trust Deposit fee checks
+###### [MOD-PP-MSG-13-2-2] Repay Participant Slashed Trust Deposit fee checks
 
 - Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]];
 - `corporation` MUST have at least `applicant_participant.slashed_deposit` in its account balance, else [[ref: transaction]] MUST abort.
 
-##### [MOD-PP-MSG-13-3] Repay Permission Slashed Trust Deposit execution
+##### [MOD-PP-MSG-13-3] Repay Participant Slashed Trust Deposit execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -4275,12 +4275,12 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 
 use [Adjust Trust Deposit](#mod-td-msg-1-adjust-trust-deposit) to transfer `applicant_participant.slashed_deposit` to trust deposit of `applicant_participant.corporation`.
 
-- Load `Permission` entry `applicant_participant` from `id`.
+- Load `Participant` entry `applicant_participant` from `id`.
 - set `applicant_participant.repaid` to `now`
 - set `applicant_participant.modified` to `now`
 - set `applicant_participant.repaid_deposit` to `applicant_participant.slashed_deposit`.
 
-#### [MOD-PP-MSG-14] Self Create Permission
+#### [MOD-PP-MSG-14] Self Create Participant
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
@@ -4290,11 +4290,11 @@ This simple permission creation method can be used to self-create an ISSUER (res
 Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else their permission may be revoked by ecosystem governance authority and their deposit slashed.
 :::
 
-##### [MOD-PP-MSG-14-1] Self Create Permission parameters
+##### [MOD-PP-MSG-14-1] Self Create Participant parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `type` (PermissionType) (*mandatory*): ISSUER or VERIFIER.
+- `type` (ParticipantRole) (*mandatory*): ISSUER or VERIFIER.
 - `validator_participant_id` (uint64) (*mandatory*): MUST be an ECOSYSTEM [[ref: active permission]] or [[ref: future permission]].
 - `vs_operator` (account) (*optional*): the account we want to authorize to create permission sessions linked to this permission. **Required** for payment delegation.
 - `did` (string) (*mandatory*): [[ref: DID]] of the VS grantee service.
@@ -4303,9 +4303,9 @@ Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else
 - `verification_fees` (number) (*optional*): price to pay by the verifier of a credential of this schema to the grantee of this ISSUER perm when a credential is verified, in the denom specified in the credential schema. Default to 0.
 - `validation_fees` (number) (*optional*): price to pay by the holder of a credential of this schema to the issuer when executing a validation process to obtain a credential, in the denom specified in the credential schema. Default to 0.
 
-The following VS Operator Authorization parameters are **optional** and collectively define the initial [PermissionAuthorizationRecord](#permissionauthorizationrecord) for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
+The following VS Operator Authorization parameters are **optional** and collectively define the initial [ParticipantAuthorizationRecord](#participantauthorizationrecord) for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
 
-- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `PermissionAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified.
+- `vs_operator_authz_msg_types[]` (msg_type[]) (*optional*): list of VPR delegable message types `vs_operator` is authorized to execute on behalf of `corporation` in the context of this permission. If provided, a `ParticipantAuthorizationRecord` is created (see execution below) and `vs_operator` MUST be specified.
 - `vs_operator_authz_spend_limit` (DenomAmount[]) (*optional*): maximum amount of funds `vs_operator` is allowed to spend in the context of this permission as a direct consequence of executing authorized messages.
 - `vs_operator_authz_with_feegrant` (bool) (*optional*, default: false): if true, `corporation` pays transaction fees for `vs_operator` via an on-chain `FeeGrant` when executing authorized messages in the context of this permission.
 - `vs_operator_authz_fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
@@ -4316,23 +4316,23 @@ Permitted message types to be set in `vs_operator_authz_msg_types` depends on `t
 |Permission type|Permitted Messages|
 |-|-|
 | HOLDER | TriggerResolver |
-| ISSUER | CreateOrUpdatePermissionSession, SetPermissionVPtoValidated |
-| VERIFIER | CreateOrUpdatePermissionSession |
+| ISSUER | CreateOrUpdateParticipantSession, SetPermissionVPtoValidated |
+| VERIFIER | CreateOrUpdateParticipantSession |
  
-##### [MOD-PP-MSG-14-2] Self Create Permission precondition checks
+##### [MOD-PP-MSG-14-2] Self Create Participant precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-14-2-1] Self Create Permission basic checks
+###### [MOD-PP-MSG-14-2-1] Self Create Participant basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
-Load `Permission` `validator_participant` from `validator_participant_id`.
+Load `Participant` `validator_participant` from `validator_participant_id`.
 
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `type` (PermissionType) (*mandatory*): MUST be ISSUER or VERIFIER, else abort.
+- `type` (ParticipantRole) (*mandatory*): MUST be ISSUER or VERIFIER, else abort.
 - `validator_participant_id` (uint64) (*mandatory*): `validator_participant` MUST be an ECOSYSTEM [[ref: active permission]] or [[ref: future permission]].
 - `vs_operator` (account) (*optional*): no check required.
 - `did`, MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
@@ -4344,9 +4344,9 @@ Load `Permission` `validator_participant` from `validator_participant_id`.
   - else if not null, must be greater than `effective_from` AND if `validator_participant.effective_until` is not null, MUST be lower or equal to `validator_participant.effective_until`
 - `verification_fees` (number) (*optional*): If specified, MUST be >= 0 and MUST be a ISSUER permission.
 - `validation_fees` (number) (*optional*): If specified, MUST be >= 0 and MUST be a ISSUER permission.
-- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-14-1](#mod-pp-msg-14-1-self-create-permission-parameters).
+- VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-14-1](#mod-pp-msg-14-1-self-create-participant-parameters).
 
-###### [MOD-PP-MSG-14-2-2] Self Create Permission permission checks
+###### [MOD-PP-MSG-14-2-2] Self Create Participant permission checks
 
 To execute this method, [[ref: account]] MUST match at least one these rules, else [[ref: transaction]] MUST abort.
 
@@ -4356,17 +4356,17 @@ To execute this method, [[ref: account]] MUST match at least one these rules, el
 - if `type` is equal to VERIFIER and `validation_fees` is specified and different than 0, MUST abort.
 - if `type` is equal to VERIFIER and `verification_fees` is specified and different than 0, MUST abort.
 
-###### [MOD-PP-MSG-14-2-3] Self Create Permission fee checks
+###### [MOD-PP-MSG-14-2-3] Self Create Participant fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
-###### [MOD-PP-MSG-14-2-4] Self Create Permission overlap checks
+###### [MOD-PP-MSG-14-2-4] Self Create Participant overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-permission) to set or adjust the `effective_until` value.
+We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-participant) to set or adjust the `effective_until` value.
 
 Find all [[ref: active permissions]] `participants[]` (not revoked, not slashed, not repaid) for `cs.id`, `type`, `validator_participant_id`, `corporation`.
 
-for each `Permission` entry `p` from `participants[]`:
+for each `Participant` entry `p` from `participants[]`:
 
 - if `p.effective_until` is greater than `effective_from`, method execution MUST abort.
 - if `p.effective_from` is lower than `effective_until`, method execution MUST abort.
@@ -4374,16 +4374,16 @@ for each `Permission` entry `p` from `participants[]`:
 
 > note: this check was not present in v3.
 
-##### [MOD-PP-MSG-14-3] Self Create Permission execution
+##### [MOD-PP-MSG-14-3] Self Create Participant execution
 
 If all precondition checks passed, method is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
 - define `now`: current timestamp.
-- Load `Permission` `validator_participant` from `validator_participant_id`.
+- Load `Participant` `validator_participant` from `validator_participant_id`.
 
-A new entry `Permission` `perm` MUST be created:
+A new entry `Participant` `perm` MUST be created:
 
 - `participant.id`: auto-incremented uint64.
 - `participant.validator_participant_id`: `validator_participant_id`
@@ -4401,7 +4401,7 @@ A new entry `Permission` `perm` MUST be created:
 - `participant.verification_fees`: `verification_fees` if specified and `type` is ISSUER, else 0.
 - `participant.deposit`: 0
 
-If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizationRecord](#permissionauthorizationrecord) in **active** state by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
+If `vs_operator_authz_msg_types` is provided, create the [ParticipantAuthorizationRecord](#participantauthorizationrecord) in **active** state by calling [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) Grant VS Operator Authorization with:
 
 - `corporation`: `corporation`
 - `vs_operator`: `vs_operator`
@@ -4414,7 +4414,7 @@ If `vs_operator_authz_msg_types` is provided, create the [PermissionAuthorizatio
   - `record.expiration`: `participant.effective_until`
   - `record.period`: `vs_operator_authz_period`
 
-> Note: unlike [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-permission-vp), the record is created with `expiration = participant.effective_until` and is therefore immediately active. If `with_feegrant` is true and `participant.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
+> Note: unlike [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-vp), the record is created with `expiration = participant.effective_until` and is therefore immediately active. If `with_feegrant` is true and `participant.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
 
 #### [MOD-PP-MSG-15] Trigger Resolver
 
@@ -4448,7 +4448,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - `id` MUST be a valid uint64.
-- Load `Permission` entry `perm` from `id`. If no entry found, abort.
+- Load `Participant` entry `perm` from `id`. If no entry found, abort.
 - `perm` MUST be an [[ref: active permission]], else abort.
 - `participant.did` MUST NOT be null, else abort.
 
@@ -4488,9 +4488,9 @@ This method does not modify the state of the [[ref: VPR]]. It MUST emit an event
 
 - `participant_id`: equal to `id`.
 
-> Note: the identity of the signers (`corporation`, `operator`), the fee payer, the block height and timestamp, and the full Msg payload are already observable from the transaction itself. Indexers MAY use the `Permission` entry queried by `participant_id` to resolve `did`, `corporation`, `vs_operator`, and ancestor chain without duplicating them in the event payload.
+> Note: the identity of the signers (`corporation`, `operator`), the fee payer, the block height and timestamp, and the full Msg payload are already observable from the transaction itself. Indexers MAY use the `Participant` entry queried by `participant_id` to resolve `did`, `corporation`, `vs_operator`, and ancestor chain without duplicating them in the event payload.
 
-#### [MOD-PP-QRY-1] List Permissions
+#### [MOD-PP-QRY-1] List Participants
 
 Anyone CAN execute this method.
 
@@ -4503,13 +4503,13 @@ Generic query used for (at least):
 - find all ISSUER_GRANTOR active permission, so that I can apply to an ISSUER permission;
 ...
 
-##### [MOD-PP-QRY-1-1] List Permissions parameters
+##### [MOD-PP-QRY-1-1] List Participants parameters
 
 - `schema_id` (number) (*optional*): the schema id.
 - `grantee` (account) (*optional*): the grantee account.
 - `did` (string) (*optional*): the did the permission refers to.
 - `participant_id` (number) (*optional*): limit to permissions where the `validator_participant_id` is `participant_id`.
-- `type` (PermissionType) (*optional*): if we want to limit to a specific permission type.
+- `type` (ParticipantRole) (*optional*): if we want to limit to a specific permission type.
 - `only_valid` (boolean) (*optional*): if set to true, only return active permissions.
 - `only_slashed` (boolean) (*optional*): if set to true, only return slashed permissions.
 - `only_repaid` (boolean) (*optional*): if set to true, only return repaid slashed permissions.
@@ -4518,7 +4518,7 @@ Generic query used for (at least):
 - `response_max_size` (small number) (*optional*): limit to `response_max_size` results. Must be min 1, max 1,024. Default to 64.
 - `when` (timestamp) (*optional*): if set, query *at* `when`, else query *at* now(). Used to query the VPR state at a previous datetime.
 
-##### [MOD-PP-QRY-1-2] List Permissions checks
+##### [MOD-PP-QRY-1-2] List Participants checks
 
 Basic type check arg SHOULD be applied.
 
@@ -4526,23 +4526,23 @@ If any of these checks fail, [[ref: query]] MUST fail.
 
 - `response_max_size` must be between 1 and 1,024. Default to 64 if unspecified.
 
-##### [MOD-PP-QRY-1-3] List Permissions execution
+##### [MOD-PP-QRY-1-3] List Participants execution
 
 return a list of found entries, or an empty list if nothing found. Ordered by `modified` asc.
 
-#### [MOD-PP-QRY-2] Get Permission
+#### [MOD-PP-QRY-2] Get Participant
 
 Anyone CAN execute this method.
 
-##### [MOD-PP-QRY-2-1] Get Permission parameters
+##### [MOD-PP-QRY-2-1] Get Participant parameters
 
 - `id` of the [[ref: credential schema permission]] (*mandatory*);
 
-##### [MOD-PP-QRY-2-2] Get Permission checks
+##### [MOD-PP-QRY-2-2] Get Participant checks
 
 - `id` must be a uint64.
 
-##### [MOD-PP-QRY-2-3] Get Permission execution
+##### [MOD-PP-QRY-2-3] Get Participant execution
 
 return found entry (if any).
 
@@ -4554,7 +4554,7 @@ Obsoleted by [MOD-PP-QRY-1].
 
 Anyone can execute this method.
 
-To calculate the fees required for paying the beneficiaries, it is needed to recurse all involved perms until the root of the permission tree (which is the trust registry perm), starting from the 2 branches `issuer_participant` and `verifier_participant`. As both branches may have common ancestors, we can create a Set (unordered collection with no duplicates), and recurse over the 2 branches, adding found perms. If `verifier_participant` is null, `issuer_participant` is never added to the set. If `verifier_participant` is NOT null, `issuer_participant` is added to the set if it exists but `verifier_participant` is not added to the set.
+To calculate the fees required for paying the beneficiaries, it is needed to recurse all involved perms until the root of the permission tree (which is the ecosystem perm), starting from the 2 branches `issuer_participant` and `verifier_participant`. As both branches may have common ancestors, we can create a Set (unordered collection with no duplicates), and recurse over the 2 branches, adding found perms. If `verifier_participant` is null, `issuer_participant` is never added to the set. If `verifier_participant` is NOT null, `issuer_participant` is added to the set if it exists but `verifier_participant` is not added to the set.
 
 Example 1: `verifier_participant`: is not set: it's a credential offer, schema configured to have Issuer Grantors.
 
@@ -4671,29 +4671,29 @@ return `found_perms`.
 This works even is schema is open to any issuer or open to any verifier.
 :::
 
-#### [MOD-PP-QRY-5] Get PermissionSession
+#### [MOD-PP-QRY-5] Get ParticipantSession
 
-##### [MOD-PP-QRY-5-1] Get PermissionSession parameters
+##### [MOD-PP-QRY-5-1] Get ParticipantSession parameters
 
-- `id` (uuid) (*mandatory*): the id of the `PermissionSession`.
+- `id` (uuid) (*mandatory*): the id of the `ParticipantSession`.
 
-##### [MOD-PP-QRY-5-2] Get PermissionSession checks
+##### [MOD-PP-QRY-5-2] Get ParticipantSession checks
 
-##### [MOD-PP-QRY-5-3] Get PermissionSession execution
+##### [MOD-PP-QRY-5-3] Get ParticipantSession execution
 
-return `PermissionSession` entry if found, else return not found.
+return `ParticipantSession` entry if found, else return not found.
 
-##### [MOD-PP-QRY-6] List Permission Module Parameters
+##### [MOD-PP-QRY-6] List Participant Module Parameters
 
-##### [MOD-PP-QRY-6-2] List Permission Module Parameters parameters
+##### [MOD-PP-QRY-6-2] List Participant Module Parameters parameters
 
-##### [MOD-PP-QRY-6-2] List Permission Module Parameters query checks
+##### [MOD-PP-QRY-6-2] List Participant Module Parameters query checks
 
-##### [MOD-PP-QRY-6-3] List Permission Module Parameters execution of the query
+##### [MOD-PP-QRY-6-3] List Participant Module Parameters execution of the query
 
 Return the list of the existing parameters and their values.
 
-##### [MOD-PP-QRY-6-4] List Permission Module Parameters API result example
+##### [MOD-PP-QRY-6-4] List Participant Module Parameters API result example
 
 ```json
 {
@@ -4756,7 +4756,7 @@ actor "Validator\n(issuer grantor)\nAccount" as ValidatorAccount
 
 participant "Verifiable Public Registry" as VPR #3fbdb6
 
-ApplicantAccount --> VPR: Start Permission VP
+ApplicantAccount --> VPR: Start Participant VP
 VPR <-- VPR: create permission entry.
 ApplicantAccount <-- VPR: permission entry created,\nassigned participant.validator_participant_id from ISSUER_GRANTOR permissions.
 ApplicantBrowser --> ValidatorVS: connect to validator VS DID found in validator_participant.did\nby creating a DIDComm connection
@@ -4777,7 +4777,7 @@ ApplicantBrowser <-- ValidatorVS: Are you a legitimate issuer?\nProve it, by fil
 ApplicantBrowser --> ValidatorVS: perform requested tasks...
 note over ApplicantBrowser, ValidatorVS #EEEEEE: tasks completed
 ApplicantBrowser <-- ValidatorVS: Your are a legitimate issuer. I'll now create an ISSUER permission for your account and DID.
-ValidatorAccount --> VPR #3fbdb6: Set Permission VP to Validated\nset validation.state to VALIDATED\n.
+ValidatorAccount --> VPR #3fbdb6: Set Participant VP to Validated\nset validation.state to VALIDATED\n.
 VPR --> ValidatorAccount: Receive trust fees.
 ApplicantBrowser <-- ValidatorVS: notify permission added for your DID.\nDID can now issue credentials of this schema.
 ```
@@ -5036,7 +5036,7 @@ This method is used by the network governance authority to **globally slash** a 
 
 This method can only be called by a governance proposal. A globally slashed account MUST repay the slashed deposit in order to continue to use the services provided by the VPR. When and account is slashed, and while slashed deposit has not been repaid, all account linked permissions MUST be considered non trustable.
 
-This method is for network governance authority slash. For ecosystem slash, see [Slash Permission Trust Deposit](#mod-pp-msg-12-slash-permission-trust-deposit).
+This method is for network governance authority slash. For ecosystem slash, see [Slash Participant Trust Deposit](#mod-pp-msg-12-slash-participant-trust-deposit).
 
 ##### [MOD-TD-MSG-5-1] Slash Trust Deposit method parameters
 
@@ -5301,7 +5301,7 @@ if any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `msg_types` (Msg[]) (*mandatory*): MUST be a list of **VPR delegable messages only**, excepted `CreateOrUpdatePermissionSession` which is not allowed.
+- `msg_types` (Msg[]) (*mandatory*): MUST be a list of **VPR delegable messages only**, excepted `CreateOrUpdateParticipantSession` which is not allowed.
 - `expiration` (timestamp): if specified, MUST be in the future
 - `authz_spend_limit` (DenomAmount[]) if specified, MUST be a list of valid DenomAmounts
 - `authz_spend_limit_period` (duration): if specified MUST be a valid period. Ignored if `authz_spend_limit` is not set.
@@ -5374,25 +5374,25 @@ MUST abort if one of these conditions fails:
 
 This method can only be called directly by the following Permission module methods, with no signer check:
 
-- [Start Permission VP](#mod-pp-msg-1-start-permission-vp)
-- [Self Create Permission](#mod-pp-msg-14-self-create-permission)
+- [Start Participant VP](#mod-pp-msg-1-start-participant-vp)
+- [Self Create Participant](#mod-pp-msg-14-self-create-participant)
 
-It creates a new [PermissionAuthorizationRecord](#permissionauthorizationrecord) inside `VSOperatorAuthorization[corporation, vs_operator]` and, if the record enables a fee grant and its `expiration` is in the future, synchronises the on-chain `FeeGrant` for the containing VSOA.
+It creates a new [ParticipantAuthorizationRecord](#participantauthorizationrecord) inside `VSOperatorAuthorization[corporation, vs_operator]` and, if the record enables a fee grant and its `expiration` is in the future, synchronises the on-chain `FeeGrant` for the containing VSOA.
 
-This method does NOT read `Permission` state. All authorization configuration is provided by the caller.
+This method does NOT read `Participant` state. All authorization configuration is provided by the caller.
 
 ##### [MOD-DE-MSG-5-1] Grant VS Operator Authorization method parameters
 
 - `corporation` (group) (*mandatory*): the corporation delegating the authorization.
 - `vs_operator` (account) (*mandatory*): the account receiving the authorization.
-- `record` ([PermissionAuthorizationRecord](#permissionauthorizationrecord)) (*mandatory*): the full record to store.
+- `record` ([ParticipantAuthorizationRecord](#participantauthorizationrecord)) (*mandatory*): the full record to store.
 
 ##### [MOD-DE-MSG-5-2] Grant VS Operator Authorization basic checks
 
 If any of these conditions is not satisfied, [[ref: transaction]] MUST abort.
 
 - `corporation` and `vs_operator` MUST NOT be null.
-- `record.participant_id` MUST NOT match an existing `PermissionAuthorizationRecord` anywhere in the store (each record is globally unique by `participant_id`).
+- `record.participant_id` MUST NOT match an existing `ParticipantAuthorizationRecord` anywhere in the store (each record is globally unique by `participant_id`).
 - `record.msg_types` MUST be non-empty and MUST contain only VPR delegable message types.
 - No `OperatorAuthorization` `oauthz` where `oauthz.corporation` = `corporation` and `oauthz.operator` = `vs_operator` MUST exist.
 - No other `VSOperatorAuthorization` `vsoauthz'` where `vsoauthz'.vs_operator` = `vs_operator` AND `vsoauthz'.corporation` != `corporation` MUST exist. In other words, a vs-agent VPR account cannot be controlled by multiple corporations.
@@ -5435,13 +5435,13 @@ This is a shared subroutine invoked by [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-o
 
 This method can only be called directly by the following Permission module methods, with no signer check:
 
-- [Cancel Permission VP Last Request](#mod-pp-msg-6-cancel-permission-vp-last-request) (only when the cancellation terminates the permission)
-- [Revoke Permission](#mod-pp-msg-9-revoke-permission)
-- [Slash Permission Trust Deposit](#mod-pp-msg-12-slash-permission-trust-deposit)
+- [Cancel Participant VP Last Request](#mod-pp-msg-6-cancel-participant-vp-last-request) (only when the cancellation terminates the permission)
+- [Revoke Participant](#mod-pp-msg-9-revoke-participant)
+- [Slash Participant Trust Deposit](#mod-pp-msg-12-slash-participant-trust-deposit)
 
-It removes the unique [PermissionAuthorizationRecord](#permissionauthorizationrecord) identified by `participant_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no such record exists.
+It removes the unique [ParticipantAuthorizationRecord](#participantauthorizationrecord) identified by `participant_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no such record exists.
 
-This method does NOT read `Permission` state.
+This method does NOT read `Participant` state.
 
 ##### [MOD-DE-MSG-6-1] Revoke VS Operator Authorization method parameters
 
@@ -5459,7 +5459,7 @@ This method does NOT read `Permission` state.
 
 ##### [MOD-DE-MSG-6-4] Revoke VS Operator Authorization execution of the method
 
-- Locate the unique `PermissionAuthorizationRecord` `record` with `record.participant_id = participant_id`. If none exists, EXIT (no-op).
+- Locate the unique `ParticipantAuthorizationRecord` `record` with `record.participant_id = participant_id`. If none exists, EXIT (no-op).
 - Let `vsoa` = the `VSOperatorAuthorization` that contains `record`.
 - Remove `record` from `vsoa.records`.
 - Call **[Recompute VS Operator Fee Allowance](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance)** for `vsoa`.
@@ -5469,12 +5469,12 @@ This method does NOT read `Permission` state.
 
 This method can only be called directly by the following Permission module methods, with no signer check:
 
-- [Set Permission VP to Validated](#mod-pp-msg-3-set-permission-vp-to-validated)
-- [Adjust Permission](#mod-pp-msg-8-adjust-permission)
+- [Set Participant VP to Validated](#mod-pp-msg-3-set-participant-vp-to-validated)
+- [Adjust Participant](#mod-pp-msg-8-adjust-participant)
 
 It updates the `expiration` of the unique record identified by `participant_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no record exists for `participant_id`.
 
-This method does NOT read `Permission` state; the caller supplies the new expiration value directly.
+This method does NOT read `Participant` state; the caller supplies the new expiration value directly.
 
 ##### [MOD-DE-MSG-9-1] Update VS Operator Authorization Expiration method parameters
 
@@ -5494,7 +5494,7 @@ This method does NOT read `Permission` state; the caller supplies the new expira
 
 ##### [MOD-DE-MSG-9-4] Update VS Operator Authorization Expiration execution of the method
 
-- Locate the unique `PermissionAuthorizationRecord` `record` with `record.participant_id = participant_id`. If none exists, EXIT (no-op).
+- Locate the unique `ParticipantAuthorizationRecord` `record` with `record.participant_id = participant_id`. If none exists, EXIT (no-op).
 - Set `record.expiration = new_expiration`.
 - Call **[Recompute VS Operator Fee Allowance](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance)** for the VSOA containing `record`.
 
@@ -5545,7 +5545,7 @@ Return a list of `VSOperatorAuthorization` entries matching the filter criteria,
 #### [MOD-DI-MSG-1] Store Digest
 
 - Any authorized `operator` CAN execute this method on behalf of a `corporation`.
-- This method can be called directly by [Create or Update Permission Session](#mod-pp-msg-10-create-or-update-permission-session) module with no checks.
+- This method can be called directly by [Create or Update Participant Session](#mod-pp-msg-10-create-or-update-participant-session) module with no checks.
 
 ##### [MOD-DI-MSG-1-1] Store Digest method parameters
 

--- a/spec.md
+++ b/spec.md
@@ -121,7 +121,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 ~ A [[ref: verifiable public registry]] account.
 
 [[def: applicant, applicants]]:
-~ A [[ref: account]] that starts a [[ref: validation process]].
+~ A [[ref: account]] that starts a [[ref: onboarding process]].
 
 [[def: corporation, corporations]]:
 ~ An [[ref: group]] which is the owner of a specific resource in an [[ref: VPR]].
@@ -204,7 +204,7 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 ~ Fees required, in [[ref: denom]], to execute a [[ref: transaction]] in an [[ref: VPR]].
 
 [[def: trust deposit, trust deposits]]:
-~ A financial deposit that is used as a trust guarantee. For a given [[ref: corporation]], its trust deposit is increased when running validation process (either as an [[ref: applicant]] or as a [[ref: validator]]).
+~ A financial deposit that is used as a trust guarantee. For a given [[ref: corporation]], its trust deposit is increased when running onboarding process (either as an [[ref: applicant]] or as a [[ref: validator]]).
 
 [[def: trust fee, trust fees]]:
 ~ Fees paid by a [[ref: participant]] that are distributed to other [[ref: participants]].
@@ -227,11 +227,11 @@ The key words MAY, MUST, MUST NOT, OPTIONAL, RECOMMENDED, REQUIRED, SHOULD, and 
 [[def: future participant, future participants]]:
 ~ A participant of a given role, which effective_from timestamp is higher than current timestamp, and (effective_until timestamp is null or greater than effective_from timestamp), and revoked is null and slashed is null.
 
-[[def: validation process]]:
+[[def: onboarding process]]:
 ~ A process run by [[ref: applicants]] that want to, for a specific [[ref: credential schema]], be a [[ref: issuer]], be a [[ref: verifier]], or simply hold a verifiable credential linked to the [[ref: credential schema]].
 
 [[def: validator]]:
-~ A role an [[ref: entity]] performs by participating in validation processes with [[ref: applicants]] in order to register them as [[ref: issuer]], or [[ref: verifier]] of a [[ref: credential schema]], or to deliver a verifiable credential to them.
+~ A role an [[ref: entity]] performs by participating in onboarding processes with [[ref: applicants]] in order to register them as [[ref: issuer]], or [[ref: verifier]] of a [[ref: credential schema]], or to deliver a verifiable credential to them.
 
 [[def: verifiable public registry, VPR, VPRs]]:
 ~ a public, normally decentralized, ledger-based network, which provides: ecosystem features, that can be used by all its [[ref: participants]]: create ecosystems, for each ecosystem, define its credential schemas, who can issue, verify credential of a specific credential schema,... and a tokenized business model for charging/rewarding [[ref: participants]].
@@ -304,14 +304,14 @@ object "Ecosystem" as tra #3fbdb6 {
 - A **Json Schema** that defines the structure of the corresponding [[ref: verifiable credential]]
 - A **IssuerOnboardingMode** for **issuance policy**, which determines how `ISSUER` permissions are granted. Modes include:
   - `OPEN`: `ISSUER` permissions can be self-created by anyone.
-  - `ECOSYSTEM_VALIDATION_PROCESS`: `ISSUER` permissions are granted directly by the [[ref: ecosystem]], the ecosystem corporation through the execution of a Validation Process.
-  - `GRANTOR_VALIDATION_PROCESS`: `ISSUER` permissions are granted by one or several [[ref: issuer grantor]](s) (ecosystem operator(s) responsible for selecting issuers for the credential schema of this [[ref: ecosystem]]), selected by the [[ref: ecosystem]] through the execution of a Validation Process.
+  - `ECOSYSTEM_ONBOARDING_PROCESS`: `ISSUER` permissions are granted directly by the [[ref: ecosystem]], the ecosystem corporation through the execution of an Onboarding Process.
+  - `GRANTOR_ONBOARDING_PROCESS`: `ISSUER` permissions are granted by one or several [[ref: issuer grantor]](s) (ecosystem operator(s) responsible for selecting issuers for the credential schema of this [[ref: ecosystem]]), selected by the [[ref: ecosystem]] through the execution of an Onboarding Process.
 - A **VerifierOnboardingMode** for **verification policy**, which determines how `VERIFIER` permissions are granted. Modes include:
   - `OPEN`: `VERIFIER` permissions can be created by anyone.
-  - `ECOSYSTEM_VALIDATION_PROCESS`: `VERIFIER` permissions are granted directly by the [[ref: ecosystem]], the Ecosystem corporation through the execution of a Validation Process.
-  - `GRANTOR_VALIDATION_PROCESS`: `VERIFIER` permissions are granted by one or several [[ref: verifier grantor]](s) (ecosystem operator(s) responsible for selecting verifiers for the credential schema of this [[ref: ecosystem]]), selected by the [[ref: ecosystem]], through the execution of a Validation Process.
+  - `ECOSYSTEM_ONBOARDING_PROCESS`: `VERIFIER` permissions are granted directly by the [[ref: ecosystem]], the Ecosystem corporation through the execution of an Onboarding Process.
+  - `GRANTOR_ONBOARDING_PROCESS`: `VERIFIER` permissions are granted by one or several [[ref: verifier grantor]](s) (ecosystem operator(s) responsible for selecting verifiers for the credential schema of this [[ref: ecosystem]]), selected by the [[ref: ecosystem]], through the execution of an Onboarding Process.
 - An **HolderOnboardingMode** for **holder policy**, which determines how `HOLDER` permissions are granted. Modes include:
-  - `ISSUER_VALIDATION_PROCESS`: `HOLDER` permissions are granted directly by issuers to holder through the execution of a Validation Process.
+  - `ISSUER_ONBOARDING_PROCESS`: `HOLDER` permissions are granted directly by issuers to holder through the execution of an Onboarding Process.
   - `PERMISSIONLESS`: holder that want to obtain credentials from an issuer do not require a permission in the VPR.
 - A **Participant tree** that defines the roles and relationships involved in managing the schema’s lifecycle. Each created permission in the tree can define business rules, see below [Business Models](#business-models).
 
@@ -426,14 +426,14 @@ To participate in an [[ref: ecosystem]] and assume a role associated with a spec
 
 - if schema is `OPEN` for issuance and/or verification: an entity must have an [[ref: account]] in the [[ref: VPR]] and self-create its permission.
 
-- if schema is not `OPEN` for issuance and/or verification: an entity must have an [[ref: account]] in the [[ref: VPR]] and complete a [[ref: validation process]] to obtain the required permission.
+- if schema is not `OPEN` for issuance and/or verification: an entity must have an [[ref: account]] in the [[ref: VPR]] and complete a [[ref: onboarding process]] to obtain the required permission.
 
-The [[ref: validation process]] involves two parties:
+The [[ref: onboarding process]] involves two parties:
 
 - The [[ref: applicant]] — the entity requesting permission for a credential schema within the ecosystem.  
 - The [[ref: validator]] — an entity that already holds permission for the same credential schema and has been delegated authority to validate applicants and issue permissions.
 
-Running a validation process **typically involves the payment of [[ref: trust fees]]**. [[ref: Trust fee]] amount to be paid by the [[ref: applicant]] is defined in the permission of the [[ref: validator]] involved in the [[ref: validation process]]:
+Running an onboarding process **typically involves the payment of [[ref: trust fees]]**. [[ref: Trust fee]] amount to be paid by the [[ref: applicant]] is defined in the permission of the [[ref: validator]] involved in the [[ref: onboarding process]]:
 
 ```plantuml
 
@@ -549,11 +549,11 @@ The following operations **only require payment of network fees** (no trust depo
 - Updating an Ecosystem
 - ...
 
-#### Validation process trust fees
+#### Onboarding process trust fees
 
 *This section is non-normative.*
 
-We've explained in the [Credential Schemas and Permissions](#credential-schemas-and-permissions) section above what is a validation process.
+We've explained in the [Credential Schemas and Permissions](#credential-schemas-and-permissions) section above what is an onboarding process.
 
 The table below summarizes the possible combinations of applicants and validators:
 
@@ -565,14 +565,14 @@ The table below summarizes the possible combinations of applicants and validator
 | Verifier         | renewable subscription (4)          |                                       | renewable subscription (2)          |                                     |          |                                         |
 | Holder           |                                     |                                       |                                     | renewable subscription  (5)         |          |                                         |
 
-- (1): if *issuer onboarding mode* is set to GRANTOR_VALIDATION_PROCESS.
-- (2): if *verifier onboarding mode* is set to GRANTOR_VALIDATION_PROCESS.
-- (3): if *issuer onboarding mode* is set to ECOSYSTEM_VALIDATION_PROCESS.
-- (4): if *verifier onboarding mode* is set to ECOSYSTEM_VALIDATION_PROCESS.
-- (5): if *holder onboarding mode* is set to ISSUEr_VALIDATION_PROCESS.
+- (1): if *issuer onboarding mode* is set to GRANTOR_ONBOARDING_PROCESS.
+- (2): if *verifier onboarding mode* is set to GRANTOR_ONBOARDING_PROCESS.
+- (3): if *issuer onboarding mode* is set to ECOSYSTEM_ONBOARDING_PROCESS.
+- (4): if *verifier onboarding mode* is set to ECOSYSTEM_ONBOARDING_PROCESS.
+- (5): if *holder onboarding mode* is set to ISSUER_ONBOARDING_PROCESS.
 
 
-Validation process is started by the applicant.
+Onboarding process is started by the applicant.
 
 *Example of a candidate [[ref: issuer]] ([[ref: applicant]]) that would like to be granted an ISSUER permission for a credential schema of an ecosystem, by a [[ref: validator]] that has a ISSUER_GRANTOR permission:*
 
@@ -614,8 +614,8 @@ ApplicantBrowser <-- ValidatorVS: notify ISSUER permission created for your acco
 
 The **total fees** paid by the applicant consists of:
 
-- The validation [[ref: trust fees]] defined in the permission of the validator participating in the validation process, **plus**
-- An additional amount equal to the `trust_deposit_rate` of that validation [[ref: trust fees]], which is **allocated to the applicant’s trust deposit** when the validation process begins.
+- The validation [[ref: trust fees]] defined in the permission of the validator participating in the onboarding process, **plus**
+- An additional amount equal to the `trust_deposit_rate` of that validation [[ref: trust fees]], which is **allocated to the applicant’s trust deposit** when the onboarding process begins.
 - [[ref: network fees]] (not part of the escrowed amount).
 
 Example, using 20% for `trust_deposit_rate`:
@@ -647,7 +647,7 @@ issuera --> issuertd:  \t+200 TUs
 
 ```
 
-Upon completion of the validation process, **escrowed trust fees are distributed to the validator** as follows:
+Upon completion of the onboarding process, **escrowed trust fees are distributed to the validator** as follows:
 
 - A portion defined by `trust_deposit_rate` is allocated to the **validator’s trust deposit**.  
 - The remaining amount is **transferred directly to the validator’s wallet**.
@@ -1004,18 +1004,18 @@ entity "SchemaAuthorizationPolicy" as sap {
 
 enum "IssuerOnboardingMode" as iom {
   OPEN
-  GRANTOR_VALIDATION_PROCESS
-  ECOSYSTEM_VALIDATION_PROCESS
+  GRANTOR_ONBOARDING_PROCESS
+  ECOSYSTEM_ONBOARDING_PROCESS
 }
 
 enum "VerifierOnboardingMode" as vom {
   OPEN
-  GRANTOR_VALIDATION_PROCESS
-  ECOSYSTEM_VALIDATION_PROCESS
+  GRANTOR_ONBOARDING_PROCESS
+  ECOSYSTEM_ONBOARDING_PROCESS
 }
 
 enum "HolderOnboardingMode" as hom {
-  ISSUER_VALIDATION_PROCESS
+  ISSUER_ONBOARDING_PROCESS
   PERMISSIONLESS
 }
 
@@ -1281,14 +1281,14 @@ group  --o td: corporation
 - `modified` (timestamp) (*mandatory*): timestamp this CredentialSchema has been modified.
 - `archived` (timestamp) (*mandatory*): timestamp this CredentialSchema has been archived.
 - `json_schema` (string) (*mandatory*): Json Schema used for issuing credentials based on this schema.
-- `issuer_grantor_validation_validity_period` (number) (*mandatory*): number of days after which an issuer grantor validation process expires and must be renewed.
-- `verifier_grantor_validation_validity_period` (number) (*mandatory*): number of days after which a verifier grantor validation process expires and must be renewed.
-- `issuer_validation_validity_period` (number) (*mandatory*): number of days after which an issuer validation process expires and must be renewed.
-- `verifier_validation_validity_period` (number) (*mandatory*): number of days after which a verifier validation process expires and must be renewed.
-- `holder_validation_validity_period` (number) (*mandatory*): number of days after which an holder validation process expires and must be renewed.
-- `issuer_onboarding_mode` (IssuerOnboardingMode) (*mandatory*): defines how permissions are managed for issuers of this `CredentialSchema`. OPEN means anyone can issue credential of this schema; GRANTOR_VALIDATION_PROCESS means a validation process MUST be run between a candidate ISSUER and an ISSUER_GRANTOR in order to create an ISSUER permission; ECOSYSTEM_VALIDATION_PROCESS means a validation process MUST be run between a candidate ISSUER and the ecosystem owner (ecosystem) of the `CredentialSchema` entry in order to create an ISSUER permission;
-- `verifier_onboarding_mode` (VerifierOnboardingMode) (*mandatory*): defines how permissions are managed for verifiers of this `CredentialSchema`. OPEN means anyone can verify credentials of this schema (does not implies that a payment is not necessary); GRANTOR_VALIDATION_PROCESS means a validation process MUST be run between a candidate VERIFIER and a VERIFIER_GRANTOR in order to create a VERIFIER permission; ECOSYSTEM_VALIDATION_PROCESS means a validation process MUST be run between a candidate VERIFIER and the ecosystem owner (ecosystem) of the `CredentialSchema` entry in order to create a VERIFIER permission;
-- `holder_onboarding_mode` (HolderOnboardingMode) (*mandatory*): defines how permissions are managed for holders of this `CredentialSchema`. ISSUER_VALIDATION_PROCESS means a validation process MUST be run between a candidate HOLDER and an ISSUER in order to create a HOLDER permission. HOLDER permission is used to check credential revocation status; PERMISSIONLESS means no onboarding is required to take place on the VPR (and thus an ISSUER cannot use the VPR to charge validation fees to candidate holders);
+- `issuer_grantor_validation_validity_period` (number) (*mandatory*): number of days after which an issuer grantor onboarding process expires and must be renewed.
+- `verifier_grantor_validation_validity_period` (number) (*mandatory*): number of days after which a verifier grantor onboarding process expires and must be renewed.
+- `issuer_validation_validity_period` (number) (*mandatory*): number of days after which an issuer onboarding process expires and must be renewed.
+- `verifier_validation_validity_period` (number) (*mandatory*): number of days after which a verifier onboarding process expires and must be renewed.
+- `holder_validation_validity_period` (number) (*mandatory*): number of days after which an holder onboarding process expires and must be renewed.
+- `issuer_onboarding_mode` (IssuerOnboardingMode) (*mandatory*): defines how permissions are managed for issuers of this `CredentialSchema`. OPEN means anyone can issue credential of this schema; GRANTOR_ONBOARDING_PROCESS means an onboarding process MUST be run between a candidate ISSUER and an ISSUER_GRANTOR in order to create an ISSUER permission; ECOSYSTEM_ONBOARDING_PROCESS means an onboarding process MUST be run between a candidate ISSUER and the ecosystem owner (ecosystem) of the `CredentialSchema` entry in order to create an ISSUER permission;
+- `verifier_onboarding_mode` (VerifierOnboardingMode) (*mandatory*): defines how permissions are managed for verifiers of this `CredentialSchema`. OPEN means anyone can verify credentials of this schema (does not implies that a payment is not necessary); GRANTOR_ONBOARDING_PROCESS means an onboarding process MUST be run between a candidate VERIFIER and a VERIFIER_GRANTOR in order to create a VERIFIER permission; ECOSYSTEM_ONBOARDING_PROCESS means an onboarding process MUST be run between a candidate VERIFIER and the ecosystem owner (ecosystem) of the `CredentialSchema` entry in order to create a VERIFIER permission;
+- `holder_onboarding_mode` (HolderOnboardingMode) (*mandatory*): defines how permissions are managed for holders of this `CredentialSchema`. ISSUER_ONBOARDING_PROCESS means an onboarding process MUST be run between a candidate HOLDER and an ISSUER in order to create a HOLDER permission. HOLDER permission is used to check credential revocation status; PERMISSIONLESS means no onboarding is required to take place on the VPR (and thus an ISSUER cannot use the VPR to charge validation fees to candidate holders);
 - `pricing_asset_type` (PricingAssetType) (*mandatory*): used asset for paying business fees. Can be TU ([[ref: trust unit]]),  COIN (a token available on the VPR chain), FIAT (means chain is used for settlement only and payment is done off-chain). Not that in all cases, trust deposits are always handled in `denom`.
 - `pricing_asset` (string) (*mandatory*): `"tu"` if `pricing_asset_type` is set to TU, else examples: COIN: `denom` `"uvna"`, `"ufoo"`, `"ibc/3A0F9C2E4E2A9B7D6F..."`, `"factory/verana1.../ueurv"`, FIAT: `"USD"`, `"GBP"`,...
 - `digest_algorithm` (string) (*mandatory*): algorithm used to compute the `digestSRI` for credentials issued under this schema. Valid values are defined in the [Verifiable Trust spec](https://verana-labs.github.io/verifiable-trust-spec/).
@@ -1325,23 +1325,23 @@ group  --o td: corporation
 - `effective_from` (timestamp) (*optional*): timestamp from which (inclusive) this `Participant` is effective.
 - `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this `Participant` is effective, null if no time limit has been set for this permission.
 - `modified` (timestamp) (*mandatory*): timestamp this Participant has been modified.
-- `validation_fees` (number) (*mandatory*): price to pay by an applicant to a validator (`corporation` grantee of this perm) for running a validation process for a given validation period. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
+- `validation_fees` (number) (*mandatory*): price to pay by an applicant to a validator (`corporation` grantee of this perm) for running an onboarding process for a given validation period. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
 - `issuance_fees` (number) (*mandatory*): fees requested by grantee `corporation` of this perm when a credential is issued. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
 - `verification_fees` (number) (*mandatory*): fees requested by grantee `corporation` of this perm when a credential is verified. Must be an integer. Default to 0. Considered unit depends on `pricing_asset_type` and `pricing_asset` configuration of related schema.
-- `deposit` (number) (*mandatory*): accumulated *grantee* deposit in the context of the *use* of this permission (including the validation process), in [[ ref: native denom ]]. Usually, it is incremented when for example, for a ISSUER type `Participant` `perm`, issuer issues credentials that require paying issuance fees: an additional % of the fees is charged to issuer and sent to its deposit, corresponding deposit amount increases this `participant.deposit` value as well. If `perm` is, let's say revoked, then corresponding `participant.deposit` value is freed from `participant.grantee` Trust Deposit.
+- `deposit` (number) (*mandatory*): accumulated *grantee* deposit in the context of the *use* of this permission (including the onboarding process), in [[ ref: native denom ]]. Usually, it is incremented when for example, for a ISSUER type `Participant` `perm`, issuer issues credentials that require paying issuance fees: an additional % of the fees is charged to issuer and sent to its deposit, corresponding deposit amount increases this `participant.deposit` value as well. If `perm` is, let's say revoked, then corresponding `participant.deposit` value is freed from `participant.grantee` Trust Deposit.
 - `slashed_deposit` (number) (*mandatory*): part of the deposit in [[ ref: native denom ]] that has been slashed.
 - `repaid_deposit` (number) (*mandatory*): part of the slashed deposit in [[ ref: native denom ]] that has been repaid.
 - `revoked` (timestamp) (*optional*): manual revocation timestamp of this Perm.
-- `validator_participant_id` (uint64) (*optional*): permission of the validator assigned to the validation process of this permission, ie *parent node* in the `Participant` tree.
+- `validator_participant_id` (uint64) (*optional*): permission of the validator assigned to the onboarding process of this permission, ie *parent node* in the `Participant` tree.
 - `vp_state` (enum) (*mandatory*): one of PENDING, VALIDATED, TERMINATED.
-- `vp_exp` (timestamp) (*optional*): validation expiration timestamp. This expiration timestamp is for the validation process itself, not for the issued credential or `Participant` expiration timestamp.
+- `vp_exp` (timestamp) (*optional*): validation expiration timestamp. This expiration timestamp is for the onboarding process itself, not for the issued credential or `Participant` expiration timestamp.
 - `vp_last_state_change` (timestamp) (*mandatory*)
 - `vp_validator_deposit`: number (*optional*): accumulated validator trust deposit, in [[ref: denom]].
-- `vp_current_fees` (number) (*mandatory*): current action escrowed fees that will be paid to [[ref: validator]] upon validation process completion, in [[ref: denom]].
+- `vp_current_fees` (number) (*mandatory*): current action escrowed fees that will be paid to [[ref: validator]] upon onboarding process completion, in [[ref: denom]].
 - `vp_current_deposit` (number) (*mandatory*): current action trust deposit, in [[ref: denom]].
 - `vp_summary_digest` (string) (*optional*): an optional digest SRI, set by [[ref: validator]], of a summary of the information, proofs... provided by the [[ref: applicant]].
-- `issuance_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_VALIDATION_PROCESS mode) or an ISSUER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
-- `verification_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_VALIDATION_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
+- `issuance_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_ONBOARDING_PROCESS mode) or an ISSUER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
+- `verification_fee_discount`: (number) (*mandatory*): default to 0 (no discount). Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_ONBOARDING_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 
 > Note: VS operator authorization settings (spend limits, feegrant, expiration, authorized message types) are no longer stored on `Participant`. They live in `ParticipantAuthorizationRecord` entries inside [VSOperatorAuthorization](#vsoperatorauthorization), keyed by `Participant.id`. See [[MOD-DE-MSG-5]](#mod-de-msg-5-grant-vs-operator-authorization) and [[AUTHZ-CHECK-3]](#authz-check-3-vs-operator-authorization-checks).
 
@@ -2271,7 +2271,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - `cs.digest_algorithm`: `digest_algorithm`
 
 :::note
-If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM `Participant` so that validation processes can be run.
+If needed, depending on configuration mode, Ecosystem controller MAY need to create a ECOSYSTEM `Participant` so that onboarding processes can be run.
 :::
 
 #### [MOD-CS-MSG-2] Update Credential Schema
@@ -2416,7 +2416,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 This message creates a **draft** `SchemaAuthorizationPolicy` for a given `(schema_id, role)`, or overwrites the existing draft policy if one already exists.  
 A draft policy is defined as a policy with `effective_from == null` and MUST NOT be revoked.
 
-Accordingly, if a credential schema defines one or more active policies for the ISSUER or VERIFIER role, the corresponding corporation that grants the ISSUER or VERIFIER role for this schema (ISSUER_GRANTOR, VERIFIER_GRANTOR, or ECOSYSTEM, depending on how schema issuer and verifier modes have been configured) MUST issue an IAC or VAC credential to the candidate upon successful completion of the validation process. Refer to the [Verifiable Trust spec](https://github.com/verana-labs/verifiable-trust-spec) for more information.
+Accordingly, if a credential schema defines one or more active policies for the ISSUER or VERIFIER role, the corresponding corporation that grants the ISSUER or VERIFIER role for this schema (ISSUER_GRANTOR, VERIFIER_GRANTOR, or ECOSYSTEM, depending on how schema issuer and verifier modes have been configured) MUST issue an IAC or VAC credential to the candidate upon successful completion of the onboarding process. Refer to the [Verifiable Trust spec](https://github.com/verana-labs/verifiable-trust-spec) for more information.
 
 ##### [MOD-CS-MSG-5-1] Create Schema Authorization Policy parameters
 
@@ -2756,9 +2756,9 @@ issuer --> holder: granted schema permission
 
 ```
 
-The ECOSYSTEM type permissions are created by the Credential Schema owner. All other permissions are created by running a Validation Process (or by any account: - for `ISSUER` permissions if issuer_onboarding_mode is equal to `OPEN`, - for `VERIFIER` permissions if verifier_onboarding_mode is equal to `OPEN`).
+The ECOSYSTEM type permissions are created by the Credential Schema owner. All other permissions are created by running an Onboarding Process (or by any account: - for `ISSUER` permissions if issuer_onboarding_mode is equal to `OPEN`, - for `VERIFIER` permissions if verifier_onboarding_mode is equal to `OPEN`).
 
-A Validation Process (VP) is a process which involves an [[ref: applicant]] (which is the [[ref: corporation]] of validation entry stored in a validation [[ref: keeper]]), a [[ref: validator]] permission, and optional validation fees plus transaction fees.
+A Onboarding Process (VP) is a process which involves an [[ref: applicant]] (which is the [[ref: corporation]] of validation entry stored in a validation [[ref: keeper]]), a [[ref: validator]] permission, and optional validation fees plus transaction fees.
 
 Validation is used by [[ref: applicants]] that want to:
 
@@ -2769,10 +2769,10 @@ Validation is used by [[ref: applicants]] that want to:
 - get issued a credential of a specific [[ref: credential schema]];
 - obtain a HOLDER permission from a issuer of a specific [[ref: credential schema]] and get issued a verifiable credential of this schema (HOLDER permission provide credential status (revoked, etc...));
 
-In all cases, the process is very similar. Example execution of a validation process:
+In all cases, the process is very similar. Example execution of an onboarding process:
 
-1. Applicant starts a validation process by running the [start new validation] [[ref: transaction]]. Validation process may be subject to paying validation fees, as defined by validator.
-2. Validation process requires that [[ref: applicant]] connects to a validation [[ref: VS]] identified by its [[ref: DID]], and execute a some validation steps, required for the validation process to conclude.
+1. Applicant starts an onboarding process by running the [start new validation] [[ref: transaction]]. Onboarding process may be subject to paying validation fees, as defined by validator.
+2. Onboarding process requires that [[ref: applicant]] connects to a validation [[ref: VS]] identified by its [[ref: DID]], and execute a some validation steps, required for the onboarding process to conclude.
 3. If [[ref: applicant]] qualifies, [[ref: validator]] updates the validation entry by running the [set to validated] [[ref: transaction]], and [[ref: applicant]] is granted new permissions, and/or gets issued a credential.
 
 Validation is valid for a specific period, for example 365 days, as configured in the [[ref: credential schema]] for credential schema related validations, or set by ecosystem for user-agent validation.
@@ -2783,12 +2783,12 @@ In some cases, even if the validation is valid for a period of time, the resulti
 
 If validation is set to expire, [[ref: applicant]] that wishes to extend the expiration timestamp must renew its validation.
 
-At any time, [[ref: applicant]] can cancel the validation process.
+At any time, [[ref: applicant]] can cancel the onboarding process.
 
 Some special unexpected situation may arise and must be mitigated. Examples:
 
-- if selected validator permission is revoked while applicant's validation is in PENDING state: Applicant CAN cancel the validation process [MOD-PP-MSG-6].
-- if selected validator permission is revoked while applicant is in VALIDATED state: Applicant CAN renew the validation process by choosing a new validator [MOD-PP-MSG-2].
+- if selected validator permission is revoked while applicant's validation is in PENDING state: Applicant CAN cancel the onboarding process [MOD-PP-MSG-6].
+- if selected validator permission is revoked while applicant is in VALIDATED state: Applicant CAN renew the onboarding process by choosing a new validator [MOD-PP-MSG-2].
 
 #### [MOD-PP-MSG-1] Start Participant VP
 
@@ -2796,7 +2796,7 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 ##### [MOD-PP-MSG-1-1] Start Participant VP parameters
 
-An Applicant that would like to start a permission validation process MUST execute this method by specifying:
+An Applicant that would like to start a permission onboarding process MUST execute this method by specifying:
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
@@ -2850,7 +2850,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - VS Operator Authorization parameters: if any of `vs_operator_authz_*` parameters is provided, `vs_operator_authz_msg_types` MUST also be provided and `vs_operator` MUST NOT be null, else abort. If `vs_operator_authz_msg_types` is provided, it MUST be a non-empty list of VPR delegable message types, and match the permitted messages defined in [MOD-PP-MSG-1-1](#mod-pp-msg-1-1-start-participant-vp-parameters).
 
 :::note
-A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It's up to the issuer to decide if running the validation process is REQUIRED or not.
+A holder MAY directly connect to the DID VS of an issuer in order to get issued a credential. It's up to the issuer to decide if running the onboarding process is REQUIRED or not.
 :::
 
 ###### [MOD-PP-MSG-1-2-2] Start Participant VP permission checks
@@ -2860,15 +2860,15 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 
 - if `type` (ParticipantRole) is equal to ISSUER:
 
-  - if `cs.issuer_onboarding_mode` is equal to GRANTOR_VALIDATION_PROCESS: `validator_participant.role` MUST be ISSUER_GRANTOR, else MUST abort.
+  - if `cs.issuer_onboarding_mode` is equal to GRANTOR_ONBOARDING_PROCESS: `validator_participant.role` MUST be ISSUER_GRANTOR, else MUST abort.
   
-  - else if `cs.issuer_onboarding_mode` is equal to ECOSYSTEM_VALIDATION_PROCESS: `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
+  - else if `cs.issuer_onboarding_mode` is equal to ECOSYSTEM_ONBOARDING_PROCESS: `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
 
   - else MUST abort.
 
 - else if `type` (ParticipantRole) is equal to ISSUER_GRANTOR:
 
-  - if `cs.issuer_onboarding_mode` is equal to GRANTOR_VALIDATION_PROCESS:  `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
+  - if `cs.issuer_onboarding_mode` is equal to GRANTOR_ONBOARDING_PROCESS:  `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
   
   - else abort.
 
@@ -2876,19 +2876,19 @@ A holder MAY directly connect to the DID VS of an issuer in order to get issued 
 
   - if `cs.verifier_onboarding_mode` is equal to GRANTOR: `validator_participant.role` MUST be VERIFIER_GRANTOR, else MUST abort.
   
-  - else if `cs.verifier_onboarding_mode` is equal to ECOSYSTEM_VALIDATION_PROCESS: `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
+  - else if `cs.verifier_onboarding_mode` is equal to ECOSYSTEM_ONBOARDING_PROCESS: `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
 
   - else abort.
 
 - else if `type` (ParticipantRole) is equal to VERIFIER_GRANTOR:
 
-  - if `cs.verifier_onboarding_mode` is equal to GRANTOR_VALIDATION_PROCESS: `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
+  - if `cs.verifier_onboarding_mode` is equal to GRANTOR_ONBOARDING_PROCESS: `validator_participant.role` MUST be ECOSYSTEM, else MUST abort.
   
   - else abort.
 
 - else if `type` (ParticipantRole) is equal to HOLDER:
 
-  - if `cs.holder_onboarding_mode` is equal to ISSUER_VALIDATION_PROCESS: `validator_participant.role` MUST be ISSUER, else MUST abort.
+  - if `cs.holder_onboarding_mode` is equal to ISSUER_ONBOARDING_PROCESS: `validator_participant.role` MUST be ISSUER, else MUST abort.
   
   - else abort.
 
@@ -2935,11 +2935,11 @@ Trust deposit MUST always be paid in [[ref: native denom]]
 
 ###### [MOD-PP-MSG-1-2-4] Start Participant VP overlap checks
 
-We want to make sure that 2 validation processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different VP with differents validators for the same `schema_id`, `type`.
+We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different VP with differents validators for the same `schema_id`, `type`.
 
 Find all permission `participants[]` for `schema_id`, `type`, `validator_participant_id`, `corporation` with vp_state = VALIDATED or PENDING.
 
-if size of `participants[]` > 0, it means there is already an existing validation process in this context, so MUST abort.
+if size of `participants[]` > 0, it means there is already an existing onboarding process in this context, so MUST abort.
 
 > note: this check was not present in v3.
 
@@ -2999,7 +2999,7 @@ If `vs_operator_authz_msg_types` is provided, create the [ParticipantAuthorizati
 
 This action must be initiated by the [[ref: applicant]].
 
-During a validation process, if the associated `validator_participant` includes a specific `did`, the [[ref: applicant]] should establish a secure connection with the validator's [[ref: VS]] (Verifiable Service) using a secure communication protocol such as [[ref: DIDComm]].
+During an onboarding process, if the associated `validator_participant` includes a specific `did`, the [[ref: applicant]] should establish a secure connection with the validator's [[ref: VS]] (Verifiable Service) using a secure communication protocol such as [[ref: DIDComm]].
 
 Upon connecting to the [[ref: VS]], the [[ref: applicant]] should be required by the [[ref: validator]] to complete one or more of the following tasks:
 
@@ -3007,14 +3007,14 @@ Upon connecting to the [[ref: VS]], the [[ref: applicant]] should be required by
 2. **Provide requested information**, such as filling out forms, submitting documents, or other forms of disclosure as required by the validation [[ref: VS]].
 3. If the requested permission includes a [[ref: VS]] DID, the [[ref: applicant]] should prove control over the corresponding [[ref: DID]] to the validator's [[ref: VS]].
 
-Once the [[ref: validator]] determines that the process is complete, they may terminate the validation process and create the permission accordingly. This permission configuration usually include:
+Once the [[ref: validator]] determines that the process is complete, they may terminate the onboarding process and create the permission accordingly. This permission configuration usually include:
 
 - `validation_fees`  
 - `issuance_fees`  
 - `verification_fees`  
 - `permission expiration`
 
-The [[ref: validator]] may compile a summary file of the validation process, documenting exchanged data, proofs, and decisions, and share it with the [[ref: applicant]] via the [[ref: VS]] connection or another secure channel.
+The [[ref: validator]] may compile a summary file of the onboarding process, documenting exchanged data, proofs, and decisions, and share it with the [[ref: applicant]] via the [[ref: VS]] connection or another secure channel.
 
 For audit or governance purposes, the [[ref: validator]] should register a digest (e.g., hash or SRI) of this summary in `applicant_participant.vp_summary_digest`.
 
@@ -3026,15 +3026,15 @@ Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
 - Requesting a renewal has no effect on permission expiration or issued credentials.
 - Renewal is only possible with the same validator.
-- If validator permission is not valid anymore, applicant MUST perform a new validation process with another validator.
-- Renewal does not allow changing the `participant.validation_fees`, `participant.issuance_fees`, `participant.verification_fees`. To change these values, applicant MUST start a new validation process.
+- If validator permission is not valid anymore, applicant MUST perform a new onboarding process with another validator.
+- Renewal does not allow changing the `participant.validation_fees`, `participant.issuance_fees`, `participant.verification_fees`. To change these values, applicant MUST start a new onboarding process.
 - if permission is revoked, slashed, or repaid, method MUST fail.
 
 ##### [MOD-PP-MSG-2-1] Renew Participant VP parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): id of the permission for which applicant would like to renew the validation process;
+- `id` (uint64) (*mandatory*): id of the permission for which applicant would like to renew the onboarding process;
 
 ##### [MOD-PP-MSG-2-2] Renew Participant VP precondition checks
 
@@ -3127,14 +3127,14 @@ An [[ref: account]] that would like to set a validation entry to VALIDATED MUST 
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `id` (uint64) (*mandatory*): id of the validation process;
-- `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this `Participant` is effective, null if no time limit should been set for this permission or if we want it to be aligned with the validation process expiration timestamp calculated by this method.
+- `id` (uint64) (*mandatory*): id of the onboarding process;
+- `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this `Participant` is effective, null if no time limit should been set for this permission or if we want it to be aligned with the onboarding process expiration timestamp calculated by this method.
 - `validation_fees` (number) (*mandatory*): Agreed validation_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
 - `issuance_fees` (number) (*mandatory*): Agreed issuance_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
 - `verification_fees` (number) (*mandatory*): Agreed verification_fees for this permission. Can be set only the first time this method is called (cannot be set for renewals). Use 0 for no fees.
 - `vp_summary_digest` (string) (*optional*): an optional digest, set by [[ref: validator]], of a summary of the information, proofs... provided by the [[ref: applicant]].
-- `issuance_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_VALIDATION_PROCESS mode) or an ISSUER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
-- `verification_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_VALIDATION_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_VALIDATION_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
+- `issuance_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to an ISSUER_GRANTOR, ISSUER permission (if GRANTOR_ONBOARDING_PROCESS mode) or an ISSUER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated issuance fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
+- `verification_fee_discount`: (number) (*mandatory*): use 0 for no discount. Maximum 1 (100% discount). Can be set to a VERIFIER_GRANTOR, VERIFIER permission (if GRANTOR_ONBOARDING_PROCESS mode) and/or a VERIFIER permission (ECOSYSTEM_ONBOARDING_PROCESS mode) to reduce (or void) calculated fees for subtree of permissions. Note: this should generally not be used because it reduces or void commission of all related ecosystem participants.
 
 ##### [MOD-PP-MSG-3-2] Set Participant VP to Validated precondition checks
 
@@ -3170,23 +3170,23 @@ else MUST abort.
 
 - `issuance_fee_discount` : (number) (*mandatory*):
   - if `applicant_participant.effective_from` is not null (renewal), then `issuance_fee_discount` must be equal to `applicant_participant.issuance_fee_discount` else MUST abort.
-  - if `cs.issuer_onboarding_mode` is set to GRANTOR_VALIDATION_PROCESS:
+  - if `cs.issuer_onboarding_mode` is set to GRANTOR_ONBOARDING_PROCESS:
     - if `applicant_participant.role` == ISSUER_GRANTOR: `issuance_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
     - if `applicant_participant.role` == ISSUER: if `validator_participant.issuance_fee_discount` is defined,  `issuance_fee_discount` can be set between 0 (no discount) and `validator_participant.issuance_fee_discount` (100% discount) inclusive.
-  - if `cs.issuer_onboarding_mode` is set to ECOSYSTEM_VALIDATION_PROCESS:
+  - if `cs.issuer_onboarding_mode` is set to ECOSYSTEM_ONBOARDING_PROCESS:
     - if `applicant_participant.role` == ISSUER: `issuance_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
   - else MUST abort.
 
 - `verification_fee_discount` : (number) (*mandatory*):
   - if `applicant_participant.effective_from` is not null (renewal), then `verification_fee_discount` must be equal to `applicant_participant.verification_fee_discount` else MUST abort.
-  - if `cs.verifier_onboarding_mode` is set to GRANTOR_VALIDATION_PROCESS:
+  - if `cs.verifier_onboarding_mode` is set to GRANTOR_ONBOARDING_PROCESS:
     - if `applicant_participant.role` == VERIFIER_GRANTOR: `verification_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
     - if `applicant_participant.role` == VERIFIER: if `validator_participant.verification_fee_discount` is defined,  `verification_fee_discount` can be set between 0 (no discount) and `validator_participant.verification_fee_discount` (100% discount) inclusive.
-  - if `cs.verifier_onboarding_mode` is set to ECOSYSTEM_VALIDATION_PROCESS:
+  - if `cs.verifier_onboarding_mode` is set to ECOSYSTEM_ONBOARDING_PROCESS:
     - if `applicant_participant.role` == VERIFIER: `verification_fee_discount` can be set between 0 (no discount) and 1 (100% discount) inclusive.
   - else MUST abort.
 
-Calculation of `vp_exp`, the validation process expiration timestamp, required to verify provided `effective_until`:
+Calculation of `vp_exp`, the onboarding process expiration timestamp, required to verify provided `effective_until`:
 
 - let's define `validity_period` = `cs.issuer_grantor_validation_validity_period` (if `applicant_participant.role` is ISSUER_GRANTOR), `cs.verifier_grantor_validation_validity_period` (if `applicant_participant.role` is VERIFIER_GRANTOR), `cs.issuer_validation_validity_period` (if `applicant_participant.role` is ISSUER), `cs.verifier_validation_validity_period` (if `applicant_participant.role` is VERIFIER), or `cs.holder_validation_validity_period` (if `applicant_participant.role` is HOLDER).
 
@@ -3205,7 +3205,7 @@ Now, let's verify `effective_until`:
 - load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active participant]].
 - `corporation` running the method MUST be `validator_participant.corporation`.
 
-If `validator_participant` is not a [[ref: active participant]] (expired, revoked, slashed...) then applicant MUST start a new validation process.
+If `validator_participant` is not a [[ref: active participant]] (expired, revoked, slashed...) then applicant MUST start a new onboarding process.
 
 ###### [MOD-PP-MSG-3-2-3] Set Participant VP to Validated fee checks
 
@@ -3298,7 +3298,7 @@ This call is a no-op if no record was created at [[MOD-PP-MSG-1]](#mod-pp-msg-1-
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-At any time, [[ref: applicant]] of a permission validation process may request cancellation of the process, provided state is PENDING. Upon method execution, the pending validation is cancelled and escrewed [[ref: trust fees]] are refunded. If `vp_exp` is not null, `vp_state` is set back to VALIDATED, else `vp_state` is set to TERMINATED.
+At any time, [[ref: applicant]] of a permission onboarding process may request cancellation of the process, provided state is PENDING. Upon method execution, the pending validation is cancelled and escrewed [[ref: trust fees]] are refunded. If `vp_exp` is not null, `vp_state` is set back to VALIDATED, else `vp_state` is set to TERMINATED.
 
 ##### [MOD-PP-MSG-6-1] Cancel Participant VP Last Request parameters
 
@@ -3353,7 +3353,7 @@ If `applicant_participant.vp_state` was set to TERMINATED (i.e. `applicant_parti
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
-This method is used by controller authorities of Ecosystems. When they create a Credential Schema, they need to create (a) permission(s) of type ECOSYSTEM so that other participants can run validation processes (if schema mode is ECOSYSTEM) or self create their permissions (schema mode set to OPEN).
+This method is used by controller authorities of Ecosystems. When they create a Credential Schema, they need to create (a) permission(s) of type ECOSYSTEM so that other participants can run onboarding processes (if schema mode is ECOSYSTEM) or self create their permissions (schema mode set to OPEN).
 
 ##### [MOD-PP-MSG-7-1] Create Root Participant parameters
 
@@ -3366,7 +3366,7 @@ An [[ref: account]] that would like to create a `Participant` entry MUST call th
 - `did` (string) (*mandatory*): [[ref: DID]] of the VS.
 - `effective_from` (timestamp) (*mandatory*): timestamp from when (exclusive) this Perm is effective. MUST be in the future.
 - `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this Perm is effective, null if it doesn't expire. If not null, MUST be greater than `effective_from`.
-- `validation_fees` (number) (*mandatory*): price to pay by applicant to validator for running a validation process that uses this perm as validator, for a given validation period, in the denom specified in the credential schema. Default to 0. Note that setting validation fees for OPEN schemas has no effect and does not mean a validation process must take place. For enabling validation processes, at least one of the two issuer, verifier mode must be different than OPEN.
+- `validation_fees` (number) (*mandatory*): price to pay by applicant to validator for running an onboarding process that uses this perm as validator, for a given validation period, in the denom specified in the credential schema. Default to 0. Note that setting validation fees for OPEN schemas has no effect and does not mean an onboarding process must take place. For enabling onboarding processes, at least one of the two issuer, verifier mode must be different than OPEN.
 - `issuance_fees` (number) (*mandatory*): price to pay by the issuer of a credential of this schema to the grantee of this perm when a credential is issued, in the denom specified in the credential schema. Default to 0.
 - `verification_fees` (number) (*mandatory*): price to pay by the verifier of a credential of this schema to the grantee of this perm when a credential is verified, in the denom specified in the credential schema. Default to 0.
 
@@ -4302,7 +4302,7 @@ Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else
 - `effective_from` (timestamp) (*optional*): timestamp from when (exclusive) this Perm is effective. MUST be in the future.
 - `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this Perm is effective, null if it doesn't expire. If not null, MUST be greater than `effective_from`.
 - `verification_fees` (number) (*optional*): price to pay by the verifier of a credential of this schema to the grantee of this ISSUER perm when a credential is verified, in the denom specified in the credential schema. Default to 0.
-- `validation_fees` (number) (*optional*): price to pay by the holder of a credential of this schema to the issuer when executing a validation process to obtain a credential, in the denom specified in the credential schema. Default to 0.
+- `validation_fees` (number) (*optional*): price to pay by the holder of a credential of this schema to the issuer when executing an onboarding process to obtain a credential, in the denom specified in the credential schema. Default to 0.
 
 The following VS Operator Authorization parameters are **optional** and collectively define the initial [ParticipantAuthorizationRecord](#participantauthorizationrecord) for this permission. Presence of `vs_operator_authz_msg_types` is the trigger: if it is not provided, no authorization record is created and the permission operates in manual mode. VSOA configuration is **frozen at creation time** and cannot be modified later; to change it, the permission MUST be revoked and re-created.
 
@@ -4498,7 +4498,7 @@ Anyone CAN execute this method.
 Generic query used for (at least):
 
 - find all permissions (all or limit to active) of a given schema;
-- for a given validator, get PENDING validation processes;
+- for a given validator, get PENDING onboarding processes;
 - find all permissions of a given grantee;
 - find all permissions of a given did;
 - find all ISSUER_GRANTOR active participants, so that I can apply to an ISSUER permission;
@@ -4951,7 +4951,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
 - else if `augend` < 0:
   - set `td.refunded` to `td.refunded` - `augend`
 
-The last case, `augend` < 0, is to refund trust deposit (e.g. when canceling a validation process). The refunded amount is added to `td.refunded` and is reused for the next trust deposit spending.
+The last case, `augend` < 0, is to refund trust deposit (e.g. when canceling an onboarding process). The refunded amount is added to `td.refunded` and is reused for the next trust deposit spending.
 
 #### [MOD-TD-MSG-2] Reclaim Trust Deposit Yield
 

--- a/spec.md
+++ b/spec.md
@@ -1514,7 +1514,7 @@ A `ParticipantAuthorizationRecord` carries the per-permission authorization conf
 - `fee_spend_limit` (DenomAmount[]) (*optional*): maximum total amount of transaction fees that can be spent by `vs_operator` (paid by `corporation` via fee grant) in the context of this permission.
 - `remaining_fee_spend` (DenomAmount[]) (*conditional*): runtime balance for `fee_spend_limit`. Present iff `fee_spend_limit` is set. Initialized, decremented and reset following the same rules as `remaining_spend`.
 - `with_feegrant` (bool) (*mandatory*): if true, `corporation` pays the transaction fees for `vs_operator` when executing authorized messages in the context of this permission, through an on-chain `FeeGrant`.
-- `expiration` (timestamp) (*mandatory*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the record is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the record auto-renews until removed via [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)). Initially written to `now` at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op) (disabled until validation) and to `Participant.effective_until` at [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-op-to-validated) / [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-participant) / [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant).
+- `expiration` (timestamp) (*mandatory*): authorization window boundary. If `period` is unset, this is the absolute end-of-life: when `now() >= expiration`, the record is dead. If `period` is set, this is the end of the current cycle: when `now() >= expiration`, the runtime balances are reset to their original limits and `expiration` is advanced to `now() + period` (the record auto-renews until removed via [[MOD-DE-MSG-6]](#mod-de-msg-6-revoke-vs-operator-authorization)). Initially written to `now` at [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op) (disabled until validation) and to `Participant.effective_until` at [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-op-to-validated) / [[MOD-PP-MSG-8]](#mod-pp-msg-8-set-participant-effective-until) / [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant).
 - `period` (duration) (*optional*): reset period for `spend_limit` and `fee_spend_limit` in the context of this permission.
 
 ### ExchangeRate
@@ -1876,7 +1876,7 @@ As a result, `accountABC` is authorized to:
 |                                | Set Participant OP to Validated          |        N/A (Tx)                     | Msg    | [[MOD-PP-MSG-3]](#mod-pp-msg-3-set-participant-op-to-validated)    |corporation + operator |
 |                                | Cancel Participant OP Last Request       |         N/A (Tx)                    | Msg    | [[MOD-PP-MSG-6]](#mod-pp-msg-6-cancel-participant-op-last-request)    |corporation + operator |
 |                                | Create Root Participant                  |         N/A (Tx)                | Msg    | [[MOD-PP-MSG-7]](#mod-pp-msg-7-create-root-participant)   |corporation + operator |
-|                                | Adjust Participant                       |         N/A (Tx)            | Msg    | [[MOD-PP-MSG-8]](#mod-pp-msg-8-adjust-participant)  |corporation + operator |
+|                                | Set Participant Effective Until                       |         N/A (Tx)            | Msg    | [[MOD-PP-MSG-8]](#mod-pp-msg-8-set-participant-effective-until)  |corporation + operator |
 |                                | Revoke Participant                       |          N/A (Tx)              | Msg    | [[MOD-PP-MSG-9]](#mod-pp-msg-9-revoke-participant)  |corporation + operator |
 |                                | Create or update Participant Session     |           N/A (Tx)              | Msg    | [[MOD-PP-MSG-10]](#mod-pp-msg-10-create-or-update-participant-session)  |corporation + operator |
 |                                | Update Participant Module Parameters     |           N/A (Tx)             | Msg    | [[MOD-PP-MSG-11]](#mod-pp-msg-11-update-participant-module-parameters) |governance proposal |
@@ -3211,10 +3211,10 @@ An Applicant that would like to start a permission onboarding process MUST execu
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
-- `vs_operator` (account) (*optional*): the account of the Veriable Service we want to authorize to create permission sessions linked to this permission. If not specified, Verifiable Service will not be able to use the payment delegation feature. **Required** to use the payment delegation feature.
-- `role` (ParticipantRole) (*mandatory*): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the permission that the applicant would like to get;
-- `validator_participant_id` (uint64) (*mandatory*): the [[ref: validator]] permission (parent permission in the tree), chosen by the applicant.
-- `validation_fees` (number) (*optional*): Requested validation_fees for this permission (can be modified by validator).
+- `vs_operator` (account) (*optional*): the account of the Veriable Service we want to authorize to create participant sessions linked to this participant. If not specified, Verifiable Service will not be able to use the payment delegation feature. **Required** to use the payment delegation feature.
+- `role` (ParticipantRole) (*mandatory*): (ISSUER_GRANTOR, VERIFIER_GRANTOR, ISSUER, VERIFIER, HOLDER): the Participant role that the applicant would like to get;
+- `validator_participant_id` (uint64) (*mandatory*): the [[ref: validator]] participant (parent participant in the tree), chosen by the applicant.
+- `validation_fees` (number) (*optional*): Requested validation_fees for this participant (can be modified by validator).
 - `issuance_fees` (number) (*optional*): Requested issuance_fees for this permission (can be modified by validator).
 - `verification_fees` (number) (*optional*): Requested verification_fees for this permission (can be modified by validator).
 - `did` (string) (*required*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
@@ -3574,7 +3574,7 @@ else MUST abort.
 - `validation_fees` (number) (*mandatory*): MUST be zero or a positive integer. If `applicant_participant.effective_from` is not null (we are in renewal) `validation_fees` MUST be equal to `applicant_participant.validation_fees`, else abort.
 - `issuance_fees` (number) (*mandatory*): MUST be zero or a positive integer.  If `applicant_participant.effective_from` is not null (we are in renewal) `issuance_fees` MUST be equal to `applicant_participant.issuance_fees` or, else abort.
 - `verification_fees` (number) (*mandatory*): MUST be zero or a positive integer.  If `applicant_participant.effective_from` is not null (we are in renewal) `verification_fees` MUST be equal to `applicant_participant.verification_fees`, else abort.
-- `op_summary_digest` (string) (*optional*): MUST be null if `validation.role` is set to HOLDER (for HOLDER, proofs can be stored in credentials). Else, MUST be a valid digest. Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
+- `op_summary_digest` (string) (*optional*): MUST be a valid digest. Example: `sha384-MzNNbQTWCSUSi0bbz7dbua+RcENv7C6FvlmYJ1Y+I727HsPOHdzwELMYO9Mz68M26`.
 
 - Load `CredentialSchema` `cs` from `applicant_participant.schema_id`.
 - Load `Participant` `validator_participant` from `applicant_participant.validator_participant_id`.
@@ -3830,7 +3830,7 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
 ###### [MOD-PP-MSG-7-2-4] Create Root Participant overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-participant) to set or adjust the `effective_until` value.
+We want to make sure that 2 permissions cannot be active at the same time. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Set Participant Effective Until](#mod-pp-msg-8-set-participant-effective-until) to set or adjust the `effective_until` value.
 
 Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, ECOSYSTEM,  `corporation`.
 
@@ -3884,7 +3884,7 @@ If `vs_operator_authz_msg_types` is provided, create the [ParticipantAuthorizati
 
 > Note: like [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant), the record is created with `expiration = participant.effective_until` and is therefore immediately active. If `with_feegrant` is true and `participant.effective_until > now`, [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance) grants the on-chain `FeeGrant` as part of this execution.
 
-#### [MOD-PP-MSG-8] Adjust Participant
+#### [MOD-PP-MSG-8] Set Participant Effective Until
 
 Any authorized `operator` CAN execute this method on behalf of a `corporation`.
 
@@ -3894,18 +3894,18 @@ This method can be called:
 - by `participant.corporation`, if it is a self-created permission (schema configuration is open)
 - by a `corporation` of a validator permission (if permission is managed by an OP).
 
-##### [MOD-PP-MSG-8-1] Adjust Participant parameters
+##### [MOD-PP-MSG-8-1] Set Participant Effective Until parameters
 
 - `corporation` (group): (Signer) the signing corporation on whose behalf this message is executed.
 - `operator` (account): (Signer) the account authorized by the `corporation` to run this Msg.
 - `id` (uint64) (*mandatory*): id of the permission;
 - `effective_until` (timestamp) (*mandatory*): timestamp until when (exclusive) this `Participant` will be effective.
 
-##### [MOD-PP-MSG-8-2] Adjust Participant precondition checks
+##### [MOD-PP-MSG-8-2] Set Participant Effective Until precondition checks
 
 If any of these precondition checks fail, [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-8-2-1] Adjust Participant basic checks
+###### [MOD-PP-MSG-8-2-1] Set Participant Effective Until basic checks
 
 if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
@@ -3920,7 +3920,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 
 > Note: This method can be used to both Extend or Reduce the `effective_until`, or set an `effective_until` if it was null,  which was not the case in spec v3.
 
-###### [MOD-PP-MSG-8-2-2] Adjust Participant advanced checks
+###### [MOD-PP-MSG-8-2-2] Set Participant Effective Until advanced checks
 
 1. ECOSYSTEM permissions
 
@@ -3935,13 +3935,13 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 - `effective_until` MUST be lower or equal to `applicant_participant.op_exp` else MUST abort.
 - load `validator_participant` from `applicant_participant.validator_participant_id`. `validator_participant` MUST be a [[ref: active participant]]. `corporation` running the method MUST be `validator_participant.corporation`.
 
-###### [MOD-PP-MSG-8-2-3] Adjust Participant fee checks
+###### [MOD-PP-MSG-8-2-3] Set Participant Effective Until fee checks
 
 Fee payer MUST have the required [[ref: estimated transaction fees]] in its [[ref: account]], else [[ref: transaction]] MUST abort.
 
-###### [MOD-PP-MSG-8-2-4] Adjust Participant overlap checks
+###### [MOD-PP-MSG-8-2-4] Set Participant Effective Until overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-participant) to set or adjust the `effective_until` value.
+We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Set Participant Effective Until](#mod-pp-msg-8-set-participant-effective-until) to set or adjust the `effective_until` value.
 
 Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `role`, `validator_participant_id`, `corporation`.
 
@@ -3953,7 +3953,7 @@ for each `Participant` entry `p` from `participants[]`:
 
 > note: this check was not present in v3.
 
-##### [MOD-PP-MSG-8-3] Adjust Participant execution
+##### [MOD-PP-MSG-8-3] Set Participant Effective Until execution
 
 If all precondition checks passed, [[ref: transaction]] is executed.
 
@@ -3972,7 +3972,7 @@ Synchronise VS Operator Authorization expiration, if any. Call [[MOD-DE-MSG-9]](
 - `participant_id`: `applicant_participant.id`
 - `new_expiration`: `applicant_participant.effective_until`
 
-This call is a no-op if no record exists for `applicant_participant.id`. If a record exists, its `expiration` is updated and the on-chain `FeeGrant` for the containing VSOA is refreshed via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance). Adjust Participant does **not** accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant)). Adjust also cannot create a record that does not already exist.
+This call is a no-op if no record exists for `applicant_participant.id`. If a record exists, its `expiration` is updated and the on-chain `FeeGrant` for the containing VSOA is refreshed via [[MOD-DE-MSG-5-5]](#mod-de-msg-5-5-recompute-vs-operator-fee-allowance). Set Participant Effective Until does **not** accept VSOA parameters and cannot modify any other field of the record; VSOA configuration is frozen at record creation (see [[MOD-PP-MSG-1]](#mod-pp-msg-1-start-participant-op) and [[MOD-PP-MSG-14]](#mod-pp-msg-14-self-create-participant)). This method also cannot create a record that does not already exist.
 
 #### [MOD-PP-MSG-9] Revoke Participant
 
@@ -4774,7 +4774,7 @@ Fee payer MUST have the required [[ref: estimated transaction fees]] available.
 
 ###### [MOD-PP-MSG-14-2-4] Self Create Participant overlap checks
 
-We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Extend Perm Msg](#mod-pp-msg-8-adjust-participant) to set or adjust the `effective_until` value.
+We want to make sure that 2 permissions cannot be active at the same time for the same `validator_participant_id`. If `corporation` wishes to create a new permission but existing active one never expires (or expire too far from now), `corporation` MUST use first the [Set Participant Effective Until](#mod-pp-msg-8-set-participant-effective-until) to set or adjust the `effective_until` value.
 
 Find all [[ref: active participants]] `participants[]` (not revoked, not slashed, not repaid) for `cs.id`, `role`, `validator_participant_id`, `corporation`.
 
@@ -5882,7 +5882,7 @@ This method does NOT read `Participant` state.
 This method can only be called directly by the following Participant module methods, with no signer check:
 
 - [Set Participant OP to Validated](#mod-pp-msg-3-set-participant-op-to-validated)
-- [Adjust Participant](#mod-pp-msg-8-adjust-participant)
+- [Set Participant Effective Until](#mod-pp-msg-8-set-participant-effective-until)
 
 It updates the `expiration` of the unique record identified by `participant_id` and recomputes the on-chain `FeeGrant` of its containing VSOA. No-op if no record exists for `participant_id`.
 

--- a/spec.md
+++ b/spec.md
@@ -2074,7 +2074,7 @@ Anyone CAN execute this method.
 
 ##### [MOD-CO-QRY-1-1] Get Corporation query parameters
 
-- `id` (uint64) (*mandatory*): the id of the Cosmos SDK [[ref: group]] that the target `Corporation` entry extends (a `Corporation` has no `id` of its own; its primary key is the underlying group).
+- `corporation` (group) (*mandatory*): the [[ref: corporation]] to fetch (i.e., the underlying Cosmos SDK [[ref: group]] whose `Corporation` entry is keyed by it).
 - `active_gf_only` (boolean) (*optional*): if true, include only current governance framework data. If false or null, returns everything.
 - `preferred_language` (string) (*optional*): if set, return only one document per version, preferring `preferred_language`.
 
@@ -2082,11 +2082,11 @@ Anyone CAN execute this method.
 
 If any of these checks fail, [[ref: query]] MUST fail.
 
-- `id` (uint64) (*mandatory*): MUST be a valid uint64.
+- `corporation` (group) (*mandatory*): MUST be a valid group id.
 
 ##### [MOD-CO-QRY-1-3] Get Corporation execution
 
-Return found `Corporation` entry (if any), as well as *all its nested* `GovernanceFrameworkVersion` and `GovernanceFrameworkDocument` entries. If `active_gf_only` is true, return only nested `GovernanceFrameworkVersion` and `GovernanceFrameworkDocument` entries for the active version.
+Return the `Corporation` entry keyed by `corporation` (if any), as well as *all its nested* `GovernanceFrameworkVersion` and `GovernanceFrameworkDocument` entries. If `active_gf_only` is true, return only nested `GovernanceFrameworkVersion` and `GovernanceFrameworkDocument` entries for the active version.
 
 #### [MOD-CO-QRY-2] List Corporations
 

--- a/spec.md
+++ b/spec.md
@@ -2225,7 +2225,7 @@ If all precondition checks passed, method is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- create and persist a new `Ecosystem` entry `tr`:
+- create and persist a new `Ecosystem` entry `ecosystem`:
 
 - `ecosystem.id` : auto-incremented uint64
 - `ecosystem.did`: `did`
@@ -2277,7 +2277,7 @@ If any of these precondition checks fail, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `id` (uint64) (*mandatory*): a `Ecosystem` entry `tr` with id `id` MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry `tr`.
+- `id` (uint64) (*mandatory*): a `Ecosystem` entry `ecosystem` with id `id` MUST exist and `corporation` executing the method MUST be the `corporation` of the `Ecosystem` entry `ecosystem`.
 - `did` (string) (*mandatory*): MUST conform to the DID Syntax, as specified [[spec-norm:DID-CORE]].
 
 ###### [MOD-ES-MSG-2-2-2] Update Ecosystem fee checks
@@ -2290,7 +2290,7 @@ If all precondition checks passed, method is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- load `Ecosystem` entry `tr` from `id` and set:
+- load `Ecosystem` entry `ecosystem` from `id` and set:
 
 - `ecosystem.did`: `did`
 - `ecosystem.modified`: current timestamp
@@ -2317,7 +2317,7 @@ If any of these precondition checks fail, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- load `Ecosystem` `tr` from `id`. `ecosystem.corporation` MUST be the corporation executing the method, else MUST abort.
+- load `Ecosystem` `ecosystem` from `id`. `ecosystem.corporation` MUST be the corporation executing the method, else MUST abort.
 - `archive` (boolean) (*mandatory*) MUST be a boolean.
   - If `archive` is true and `ecosystem.archived` is not null, MUST abort as `Ecosystem` is already archived.
   - If `archive` is false and `ecosystem.archived` is null, MUST abort as `Ecosystem` is already not archived.
@@ -2332,7 +2332,7 @@ If all precondition checks passed, method is executed.
 
 Method execution MUST perform the following tasks in a [[ref: transaction]], and rollback if any error occurs.
 
-- update `Ecosystem` entry `tr` with `ecosystem.id` equal to `id`:
+- update `Ecosystem` entry `ecosystem` with `ecosystem.id` equal to `id`:
 - if `archived` is true: set `ecosystem.archived` to current timestamp.
 - if `archived` is false: set `ecosystem.archived` to null.
 - `ecosystem.modified`: current timestamp
@@ -2489,6 +2489,7 @@ Method execution MUST perform the following tasks in a [[ref: transaction]], and
   - `gfv.corporation`: the signing `corporation` (or null if subject is an Ecosystem)
   - `gfv.created`: current timestamp
   - `gfv.version`: `version`
+  - `gfv.active_since`: null
 
 - if a `GovernanceFrameworkDocument` entry `gfd` exists with `gfd.gfv_id = gfv.id` and `gfd.language = doc_language`, update it:
   - `gfd.url`: `doc_url`
@@ -2627,7 +2628,7 @@ If any of these precondition checks fail, method MUST abort.
 - `corporation` (group): (Signer) signature must be verified.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
-- `ecosystem_id` MUST represent an existing `Ecosystem` entry `tr` and `ecosystem.corporation` MUST be the `corporation` executing the method.
+- `ecosystem_id` MUST represent an existing `Ecosystem` entry `ecosystem` and `ecosystem.corporation` MUST be the `corporation` executing the method.
 - `json_schema` MUST be a valid [[ref: Json Schema]], and size must not be greater than `GlobalVariables.credential_schema_schema_max_size`. `$id` of the [[ref: Json Schema]] is ignored and will be replaced during execution by the auto-generated id of this `CredentialSchema`.
 - `issuer_grantor_validation_validity_period` must be between 0 (never expire) and `GlobalVariables.credential_schema_issuer_grantor_validation_validity_period_max_days` days.
 - `verifier_grantor_validation_validity_period` must be between 0 (never expire) and `GlobalVariables.credential_schema_verifier_grantor_validation_validity_period_max_days` days.
@@ -2713,7 +2714,7 @@ If any of these precondition checks fail, method MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST represent an existing `CredentialSchema` entry `cs`.
-- load `Ecosystem` `tr` from `cs.ecosystem_id`. `ecosystem.corporation` MUST be the `corporation` executing the method, else MUST abort.
+- load `Ecosystem` `ecosystem` from `cs.ecosystem_id`. `ecosystem.corporation` MUST be the `corporation` executing the method, else MUST abort.
 - `issuer_grantor_validation_validity_period` MUST be between 0 (never expire) and `GlobalVariables.credential_schema_issuer_grantor_validation_validity_period_max_days` days.
 - `verifier_grantor_validation_validity_period` MUST be between 0 (never expire) and `GlobalVariables.credential_schema_verifier_grantor_validation_validity_period_max_days` days.
 - `issuer_validation_validity_period` MUST be between 0 (never expire) and `GlobalVariables.credential_schema_issuer_validation_validity_period_max_days` days.
@@ -2764,7 +2765,7 @@ If any of these precondition checks fail, method MUST abort.
 - `operator` (account): (Signer) signature must be verified.
 - [[AUTHZ-CHECK]](#authz-check-common-authorization-and-fee-grant-precondition-checks) MUST pass for this (`corporation`, `operator`) pair and this message type.
 - `id` MUST represent an existing `CredentialSchema` entry `cs`.
-- load `Ecosystem` `tr` from `cs.ecosystem_id`. `ecosystem.corporation` MUST be the `corporation` executing the method, else MUST abort.
+- load `Ecosystem` `ecosystem` from `cs.ecosystem_id`. `ecosystem.corporation` MUST be the `corporation` executing the method, else MUST abort.
 - `archive` (boolean) (*mandatory*) MUST be a boolean. 
   - If `archive` is true and `cs.archived` is not null, MUST abort as Credential Schema is already archived.
   - If `archive` is false and `cs.archived` is null, MUST abort as Credential Schema is already not archived.
@@ -3820,7 +3821,7 @@ if a mandatory parameter is not present, [[ref: transaction]] MUST abort.
 To execute this method, [[ref: account]] MUST match at least one these rules, else [[ref: transaction]] MUST abort.
 
 - The related `CredentialSchema` entry is loaded with `schema_id`, and will be named `cs` in this section.
-- The related `Ecosystem` entry `tr` is loaded from `cs.ecosystem_id`.
+- The related `Ecosystem` entry `ecosystem` is loaded from `cs.ecosystem_id`.
 - `corporation` executing the method MUST be `ecosystem.corporation`.
 - else MUST abort.
 
@@ -4023,7 +4024,7 @@ if `applicant_participant.validator_participant_id` is defined:
 *Option #2*: executed by `Ecosystem` controller
 
 - load `CredentialSchema` `cs` from `applicant_participant.schema_id`
-- load `Ecosystem` `tr` from `cs.ecosystem_id`
+- load `Ecosystem` `ecosystem` from `cs.ecosystem_id`
 - if `corporation` running the method is `ecosystem.corporation`, return true.
 - else return false.
 
@@ -4619,7 +4620,7 @@ if `applicant_participant.validator_participant_id` is defined:
 *Option #2*: executed by `Ecosystem` controller
 
 - load `CredentialSchema` `cs` from `applicant_participant.schema_id`
-- load `Ecosystem` `tr` from `cs.ecosystem_id`
+- load `Ecosystem` `ecosystem` from `cs.ecosystem_id`
 - if `corporation` running the method is `ecosystem.corporation`, return true.
 - else return false.
 


### PR DESCRIPTION
## Summary
 
This PR completes the v3→v4 entity model reshape:
 
- **Renames** `Permission` → `Participant` and `TrustRegistry` → `Ecosystem` across the entire spec (entities, glossary, msg/query params, anchors, REST paths, PlantUML, sequence diagrams).
- **Renames** the validation pipeline to onboarding terminology (`validation process` → `onboarding process`, `ValidationState` → `OnboardingState`, `vp_*` fields → `op_*`, "VP" → "OP" in method headers).
- **Introduces `Corporation`** as a first-class VPR entity that extends a Cosmos SDK group with VPR-level attributes (DID, governance framework, lifecycle). Corporations have **no uint64 id** — the primary key is the underlying group.
- **Adds `MOD-CO` (Corporation Module)** with create/update/archive/queries.
- **Extracts `MOD-GF` (Governance Framework Module)** from `MOD-ES` and makes it **polymorphic** over Ecosystem-or-Corporation (handles both EGFs and CGFs).
- **Adds `AUTHZ-CHECK-5`** — every delegable Msg now requires the signing `corporation` to have a registered `Corporation` entry.
 
---
 
## Breaking changes
 
| Old | New |
|---|---|
| `Permission` entity | `Participant` entity |
| `TrustRegistry` entity | `Ecosystem` entity |
| `Permission.type` | `Participant.role` |
| `corporation_id (uint64)` (everywhere) | `corporation (group)` |
| `validation_*` fields | `onboarding_*` / `op_*` fields |
| `ValidationState` enum | `OnboardingState` enum |
| `Set Permission VP to Validated` | `Set Participant OP to Validated` |
| `Adjust Participant` (MOD-PP-MSG-8) | `Set Participant Effective Until` |
| `MOD-ES-MSG-2/3` (GF doc + version bump) | `MOD-GF-MSG-1/2` (extracted module) |
| Ecosystem REST prefix `/es/v1/...` | `/ec/v1/...` |
| `MOD-CO-MSG-2 Update Corporation`: `language` param | **removed** (immutable; set at create) |
| `MOD-GF-MSG-1/2`: target `corporation_id` param | **dropped** (redundant with Signer; subject = signer's CGF if `ecosystem_id` is null) |
 
---
 
## New entities & modules
 
- **`Corporation`** — group-keyed; fields: `did`, `language`, `active_version`, `created/modified/archived`. Glossary terms: `corporation`, `corporation governance framework (CGF)`, `corporation governance authority (CGA)`.
- **`MOD-CO` (Corporation Module)** — `MOD-CO-MSG-1` Create / `-MSG-2` Update / `-MSG-3` Archive / `-MSG-4` Update Module Params + `-QRY-1/2/3` Get / List / Params.
- **`MOD-GF` (Governance Framework Module)** — `MOD-GF-MSG-1` Add GF Document / `-MSG-2` Increase Active GF Version + `-QRY-1/2` Get / List GF Versions. All polymorphic over `Ecosystem` (`ecosystem_id` set) or `Corporation` (signing corp's own CGF when `ecosystem_id` not set).
- **`AUTHZ-CHECK-5`** — corporation registration check, applied to all delegable Msgs.
 
---
 
## Highlights of editorial / structural changes
 
- "What is a VPR?" overview now mentions Corporations as foundational actors.
- Features section, Pay-Per Trust Fees, Onboarding Process Trust Fees, and "Governance of a VPR" rewritten for v4 terminology (CGFs alongside EGFs).
- Participant Module intro prose cleaned; Method List re-tabulated.
- `Corporation` reordered before `Ecosystem` in the Data Model section.
- PlantUML diagrams aligned with the new entity model and `(group)` typing.
- Glossary: added `corporation`, `CGF`, `CGA`; renamed `credential schema permission` → `credential schema participant`; `active/future permission` → `active/future participant`.
 
