### PR TITLE
fix(v4,v5): store the credential digestJCS in MOD-DI-MSG-1, not a digest SRI

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -4604,7 +4604,7 @@ Else update:
 
 then, add the `cspsr` to `session.session_records`
 
-if current transaction if for issuance of a credential, persist the digest SRI by calling [[MOD-DI-MSG-1]](#mod-di-msg-1-store-digest).
+if current transaction if for issuance of a credential, persist the credential's `digestJCS` by calling [[MOD-DI-MSG-1]](#mod-di-msg-1-store-digest).
 
 :::warning
 `session.authz[]` can contain null `issuer_participant_id` OR `verifier_participant_id`

--- a/versions/v4/spec.md
+++ b/versions/v4/spec.md
@@ -4360,7 +4360,7 @@ Else update:
 
 then, add the `cspsr` to `session.session_records`
 
-if current transaction if for issuance of a credential, persist the digest SRI by calling [[MOD-DI-MSG-1]](#mod-di-msg-1-store-digest).
+if current transaction if for issuance of a credential, persist the credential's `digestJCS` by calling [[MOD-DI-MSG-1]](#mod-di-msg-1-store-digest).
 
 :::warning
 `session.authz[]` can contain null `issuer_participant_id` OR `verifier_participant_id`


### PR DESCRIPTION
Follow-up to https://github.com/verana-labs/verifiable-trust-vpr-spec/pull/160, which missed one line.

The CreateOrUpdateParticipantSession flow still said "persist the digest SRI by calling MOD-DI-MSG-1". The digest stored there is the credential's digestJCS, which has no algorithm prefix. Same fix in v4 and v5.