### PR TITLE
fix(v4,v5): exclude revoked, slashed and repaid participants from MOD-PP-MSG-1-2-4 overlap check

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -3419,7 +3419,7 @@ Trust deposit MUST always be paid in [[ref: native denom]]
 
 We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different OP with differents validators for the same `schema_id`, `role`.
 
-Find all `Participant` entries `participants[]` for `schema_id`, `role`, `validator_participant_id`, `corporation` with op_state = VALIDATED or PENDING.
+Find all `Participant` entries `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `role`, `validator_participant_id`, `corporation` with op_state = VALIDATED or PENDING.
 
 if size of `participants[]` > 0, it means there is already an existing onboarding process in this context, so MUST abort.
 

--- a/versions/v4/spec.md
+++ b/versions/v4/spec.md
@@ -3175,7 +3175,7 @@ Trust deposit MUST always be paid in [[ref: native denom]]
 
 We want to make sure that 2 onboarding processes cannot be active at the same time in the same context. This does not prevent a `corporation` from running different OP with differents validators for the same `schema_id`, `role`.
 
-Find all `Participant` entries `participants[]` for `schema_id`, `role`, `validator_participant_id`, `corporation` with op_state = VALIDATED or PENDING.
+Find all `Participant` entries `participants[]` (not revoked, not slashed, not repaid) for `schema_id`, `role`, `validator_participant_id`, `corporation` with op_state = VALIDATED or PENDING.
 
 if size of `participants[]` > 0, it means there is already an existing onboarding process in this context, so MUST abort.
 


### PR DESCRIPTION
Closes #162
Related implementation issue: verana-labs/verana-node#34

## What

Adds the exclusion "(not revoked, not slashed, not repaid)" to the
[MOD-PP-MSG-1-2-4] overlap check query, in both v4 and v5.

## Why

Revocation ([MOD-PP-MSG-9-3]) does not change op_state, so a revoked
participant keeps op_state = VALIDATED and matches the overlap check
forever. This permanently blocks any new onboarding in the same
(schema_id, role, validator_participant_id, corporation) context, with
no recovery path.

The sibling overlap checks ([MOD-PP-MSG-3-2-4], [MOD-PP-MSG-7-2-4],
[MOD-PP-MSG-8-2-4], [MOD-PP-MSG-14-2-4]) already use this exclusion.
This change makes [MOD-PP-MSG-1-2-4] consistent with them and with its
own intent sentence.

## Files

- versions/v4/spec.md
- spec.md (v5 draft)
