### PR TITLE
docs: bump spec draft version to v4-rc5

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1,6 +1,6 @@
 # Verifiable Public Registry v4 Specification
 
-**Latest draft:** [spec v4-rc4](https://verana-labs.github.io/verifiable-trust-vpr-spec/)
+**Latest draft:** [spec v4-rc5](https://verana-labs.github.io/verifiable-trust-vpr-spec/)
 
 **Latest stable:** [spec v3](https://verana-labs.github.io/verifiable-trust-vpr-spec/index-v3.html)
 


### PR DESCRIPTION
## Summary

Bump the draft version label from `v4-rc4` to `v4-rc5`.

This was intended as part of PR #143 (trust deposit withdrawal fix) but the version-line change did not make it into that commit (its merged diff was `additions: 0, deletions: 2`). This PR applies the missing bump.

## Changes

- `spec.md`: `**Latest draft:** [spec v4-rc4]` → `[spec v4-rc5]`