### PR TITLE
fix: remove trust deposit withdrawal references and bump to v4-rc5

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -643,8 +643,6 @@ The trust deposit is fundamental to the **"Proof-of-Trust" (PoT)** mechanism of 
 - **network-level penalties**: If a participant violates the [[ref: governance framework]] of the [[ref: VPR]] or engages in **fraudulent activity**, their **trust deposit may be partially or fully slashed** by the [[ref: VPR]]'s governance authority.
 - **ecosystem-level penalties**: If a participant operates within an ecosystem (e.g., as a [[ref: grantor]], [[ref: issuer]], [[ref: verifier]], or [[ref: holder]],...) and **fails to comply** with that ecosystem’s governance framework (EGF), their **ecosystem-specific trust deposit can be slashed** by the corresponding ecosystem governance authority.
 - A slashed deposit must be **refilled** to continue using the services that triggered the penalty.
-- When a participant **withdraws from an ecosystem**, the associated accumulated trust deposit **may be released**.
-- Released deposits can be **reused** in other services or **withdrawn**, however, withdrawals incur penalties, and **a portion of the withdrawn amount is burned**.
 - Holding a large trust deposit **does not grant governance rights** in the [[ref: VPR]]: participants who generate high transaction volume **cannot gain control** over the governance of the [[ref: VPR]] solely through usage or deposit size.
 
 This system ensures that participation in the trust ecosystem is backed by economic accountability, reinforcing the integrity, governability and verifiability of the [[ref: VPR]].


### PR DESCRIPTION
## Summary

The non-normative **Trust Deposit** business-models section described a trust-deposit **withdrawal** mechanism that has been removed from the model. This PR removes those references and bumps the draft version.

## Changes

- Removed two bullets in the `#### Trust Deposit` section:
  - "When a participant **withdraws from an ecosystem**, the associated accumulated trust deposit **may be released**."
  - "Released deposits can be **reused** in other services or **withdrawn**, however, withdrawals incur penalties, and **a portion of the withdrawn amount is burned**."
- Bumped draft version `v4-rc4` → `v4-rc5`.

## Notes

The normative Trust Deposit module is already consistent with the no-withdrawal model:
- `MOD-TD-MSG-3` is already marked **Void** (the retired reclaim/withdraw-deposit method).
- `MOD-TD-MSG-2` only reclaims **yield**, not deposit principal.
- The `refunded` field is internal accounting (e.g. onboarding cancellation), not a withdrawal to wallet.

No other withdrawal-related inconsistencies were found in the spec.