### PR TITLE
chore(spec): set trust_deposit_rate default to 5% (0.05)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -727,7 +727,7 @@ The **total fees** paid by the applicant consist of:
 - an additional amount equal to the `trust_deposit_rate` of that validation [[ref: trust fees]], which is **allocated to the applicant's [[ref: trust deposit]]** when the onboarding process begins, **plus**
 - [[ref: network fees]] (not part of the escrowed amount).
 
-Example, using 20% for `trust_deposit_rate`:
+Example, using 5% for `trust_deposit_rate`:
 
 ```plantuml
 
@@ -738,10 +738,10 @@ scale max 1200 width
 
 package "Applicant" as issuer #7677ed {
     object "A Account" as issuera {
-         \t-1200 TUs
+         \t-1050 TUs
     }
     object "A Trust Deposit" as issuertd {
-         \t+200 TUs
+         \t+50 TUs
     }
 
 }
@@ -749,7 +749,7 @@ package "Applicant" as issuer #7677ed {
 object "Escrow Account" as escrow
 
 issuera -r-> escrow: \t+1000 TUs
-issuera --> issuertd:  \t+200 TUs
+issuera --> issuertd:  \t+50 TUs
 
 
 @enduml
@@ -768,10 +768,10 @@ scale max 1200 width
 
 package "Issuer Grantor B" as ig {
     object "IG Account" as iga {
-        \t+800 TUs
+        \t+950 TUs
     }
     object "IG Trust Deposit" as igtd {
-        \t+200 TUs
+        \t+50 TUs
     }
 }
 object "Escrow Account" as escrow
@@ -779,8 +779,8 @@ object "Escrow Account" as escrow
 
 
 escrow -r-> ig: \t+1000 TUs \t\t\t\t\t
-ig --> iga: \t+800 TUs
-ig --> igtd: \t+200 TUs
+ig --> iga: \t+950 TUs
+ig --> igtd: \t+50 TUs
 
 @enduml
 
@@ -862,7 +862,7 @@ If not, they **must reject** the issuance or verification request.
 Note: The **User Agent** and **Wallet User Agent** may refer to the same implementation.
 :::
 
-Distribution example for the issuance by `ISSUER` #C of a credential, using the `Participant` tree above, 20% for `trust_deposit_rate`, 10% for `wallet_user_agent_reward_rate` and `user_agent_reward_rate`.
+Distribution example for the issuance by `ISSUER` #C of a credential, using the `Participant` tree above, 5% for `trust_deposit_rate`, 10% for `wallet_user_agent_reward_rate` and `user_agent_reward_rate`.
 
 ```plantuml
 
@@ -872,46 +872,46 @@ scale max 800 width
 
 package "Ecosystem #A" as tr #3fbdb6 {
     object "E Account" as tra {
-         \t+8 TUs
+         \t+9.5 TUs
     }
     object "E Trust Deposit" as trtd {
-         \t+2 TUs
+         \t+0.5 TUs
     }
 }
 
 package "Issuer Grantor #B" as ig {
     object "IG Account" as iga {
-        \t+4 TUs
+        \t+4.75 TUs
     }
     object "IG Trust Deposit" as igtd {
-        \t+1 TUs
+        \t+0.25 TUs
     }
 }
 package "Issuer #C" as issuer #7677ed {
     object "I Account" as issuera {
-         \t-21 TUs
+         \t-18.75 TUs
     }
     object "I Trust Deposit" as issuertd {
-         \t+3 TUs
+         \t+0.75 TUs
     }
 
 }
 
 package "User Agent" as ua {
     object "UA Account" as uaa {
-         \t+1.2 TUs
+         \t+1.425 TUs
     }
     object "UA Trust Deposit" as uatd {
-        \t+0.3 TUs
+        \t+0.075 TUs
     }
 
 }
 package "Wallet User Agent" as wua {
     object "WUA Account" as wuaa {
-         \t+1.2 TUs
+         \t+1.425 TUs
     }
     object "WUA Trust Deposit" as wuatd {
-        \t+0.3 TUs
+        \t+0.075 TUs
     }
 
 }
@@ -924,13 +924,13 @@ issuera -d-> ua: \t+1.5 TUs
 
 issuera -d-> wua: \t+1.5 TUs
 
-issuera --> issuertd:  \t+3 TUs
+issuera --> issuertd:  \t+0.75 TUs
 
 @enduml
 
 ```
 
-Distribution example for the verification by `VERIFIER` #E of a credential issued by `ISSUER` #C, using the `Participant` tree above, 20% for `trust_deposit_rate`, 10% for `wallet_user_agent_reward_rate` and `user_agent_reward_rate`.
+Distribution example for the verification by `VERIFIER` #E of a credential issued by `ISSUER` #C, using the `Participant` tree above, 5% for `trust_deposit_rate`, 10% for `wallet_user_agent_reward_rate` and `user_agent_reward_rate`.
 
 ```plantuml
 
