### PR TITLE
docs: add rationale for non-withdrawable trust deposits

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -647,6 +647,16 @@ The trust deposit is fundamental to the **"Proof-of-Trust" (PoT)** mechanism of 
 
 This system ensures that participation in the trust ecosystem is backed by economic accountability, reinforcing the integrity, governability and verifiability of the [[ref: VPR]].
 
+#### Why Trust Deposits Are Non-Withdrawable
+
+*This section is non-normative.*
+
+A [[ref: trust deposit]] cannot be withdrawn. This is a deliberate design choice, motivated by the following rationale:
+
+- **Lasting accountability to the ecosystem.** A trust deposit is bound to the ecosystem it was accumulated in. Choosing to stop using that ecosystem does not release a participant from its obligations toward it — a participant cannot simply walk away and harm the ecosystem because they no longer need it. Since the accumulated deposit cannot be moved, the participant remains economically accountable: any harmful behavior can still be slashed, lowering their trust score.
+- **Sustained token demand.** Making deposits non-withdrawable locks value into the system, creating ongoing demand for the token rather than allowing it to flow back out.
+- **No exit-and-rejoin arbitrage.** Token value fluctuates over time, so a deposit made in the past typically represents more value today. If deposits were withdrawable, a participant could leave the ecosystem solely to withdraw their appreciated deposit and then rejoin — gaming the mechanism. Non-withdrawability removes this incentive.
+
 #### Onboarding Process Trust Fees
 
 *This section is non-normative.*


### PR DESCRIPTION
## Summary

Adds a non-normative subsection **"Why Trust Deposits Are Non-Withdrawable"** to the Trust Deposit business-models section, documenting the rationale behind the no-withdrawal design.

## Rationale captured

- **Lasting accountability to the ecosystem** — the deposit stays bound to its ecosystem, so a participant remains slashable and cannot walk away to harm it.
- **Sustained token demand** — locking value in creates ongoing token demand.
- **No exit-and-rejoin arbitrage** — prevents leaving solely to withdraw an appreciated deposit and rejoining.

Follows up on #143, which removed the contradictory withdrawal text.