### PR TITLE
fix(v4,v5): digest is opaque in MOD-PP-MSG-10, not a digest SRI (v4 + v5)

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -4251,7 +4251,7 @@ if `issuer_participant_id` is not null:
 - if `issuer_participant` is not a [[ref: active participant]], abort.
 - if `issuer_participant.vs_operator` is not equal to `operator`, abort.
 - if `issuer_participant.corporation_id` is not equal to `co.id` (where `co` is the `Corporation` entry resolved from the signing `corporation` account), abort.
-- if `digest_sri` is present but not a valid digest SRI, abort.
+- if `digest` is present and longer than 256 characters, abort.
 
 if `verifier_participant_id` is not null:
 
@@ -4260,7 +4260,7 @@ if `verifier_participant_id` is not null:
 - if `verifier_participant` is not a [[ref: active participant]], abort.
 - if `verifier_participant.vs_operator` is not equal to `operator`, abort.
 - if `verifier_participant.corporation_id` is not equal to `co.id` (where `co` is the `Corporation` entry resolved from the signing `corporation` account), abort.
-- if `digest_sri` is present but not a valid digest SRI, abort.
+- if `digest` is present and longer than 256 characters, abort.
 
 Define the **primary `Participant`** `perm`: if `verifier_participant` is not null, `perm` = `verifier_participant` (the caller is the `vs_operator` of the verifier). Else, `perm` = `issuer_participant` (the caller is the `vs_operator` of the issuer).
 

--- a/spec.md
+++ b/spec.md
@@ -15,6 +15,7 @@
 ~ [Ariel Gentile](https://www.linkedin.com/in/aogentile/)
 ~ [Mathieu Gauthron](https://www.linkedin.com/in/mathieugauthron/)
 ~ [Pratik Kumar](https://www.linkedin.com/in/pratik-kumar-/)
+~ [Tarun Vadde](https://www.linkedin.com/in/tarunvadde/)
 
 **Participate:**
 

--- a/versions/v4/spec.md
+++ b/versions/v4/spec.md
@@ -4007,7 +4007,7 @@ if `issuer_participant_id` is not null:
 - if `issuer_participant` is not a [[ref: active participant]], abort.
 - if `issuer_participant.vs_operator` is not equal to `operator`, abort.
 - if `issuer_participant.corporation_id` is not equal to `co.id` (where `co` is the `Corporation` entry resolved from the signing `corporation` account), abort.
-- if `digest_sri` is present but not a valid digest SRI, abort.
+- if `digest` is present and longer than 256 characters, abort.
 
 if `verifier_participant_id` is not null:
 
@@ -4016,7 +4016,7 @@ if `verifier_participant_id` is not null:
 - if `verifier_participant` is not a [[ref: active participant]], abort.
 - if `verifier_participant.vs_operator` is not equal to `operator`, abort.
 - if `verifier_participant.corporation_id` is not equal to `co.id` (where `co` is the `Corporation` entry resolved from the signing `corporation` account), abort.
-- if `digest_sri` is present but not a valid digest SRI, abort.
+- if `digest` is present and longer than 256 characters, abort.
 
 Define the **primary `Participant`** `perm`: if `verifier_participant` is not null, `perm` = `verifier_participant` (the caller is the `vs_operator` of the verifier). Else, `perm` = `issuer_participant` (the caller is the `vs_operator` of the issuer).
 

--- a/versions/v4/spec.md
+++ b/versions/v4/spec.md
@@ -15,6 +15,7 @@
 ~ [Ariel Gentile](https://www.linkedin.com/in/aogentile/)
 ~ [Mathieu Gauthron](https://www.linkedin.com/in/mathieugauthron/)
 ~ [Pratik Kumar](https://www.linkedin.com/in/pratik-kumar-/)
+~ [Tarun Vadde](https://www.linkedin.com/in/tarunvadde/)
 
 **Participate:**
 


### PR DESCRIPTION
MOD-PP-MSG-10-2 aborts if `digest_sri` is not a valid digest SRI, in both the issuer and verifier branches. Two problems with that.

The parameter does not exist. MOD-PP-MSG-10-1 declares `digest` (string(256)) (*optional*).

And the SRI validation was removed from the chain in https://github.com/verana-labs/verana-node/pull/27, digests are opaque now. Verified against a live chain: v0.10.1-dev.25 rejects an unprefixed digest with "invalid digest format", v0.10.1 accepts it.

Replaced with a length check, which matches MOD-DI-MSG-1-2-1 ("if `digest` is longer than 256 characters, abort") and matches what the chain does, `len(msg.Digest) > 256`.

Applied to `spec.md` and `versions/v4/spec.md`. The governance and policy `digest_sri` fields are untouched, those are genuinely SRI.
