### PR TITLE
refactor: change credential schema VPR URN to colon-separated form; bump to v4-rc3

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,6 +1,6 @@
 # Verifiable Public Registry v4 Specification
 
-**Latest draft:** [spec v4-rc2](https://verana-labs.github.io/verifiable-trust-vpr-spec/)
+**Latest draft:** [spec v4-rc3](https://verana-labs.github.io/verifiable-trust-vpr-spec/)
 
 **Latest stable:** [spec v3](https://verana-labs.github.io/verifiable-trust-vpr-spec/index-v3.html)
 
@@ -387,7 +387,7 @@ Example of a Json Schema credential schema:
 
 ```json
 {
-  "$id": "vpr:verana:mainnet/cs/v1/js/VPR_CREDENTIAL_SCHEMA_ID", // ignored, will be generated
+  "$id": "vpr:verana:mainnet:cs:VPR_CREDENTIAL_SCHEMA_ID", // ignored, will be generated
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "ExampleCredential",
   "description": "ExampleCredential using JsonSchema",


### PR DESCRIPTION
## Summary

Changes the credential-schema VPR reference to a URN-style colon-separated form, and bumps the spec version.

## URN format change

| Old | New |
| --- | --- |
| `vpr:verana:<chain>/cs/v1/js/<id>` | `vpr:verana:<chain>:cs:<id>` |

Updated the `$id` example in the credential-schema JSON Schema (line 390). The HTTP API path `/cs/v1/js/{id}` for `[MOD-CS-QRY-3] Render Json Schema` is intentionally left unchanged — only the `vpr:` URN scheme changes, not the REST endpoint.

## Version bump

`**Latest draft:** spec v4-rc2` → `spec v4-rc3` (line 3).

## Notes

- `index.html` is intentionally not edited — it is regenerated from `spec.md` by the deploy workflow (spec-up) on merge to `main`.
- `spec-v3.md` (the v3 archive) is left untouched.
- Companion changes: `verana-spec` (pushed to working branch) and `verifiable-trust-spec` ([PR #53](https://github.com/verana-labs/verifiable-trust-spec/pull/53), bumped to v4-rc1).