### PR TITLE
fix(v4,v5): treat unset expiration as never-expiring in AUTHZ-CHECK-3 step 4

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -1879,7 +1879,7 @@ Given a `corporation`, an `operator` (the `vs_operator`), a **primary permission
 1. A `ParticipantAuthorizationRecord` `record` MUST exist for `participant_id`. Abort if not found.
 2. `record` MUST belong to `VSOperatorAuthorization[co.id, operator]` (where `co` is the `Corporation` entry resolved from the signing `corporation` account by [[AUTHZ-CHECK-5]](#authz-check-5-corporation-registration-check)), that is: the containing `VSOperatorAuthorization` MUST have `co.id` as its `corporation_id` and `operator` as its `vs_operator`. Abort otherwise.
 3. `msg_type` MUST be in `record.msg_types`. Abort otherwise.
-4. Cycle / expiration check:
+4. Cycle / expiration check. If `record.expiration` is set:
    - if `record.period` is set and `now() >= record.expiration`:
      - if `record.spend_limit` is set, set `record.remaining_spend := record.spend_limit`.
      - if `record.fee_spend_limit` is set, set `record.remaining_fee_spend := record.fee_spend_limit`.

--- a/versions/v4/spec.md
+++ b/versions/v4/spec.md
@@ -1843,7 +1843,7 @@ Given a `corporation`, an `operator` (the `vs_operator`), a **primary permission
 1. A `ParticipantAuthorizationRecord` `record` MUST exist for `participant_id`. Abort if not found.
 2. `record` MUST belong to `VSOperatorAuthorization[co.id, operator]` (where `co` is the `Corporation` entry resolved from the signing `corporation` account by [[AUTHZ-CHECK-5]](#authz-check-5-corporation-registration-check)), that is: the containing `VSOperatorAuthorization` MUST have `co.id` as its `corporation_id` and `operator` as its `vs_operator`. Abort otherwise.
 3. `msg_type` MUST be in `record.msg_types`. Abort otherwise.
-4. Cycle / expiration check:
+4. Cycle / expiration check. If `record.expiration` is set:
    - if `record.period` is set and `now() >= record.expiration`:
      - if `record.spend_limit` is set, set `record.remaining_spend := record.spend_limit`.
      - if `record.fee_spend_limit` is set, set `record.remaining_fee_spend := record.fee_spend_limit`.


### PR DESCRIPTION
Related implementation issue: verana-labs/verana-node#36

## What

Adds the missing "If `record.expiration` is set" guard to [AUTHZ-CHECK-3]
step 4, in both v4 and v5.

## Why

A literal reading of step 4 rejects a record whose expiration is null,
because null is never "strictly greater than now()". But the spec's own
paths legitimately produce null expirations: [MOD-PP-MSG-3-3] activation,
[MOD-PP-MSG-7-3] and [MOD-PP-MSG-14-3] all set record.expiration from
participant.effective_until, which is null for a never-expiring
participant. [MOD-PP-MSG-14-3] even calls that record "active". So the
one spec-recommended way to declare a vs_operator on a never-expiring
participant produces an authorization that can never pass the check.

The sibling checks [AUTHZ-CHECK-1] and [AUTHZ-CHECK-2] already guard the
same logic with "If expiration is set". This change makes AUTHZ-CHECK-3
consistent with them: unset expiration means no expiration constraint.

## Files

- versions/v4/spec.md
- spec.md (v5 draft)
