### PR TITLE
fix(params): correct agent reward rate defaults to 10% (0.10)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1634,8 +1634,8 @@ Exchange rates are a *protocol-level oracle*: they are consumed by [[MOD-XR-QRY-
 - `trust_deposit_rate`(number) (*mandatory*): Rate used for dynamically calculating trust deposits from trust fees. Default value: 20% (0.20)
 - `trust_deposit_max_yield_rate`(number) (*mandatory*): Maximum yearly yield, in percent, that a trust deposit holder can obtain by receiving block rewards.
 - `trust_deposit_block_reward_share`(number) (*mandatory*): Percentage of block reward that must be distributed to trust deposit holders. Default value: 20% (0.20)
-- `wallet_user_agent_reward_rate`(number) (*mandatory*): Rate used for dynamically calculating wallet user agent rewards from trust fees. Default value: 20% (0.20)
-- `user_agent_reward_rate`(number) (*mandatory*): Rate used for dynamically calculating user agent rewards from trust fees. Default value: 20% (0.20)
+- `wallet_user_agent_reward_rate`(number) (*mandatory*): Rate used for dynamically calculating wallet user agent rewards from trust fees. Default value: 10% (0.10)
+- `user_agent_reward_rate`(number) (*mandatory*): Rate used for dynamically calculating user agent rewards from trust fees. Default value: 10% (0.10)
 
 ## Module Requirements
 


### PR DESCRIPTION
## What

Corrects the stated default values of `wallet_user_agent_reward_rate` and `user_agent_reward_rate` from 20% (0.20) to 10% (0.10).

## Why

The parameter descriptions were inconsistent with the `[GLO]` value of 0.10. This reconciles the spec text with the intended defaults.