### PR TITLE
fix(spec): add Create Root Participant to the MOD-DE-MSG-5 caller list (v4 + v5)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -5880,6 +5880,7 @@ MUST abort if one of these conditions fails:
 This method can only be called directly by the following Participant module methods, with no signer check:
 
 - [Start Participant OP](#mod-pp-msg-1-start-participant-op)
+- [Create Root Participant](#mod-pp-msg-7-create-root-participant)
 - [Self Create Participant](#mod-pp-msg-14-self-create-participant)
 
 It creates a new [ParticipantAuthorizationRecord](#participantauthorizationrecord) inside `VSOperatorAuthorization[corporation_id, vs_operator]` and, if the record enables a fee grant and its `expiration` is in the future, synchronises the on-chain `FeeGrant` for the containing VSOA.

--- a/versions/v4/spec.md
+++ b/versions/v4/spec.md
@@ -5880,6 +5880,7 @@ MUST abort if one of these conditions fails:
 This method can only be called directly by the following Participant module methods, with no signer check:
 
 - [Start Participant OP](#mod-pp-msg-1-start-participant-op)
+- [Create Root Participant](#mod-pp-msg-7-create-root-participant)
 - [Self Create Participant](#mod-pp-msg-14-self-create-participant)
 
 It creates a new [ParticipantAuthorizationRecord](#participantauthorizationrecord) inside `VSOperatorAuthorization[corporation_id, vs_operator]` and, if the record enables a fee grant and its `expiration` is in the future, synchronises the on-chain `FeeGrant` for the containing VSOA.


### PR DESCRIPTION
## Problem

[MOD-DE-MSG-5] Grant VS Operator Authorization restricts its callers ("This method can only be called directly by the following Participant module methods, with no signer check") to `Start Participant OP` (MOD-PP-MSG-1) and `Self Create Participant` (MOD-PP-MSG-14) — but [MOD-PP-MSG-7] Create Root Participant also invokes it: MOD-PP-MSG-7-1 defines the full `vs_operator_authz_*` parameter block (permitted messages: `ECOSYSTEM → SetParticipantOPtoValidated`) and MOD-PP-MSG-7-3 mandates "create the ParticipantAuthorizationRecord in **active** state by calling [[MOD-DE-MSG-5]]".

Read literally, a conforming Delegation module must reject the call coming from Create Root Participant while MOD-PP-MSG-7 simultaneously requires it to succeed. Since VSOA configuration is frozen at `Participant` creation with no later grant path, an implementation built from MOD-DE-MSG-5's list would make it impossible for an ecosystem to delegate `SetParticipantOPtoValidated` to its VS Agent on the root ECOSYSTEM `Participant` — breaking agent-driven validation of onboarding processes under `ECOSYSTEM_ONBOARDING_MODE` and at the top of grantor trees.

The sibling caller lists are complete (MOD-DE-MSG-6 matches its three invocation sites, MOD-DE-MSG-9 its two), so this is a stale list, not a design choice.

## Fix

Add `Create Root Participant (MOD-PP-MSG-7)` to the MOD-DE-MSG-5 caller list — one bullet each in the frozen `versions/v4/spec.md` and the v5 draft `spec.md` (the text is identical in both). Doc-consistency only: no behavior changes, MOD-PP-MSG-7-3 already mandates the call.