### PR TITLE
ci: pin GitHub Actions to full-length commit SHAs (org policy)

### DIFF
--- a/.github/workflows/build-and-deploy-spec.yml
+++ b/.github/workflows/build-and-deploy-spec.yml
@@ -34,19 +34,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Install and Build 🔧 # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
         run: |
           npm install
           npm run render
           rm -rf node_modules
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           # Upload entire repository
           path: '.'
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
The org now rejects `uses: <action>@vN` — all actions must be pinned to a full-length commit SHA. This pins the Pages deploy workflow:

| Action | Pinned SHA | Version |
|---|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4.3.1 |
| `actions/configure-pages` | `983d7736d9b0ae728b81ab479565c72886d7745b` | v5.0.0 |
| `actions/upload-pages-artifact` | `56afc609e74202658d3ffba0e8f6dda462b719fa` | v3.0.1 |
| `actions/deploy-pages` | `d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e` | v4.0.5 |

SHAs resolved from the upstream repos via `git ls-remote` (all lightweight tags → true commit SHAs); each pin carries a `# vX.Y.Z` comment. Fixes the currently failing Pages deploy on `main`.

(Re-opened from a fresh branch off `main` — the original commit rode the already-merged #146 branch.)