### PR TITLE
ci: bump upload-pages-artifact to v4.0.0 (nested SHA-pinning violation)

### DIFF
--- a/.github/workflows/build-and-deploy-spec.yml
+++ b/.github/workflows/build-and-deploy-spec.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           # Upload entire repository
           path: '.'


### PR DESCRIPTION
The Pages deploy still fails after #147: `upload-pages-artifact` is a **composite** action, and v3.0.1's own `action.yml` calls `actions/upload-artifact@v4` by tag — the org SHA-pinning policy rejects nested tag references too.

v4.0.0 (`7b1f4a764d45c48632c6b24a0339c27f5614fb0b`) fixes exactly this: it internally pins `actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2`.

The other three actions in the workflow (`checkout`, `configure-pages`, `deploy-pages`) are plain node actions with no nested `uses:` — verified, no further surprises.

(Re-opened from a fresh branch off `main` — the original commit landed on the #147 branch after its merge.)