### PR TITLE
fix(v4,v5): make effective_from mandatory in MOD-PP-MSG-14-1

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -4784,7 +4784,7 @@ Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else
 - `validator_participant_id` (uint64) (*mandatory*): MUST be an ECOSYSTEM [[ref: active participant]] or [[ref: future participant]].
 - `vs_operator` (account) (*optional*): the account we want to authorize to create `ParticipantSession` entries linked to this `Participant` entry. **Required** for payment delegation.
 - `did` (string) (*mandatory*): [[ref: DID]] of the VS grantee service.
-- `effective_from` (timestamp) (*optional*): timestamp from when (exclusive) this Perm is effective. MUST be in the future.
+- `effective_from` (timestamp) (*mandatory*): timestamp from when (exclusive) this Perm is effective. MUST be in the future.
 - `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this Perm is effective, null if it doesn't expire. If not null, MUST be greater than `effective_from`.
 - `verification_fees` (number) (*optional*): price to pay by the verifier of a credential of this schema to the grantee of this ISSUER perm when a credential is verified, in the denom specified in the credential schema. Default to 0.
 - `validation_fees` (number) (*optional*): price to pay by the holder of a credential of this schema to the issuer when executing an onboarding process to obtain a credential, in the denom specified in the credential schema. Default to 0.

--- a/versions/v4/spec.md
+++ b/versions/v4/spec.md
@@ -4540,7 +4540,7 @@ Even if a schema is OPEN, candidate MUST make sure they comply with the EGF else
 - `validator_participant_id` (uint64) (*mandatory*): MUST be an ECOSYSTEM [[ref: active participant]] or [[ref: future participant]].
 - `vs_operator` (account) (*optional*): the account we want to authorize to create `ParticipantSession` entries linked to this `Participant` entry. **Required** for payment delegation.
 - `did` (string) (*mandatory*): [[ref: DID]] of the VS grantee service.
-- `effective_from` (timestamp) (*optional*): timestamp from when (exclusive) this Perm is effective. MUST be in the future.
+- `effective_from` (timestamp) (*mandatory*): timestamp from when (exclusive) this Perm is effective. MUST be in the future.
 - `effective_until` (timestamp) (*optional*): timestamp until when (exclusive) this Perm is effective, null if it doesn't expire. If not null, MUST be greater than `effective_from`.
 - `verification_fees` (number) (*optional*): price to pay by the verifier of a credential of this schema to the grantee of this ISSUER perm when a credential is verified, in the denom specified in the credential schema. Default to 0.
 - `validation_fees` (number) (*optional*): price to pay by the holder of a credential of this schema to the issuer when executing an onboarding process to obtain a credential, in the denom specified in the credential schema. Default to 0.


### PR DESCRIPTION
Related implementation issue: verana-labs/verana-node#38

## What

Changes effective_from from optional to mandatory in the
[MOD-PP-MSG-14-1] Self Create Participant parameters, in both v4 and v5.

## Why

The parameter list marks effective_from as optional, but the basic check
in [MOD-PP-MSG-14-2-1] reads "effective_from MUST be in the future" with
no null case, and [MOD-PP-MSG-7-1] Create Root Participant marks the
same field mandatory. A participant created without effective_from is
neither active nor future, cannot be revoked or adjusted, and blocks its
slot forever. Making the field mandatory resolves the contradiction.

## Files

- versions/v4/spec.md
- spec.md (v5 draft)
