### PR TITLE
fix(spec): use canonical PricingAssetType enum value `TU` and asset string `"tu"` in MOD-XR-MSG-1-2

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -6145,10 +6145,10 @@ If any of the following conditions is not satisfied, [[ref: transaction]] MUST a
   - `quote_asset` MUST be non-empty.
   
 - **Asset type / identifier consistency**
-  - If `base_asset_type = TRUST_UNIT`:
-    - `base_asset` MUST equal `"TU"`.
-  - If `quote_asset_type = TRUST_UNIT`:
-    - `quote_asset` MUST equal `"TU"`.
+  - If `base_asset_type = TU`:
+    - `base_asset` MUST equal `"tu"`.
+  - If `quote_asset_type = TU`:
+    - `quote_asset` MUST equal `"tu"`.
 
   - If `base_asset_type = COIN`:
     - `base_asset` MUST be a valid Cosmos-SDK denom string.


### PR DESCRIPTION
## Summary

Fixes an internal inconsistency in `MOD-XR-MSG-1-2` Asset type / identifier consistency rules (lines 6148–6151), which used `TRUST_UNIT` as the enum value and `"TU"` as the asset identifier — contradicting the rest of the spec.

## Convention (now applied consistently)

- **`TU`** is the `PricingAssetType` **enum value** (asset *type*).
- **`"tu"`** is the asset *identifier string*.

## Diff

```diff
-  - If `base_asset_type = TRUST_UNIT`:
-    - `base_asset` MUST equal `"TU"`.
-  - If `quote_asset_type = TRUST_UNIT`:
-    - `quote_asset` MUST equal `"TU"`.
+  - If `base_asset_type = TU`:
+    - `base_asset` MUST equal `"tu"`.
+  - If `quote_asset_type = TU`:
+    - `quote_asset` MUST equal `"tu"`.
```

## Why these are the right values

The pre-fix lines 6148–6151 were the **only** place in the spec that used `TRUST_UNIT` and `"TU"`. Every other reference uses `TU` and `"tu"`:

- **Canonical PlantUML enum definition** (line 1158): the `PricingAssetType` enum is declared with members `TU`, `COIN`, `FIAT`.
- **`CredentialSchema` definition** (line 1430): `pricing_asset (string) (mandatory): "tu" if pricing_asset_type is set to TU, …`
- **`MOD-XR-QRY-2` query checks** (lines 6408–6410): use `TU` as the `base_asset_type` enum value.
- **`MOD-PP` fee-distribution math** (lines 4335, 4467): `getPrice(TU, "tu", COIN, …)` calls use `TU` for the type and `"tu"` for the asset.

So `TRUST_UNIT` / `"TU"` were the outliers. This PR aligns lines 6148–6151 with the canonical convention.

## Open question (out of scope, flagging for follow-up)

There's a separate, unrelated semantic conflict in the `ExchangeRate` rules that this PR does **not** address:

- **`ExchangeRate` model** (line 1588): `base_asset (string) (conditional): … MUST be null when base_asset_type is TU`
- **`MOD-XR-QRY-2` query checks** (line 6408): `if base_asset_type is set to TU, base_asset MUST be null`
- **`MOD-XR-MSG-1-2`** (this PR, post-fix line 6149): `base_asset MUST equal "tu"`

Two of the three sources say `base_asset` MUST be **null** when `base_asset_type = TU`, but `MOD-XR-MSG-1-2` (after this PR) says it MUST equal `"tu"`. This is an `ExchangeRate`-specific semantics question (whether the `TU` "asset" has any string identifier in this context, or is represented as null), distinct from the `TU` / `"tu"` rename. A follow-up PR should pick one and align all three locations.

## Downstream impact

Spotted this while reviewing the `verana-spec/v4/verana-indexer/spec.md` indexer spec, which had inherited the `TRUST_UNIT` / `"TU"` reading from the pre-fix lines. A matching update in that repo will follow.