@@ -940,63 +940,63 @@ scale max 800 width
 
 package "Ecosystem #A" as tr #3fbdb6 {
     object "E Account" as tra {
-         \t+16 TUs
+         \t+19 TUs
     }
     object "E Trust Deposit" as trtd {
-         \t+4 TUs
+         \t+1 TUs
     }
 }
 
 package "Issuer Grantor #B" as ig {
     object "IG Account" as iga {
-        \t+4 TUs
+        \t+4.75 TUs
     }
     object "IG Trust Deposit" as igtd {
-        \t+1 TUs
+        \t+0.25 TUs
     }
 }
 package "Issuer #C" as issuer #7677ed {
     object "I Account" as issuera {
-         \t+24 TUs
+         \t+28.5 TUs
     }
     object "I Trust Deposit" as issuertd {
-         \t+6 TUs
+         \t+1.5 TUs
     }
 
 }
 package "Verifier Grantor #D" as vg {
     object "VG Account" as vga {
-        \t+1.6 TUs
+        \t+1.9 TUs
     }
     object "VG Trust Deposit" as vgtd {
-        \t+0.4 TUs
+        \t+0.1 TUs
     }
 
 }
 package "Verifier #E" as verifier #00b0f0 {
     object "V Account" as verifiera {
-        \t-79.8 TUs
+        \t-71.25 TUs
     }
     object "V Trust Deposit" as verifiertd {
-        \t+11.4 TUs
+        \t+2.85 TUs
     }
 
 }
 package "User Agent" as ua {
     object "UA Account" as uaa {
-         \t+4.56 TUs
+         \t+5.415 TUs
     }
     object "UA Trust Deposit" as uatd {
-        \t+1.14 TUs
+        \t+0.285 TUs
     }
 
 }
 package "Wallet User Agent" as wua {
     object "WUA Account" as wuaa {
-         \t+4.56 TUs
+         \t+5.415 TUs
     }
     object "WUA Trust Deposit" as wuatd {
-        \t+1.14 TUs
+        \t+0.285 TUs
     }
 
 }
@@ -1014,7 +1014,7 @@ verifiera -d-> ua: \t+5.7 TUs
 
 verifiera -d-> wua: \t+5.7 TUs
 
-verifiera --> verifiertd:  \t+11.4 TUs
+verifiera --> verifiertd:  \t+2.85 TUs
 
 @enduml
 
@@ -1631,7 +1631,7 @@ Exchange rates are a *protocol-level oracle*: they are consumed by [[MOD-XR-QRY-
 **Trust Deposit:**
 
 - `trust_deposit_share_value`(number) (*mandatory*): Value of one share of trust deposit, in [[ref: native denom]]. Default an initial value: 1. Increase over time, when yield is produced.
-- `trust_deposit_rate`(number) (*mandatory*): Rate used for dynamically calculating trust deposits from trust fees. Default value: 20% (0.20)
+- `trust_deposit_rate`(number) (*mandatory*): Rate used for dynamically calculating trust deposits from trust fees. Default value: 5% (0.05)
 - `trust_deposit_max_yield_rate`(number) (*mandatory*): Maximum yearly yield, in percent, that a trust deposit holder can obtain by receiving block rewards.
 - `trust_deposit_block_reward_share`(number) (*mandatory*): Percentage of block reward that must be distributed to trust deposit holders. Default value: 20% (0.20)
 - `wallet_user_agent_reward_rate`(number) (*mandatory*): Rate used for dynamically calculating wallet user agent rewards from trust fees. Default value: 20% (0.20)
@@ -6526,7 +6526,7 @@ Default values MUST be set at VPR initialization (genesis). Below you'll find so
 **Trust Deposit:**
 
 - `trust_deposit_share_value`(number) (*mandatory*): 1.
-- `trust_deposit_rate`(number) (*mandatory*): 0.20.
+- `trust_deposit_rate`(number) (*mandatory*): 0.05.
 - `trust_deposit_max_yield_rate`(number) (*mandatory*): 0.20
 - `trust_deposit_block_reward_share`(number) (*mandatory*): 0.20
 


### PR DESCRIPTION
## What

Sets the default value of `trust_deposit_rate` to **5% (0.05)**, previously 20% (0.20), in line with the tokenomics work (Model C): the deposit-bound fraction of trust fees becomes 5% on both the payer surcharge and each payee's share.

## Changes (spec.md, v5 only)

- `GlobalVariables.trust_deposit_rate` definition: default 20% (0.20) → 5% (0.05).
- Genesis parameter example: `trust_deposit_rate` 0.20 → 0.05.
- Non-normative examples recomputed at 5% (agent reward rates left at 10%):
  - Onboarding example: applicant −1050 (escrow 1000 + 50 deposit); validator receives 950 wallet / 50 deposit.
  - Pay-per issuance example: issuer pays 18.75 (15 × 1.25); deposits and agent splits recomputed.
  - Pay-per verification example: verifier pays 71.25 (57 × 1.25); deposits and agent splits recomputed.

No other parameter defaults are touched (`trust_deposit_block_reward_share`, `wallet_user_agent_reward_rate`, `user_agent_reward_rate` unchanged). Archived `versions/v4` and v3 files are intentionally untouched.

## Note

The live chain (devnet/testnet) still runs `trust_deposit_rate = 0.20`; a parameter-update proposal / genesis change in verana-node is needed separately for the networks to match this default.